### PR TITLE
fix(ci): move permissions to workflow level in milestone-automation.yml

### DIFF
--- a/.github/workflows/milestone-automation.yml
+++ b/.github/workflows/milestone-automation.yml
@@ -15,11 +15,12 @@ on:
   milestone:
     types: [created]
 
+permissions:
+  issues: write  # required to create the exit checklist Issue and read milestone event payload
+
 jobs:
   create-exit-checklist:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The permissions block in the previous merge (PR #17) was at the job level. Job-level permissions override any workflow-level block for that job, which means adding permissions later at the workflow level would have no effect on this job.

Moves `issues: write` to the workflow level where it applies correctly.

`milestones` is not a discrete GitHub Actions permission scope — milestone event payload access (`github.event.milestone.number`, `.title`) is covered by `issues: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)