### PR TITLE
docs(architecture): add three ADR-001 diagrams — immutable state contract and event propagation

### DIFF
--- a/docs/architecture/ADR-001-flowchart-event-propagation.mmd
+++ b/docs/architecture/ADR-001-flowchart-event-propagation.mmd
@@ -1,0 +1,30 @@
+flowchart TD
+    MOD["FiscalModule.compute(BOL, State[T], T)\nreturns Event"]
+
+    EVT["Event\n────────────────────────\nsource_entity_id: BOL\nevent_type: shock\naffected_attributes:\n  debt_gdp_ratio: +0.15\nPropagationRule:\n  relationship_type: trade\n  attenuation_factor: 0.4\n  max_hops: 2\nframework: FINANCIAL"]
+
+    MOD --> EVT
+
+    EVT --> APPLY0["Apply to source entity\nBOL: debt_gdp_ratio +0.15"]
+
+    APPLY0 --> HOP1{"Hop 1\nFind outbound 'trade'\nrelationships from BOL"}
+
+    HOP1 -->|"BOL→BRA  weight=0.30"| BRA["Apply to BRA\n+0.15 × 0.4 × 0.30 = +0.018\ndebt_gdp_ratio +0.018"]
+    HOP1 -->|"BOL→ARG  weight=0.20"| ARG["Apply to ARG\n+0.15 × 0.4 × 0.20 = +0.012\ndebt_gdp_ratio +0.012"]
+    HOP1 -->|"BOL→PER  weight=0.15"| PER["Apply to PER\n+0.15 × 0.4 × 0.15 = +0.009\ndebt_gdp_ratio +0.009"]
+
+    BRA --> HOP2{"Hop 2\nFind outbound 'trade'\nrelationships from BRA, ARG, PER\nhops_so_far = 1 < max_hops=2"}
+
+    HOP2 -->|"BRA→URY  weight=0.50"| URY["Apply to URY\n+0.018 × 0.4 × 0.50 = +0.0036\ndebt_gdp_ratio +0.0036"]
+    HOP2 -->|"ARG→URY  weight=0.40"| URY2["Apply to URY (additive)\n+0.012 × 0.4 × 0.40 = +0.0019\ndebt_gdp_ratio +0.0019"]
+
+    URY --> STOP{"hops_so_far = 2 = max_hops\nStop"}
+    URY2 --> STOP
+    ARG --> STOP
+    PER --> STOP
+
+    STOP --> COLLECT["Engine collects all attribute deltas\nacross all entities for this timestep\napplies them to State[T+1]"]
+
+    style EVT fill:#f0f4ff,stroke:#4a6fa5
+    style COLLECT fill:#f0fff4,stroke:#2d6a4f
+    style STOP fill:#fff3f0,stroke:#c0392b

--- a/docs/architecture/ADR-001-flowchart-mutable-state-problem.mmd
+++ b/docs/architecture/ADR-001-flowchart-mutable-state-problem.mmd
@@ -1,0 +1,50 @@
+flowchart TD
+    subgraph BAD["❌  Mutable State — Result Depends on Execution Order"]
+        direction TB
+
+        S0["State at timestep T\ngdp_growth = 0.0\nexport_volume = 100"]
+
+        subgraph OA["Order A: Fiscal → Trade"]
+            direction TB
+            FA["FiscalModule\nreads  gdp_growth = 0.0\nwrites gdp_growth = −0.02"]
+            TA["TradeModule\nreads  gdp_growth = −0.02\n⚠ sees Fiscal's write\nwrites export_volume = 85"]
+        end
+
+        subgraph OB["Order B: Trade → Fiscal"]
+            direction TB
+            TB_["TradeModule\nreads  gdp_growth = 0.0\n✓ Fiscal hasn't run\nwrites export_volume = 92"]
+            FB["FiscalModule\nreads  gdp_growth = 0.0\nwrites gdp_growth = −0.02"]
+        end
+
+        S0 --> OA
+        S0 --> OB
+
+        RA["Result A\ngdp_growth=−0.02  export_volume=85"]
+        RB["Result B\ngdp_growth=−0.02  export_volume=92"]
+
+        OA --> RA
+        OB --> RB
+
+        PROB["Same starting state.\nDifferent outputs.\nBacktesting is meaningless.\nParallel execution is unsafe.\nReplay is impossible."]
+        RA -.-> PROB
+        RB -.-> PROB
+    end
+
+    subgraph GOOD["✅  Immutable State — Order Independent"]
+        direction TB
+
+        S1["State[T]  ← read-only snapshot\ngdp_growth = 0.0\nexport_volume = 100"]
+
+        FM2["FiscalModule\nreads  gdp_growth = 0.0\nreturns  Event: gdp_growth Δ −0.02"]
+        TM2["TradeModule\nreads  gdp_growth = 0.0\nreturns  Event: export_volume Δ −8"]
+
+        ENG["Engine\ncollects all Events after every module runs\napplies deltas to produce State[T+1]"]
+
+        RC["State[T+1]\ngdp_growth=−0.02  export_volume=92\nIdentical regardless of module execution order"]
+
+        S1 --> FM2
+        S1 --> TM2
+        FM2 --> ENG
+        TM2 --> ENG
+        ENG --> RC
+    end

