### PR TITLE
docs(adr): renew ADR-001 and ADR-002 license status to CURRENT — STD-REVIEW-001 complete

### DIFF
--- a/docs/adr/ADR-001-simulation-core-data-model.md
+++ b/docs/adr/ADR-001-simulation-core-data-model.md
@@ -7,7 +7,13 @@ Accepted
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
 **Valid Until:** Milestone 2 completion
-**License Status:** UNDER-REVIEW — pending STD-REVIEW-001 completion
+**License Status:** CURRENT
+
+**Last Reviewed:** 2026-04-17 — STD-REVIEW-001 completed. All renewal triggers
+checked; none fired. STD-REVIEW-001 created issues tracking standards amendments
+(#42–#51) but did not apply amendments to standards documents. The standards
+documents as they stand did not change in ways that activate any trigger below.
+Next scheduled review at Milestone 2 completion.
 
 **Renewal Triggers** — any of the following fires the CURRENT → UNDER-REVIEW
 transition:

--- a/docs/adr/ADR-002-input-orchestration-layer.md
+++ b/docs/adr/ADR-002-input-orchestration-layer.md
@@ -7,7 +7,13 @@ Accepted
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
 **Valid Until:** Milestone 2 completion
-**License Status:** UNDER-REVIEW — pending STD-REVIEW-001 completion
+**License Status:** CURRENT
+
+**Last Reviewed:** 2026-04-17 — STD-REVIEW-001 completed. All renewal triggers
+checked; none fired. STD-REVIEW-001 created issues tracking standards amendments
+(#42–#51) but did not apply amendments to standards documents. The standards
+documents as they stand did not change in ways that activate any trigger below.
+Next scheduled review at Milestone 2 completion.
 
 **Renewal Triggers** — any of the following fires the CURRENT → UNDER-REVIEW
 transition:


### PR DESCRIPTION
## Summary

Advances ADR-001 and ADR-002 from **UNDER-REVIEW** to **CURRENT** following
completion of STD-REVIEW-001 on 2026-04-17.

## Renewal Rationale

STD-REVIEW-001 checked all renewal triggers for both ADRs against the current
state of `CODING_STANDARDS.md`, `DATA_STANDARDS.md`, `POLICY.md`, and
`CONTRIBUTING.md`. No trigger fired:

- **ADR-001 triggers checked:** `MeasurementFramework` taxonomy (unchanged),
  data model unit standards (unchanged), backtesting integrity rules
  (unchanged), stock vs. flow distinction (not yet added — tracked in #41)
- **ADR-002 triggers checked:** `ControlInput` type taxonomy (unchanged),
  audit trail schema requirements (unchanged), uncertainty quantification
  standards (not yet added — tracked in #38), multi-framework tagging
  requirements (not yet added — tracked in #42)

STD-REVIEW-001 created issues (#42–#51) tracking required standards amendments
but did not amend the standards documents themselves. The trigger condition is
"standards document changed" — issues tracking future amendments do not fire
the trigger. Both ADRs are therefore valid against current standards.

## Changes

Both Validity Context sections updated:
- `License Status: UNDER-REVIEW — pending STD-REVIEW-001 completion` → `License Status: CURRENT`
- Added `Last Reviewed` note documenting the review date, trigger-check outcome,
  and next scheduled review at Milestone 2 completion

## Test plan

- [ ] ADR-001 Validity Context reads `License Status: CURRENT`
- [ ] ADR-002 Validity Context reads `License Status: CURRENT`
- [ ] Both ADRs contain a `Last Reviewed: 2026-04-17` note
- [ ] Renewal trigger lists are unchanged (no triggers were removed or weakened)
- [ ] Milestone 1 exit checklist Standards License Audit section can now be checked for both ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)