--- a/docs/architecture/ADR-001-sequence-timestep-cycle.mmd
+++ b/docs/architecture/ADR-001-sequence-timestep-cycle.mmd
@@ -1,0 +1,31 @@
+sequenceDiagram
+    participant Engine
+    participant FiscalModule
+    participant TradeModule
+    participant StateT  as State[T]  (read-only)
+    participant StateT1 as State[T+1]
+
+    Note over Engine: Timestep T begins
+    Engine ->> StateT: read entities, relationships
+
+    loop for each entity (e.g. BOL, GRC, THA …)
+        Engine ->>+ FiscalModule: compute(entity, State[T], T)
+        FiscalModule ->> StateT: get_attribute("gdp_growth")
+        FiscalModule ->> StateT: get_relationships_from(entity.id)
+        FiscalModule -->>- Engine: [Event: gdp_growth Δ−0.02, framework=FINANCIAL]
+
+        Engine ->>+ TradeModule: compute(entity, State[T], T)
+        TradeModule ->> StateT: get_attribute("export_volume")
+        TradeModule ->> StateT: get_relationships_to(entity.id)
+        TradeModule -->>- Engine: [Event: export_volume Δ−8, framework=FINANCIAL]
+
+        Note over StateT: State[T] untouched throughout
+    end
+
+    Note over Engine: All modules have run for all entities
+    Engine ->> Engine: collect every Event returned this timestep
+    Engine ->> StateT1: apply all event deltas → new attribute values
+    Engine ->> StateT1: propagate events along relationships (see propagation diagram)
+
+    Note over StateT: Archived — available for backtesting replay
+    Note over StateT1: Becomes the read-only State[T+1] for next tick

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -82,6 +82,9 @@ Or use the VS Code Mermaid Preview extension, which renders `.mmd` files inline.
 | File | ADR | What it shows |
 |---|---|---|
 | `ADR-001-class-diagram.mmd` | ADR-001 | Simulation core data model: SimulationEntity, SimulationState, Event, Relationship, SimulationModule |
+| `ADR-001-flowchart-mutable-state-problem.mmd` | ADR-001 | Why mutable state creates non-determinism; how immutable state + events solves it |
+| `ADR-001-sequence-timestep-cycle.mmd` | ADR-001 | Full timestep cycle: engine calls modules, collects Events, applies deltas to State[T+1] |
+| `ADR-001-flowchart-event-propagation.mmd` | ADR-001 | How a single Event propagates through the relationship graph with attenuation across hops |
 
 *This table is updated when diagrams are added. New diagrams added without
 updating this table will be flagged in pull request review.*


### PR DESCRIPTION
## Summary

- Adds `ADR-001-flowchart-mutable-state-problem.mmd` — two-panel diagram showing why mutable state creates order-dependent non-determinism and how immutable state + Events solves it
- Adds `ADR-001-sequence-timestep-cycle.mmd` — sequence diagram of the full timestep cycle: Engine calls modules against read-only State[T], collects Events, applies deltas to State[T+1]
- Adds `ADR-001-flowchart-event-propagation.mmd` — Bolivia fiscal shock propagating via trade relationships with hop-by-hop attenuation (max_hops=2)
- Updates `docs/architecture/README.md` current diagrams table to include all three new files

These diagrams were produced during an ADR-001 Socratic teaching session to verify that the immutable state contract and event propagation mechanics are legible to a first-time reader of the codebase.

## Why these diagrams exist

Per `docs/architecture/README.md`: every ADR must have at least one diagram. ADR-001 already had `ADR-001-class-diagram.mmd`. These three diagrams cover the behavioral contracts that the class diagram cannot express:

1. **Why** immutable state — the non-determinism failure mode that motivated the design
2. **How** the timestep cycle works — the sequence of calls and state transitions
3. **How** event propagation works — the attenuation math across relationship hops

## Test plan

- [ ] All three `.mmd` files render correctly on GitHub (Mermaid native rendering)
- [ ] `docs/architecture/README.md` current diagrams table matches the files present in the directory
- [ ] No binary files added

🤖 Generated with [Claude Code](https://claude.com/claude-code)