### PR TITLE
fix(ci): add workflow_dispatch to milestone automation; fix @me assignee bug

### DIFF
--- a/.github/workflows/milestone-automation.yml
+++ b/.github/workflows/milestone-automation.yml
@@ -5,18 +5,33 @@ name: Milestone Automation
 # @PublicEnemage, attaches it to the new milestone, and applies the
 # horizon:immediate label.
 #
+# Also supports manual triggering via workflow_dispatch for cases where the
+# automatic trigger was missed (e.g., milestone created before this workflow
+# existed on the default branch). Provide the milestone number and name as
+# inputs.
+#
 # The exit checklist template lives at docs/templates/milestone-exit-checklist.md.
 # This workflow interpolates MILESTONE_NUMBER and MILESTONE_NAME from the
-# milestone event payload before creating the Issue body.
+# milestone event payload (or from dispatch inputs) before creating the Issue body.
 #
 # See docs/MILESTONE_RUNBOOK.md for the full milestone ceremony process.
 
 on:
   milestone:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      milestone_number:
+        description: 'Milestone number (e.g. 3)'
+        required: true
+        type: string
+      milestone_name:
+        description: 'Milestone name as it appears in the title (e.g. Scenario Engine)'
+        required: true
+        type: string
 
 permissions:
-  issues: write  # required to create the exit checklist Issue and read milestone event payload
+  issues: write  # required to create the exit checklist Issue
 
 jobs:
   create-exit-checklist:
@@ -24,17 +39,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract milestone metadata
+      - name: Resolve milestone metadata
         id: milestone
         run: |
-          echo "number=${{ github.event.milestone.number }}" >> "$GITHUB_OUTPUT"
-          echo "title=${{ github.event.milestone.title }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.milestone_number }}" >> "$GITHUB_OUTPUT"
+            echo "name=${{ inputs.milestone_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.milestone.number }}" >> "$GITHUB_OUTPUT"
+            # Extract just the theme name from titles like "Milestone N — Theme Name"
+            FULL_TITLE="${{ github.event.milestone.title }}"
+            NAME="${FULL_TITLE#*— }"
+            echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build exit checklist body from template
         id: build-body
         run: |
           MILESTONE_NUMBER="${{ steps.milestone.outputs.number }}"
-          MILESTONE_NAME="${{ steps.milestone.outputs.title }}"
+          MILESTONE_NAME="${{ steps.milestone.outputs.name }}"
           NEXT_NUMBER=$((MILESTONE_NUMBER + 1))
 
           # Interpolate placeholders in the template
@@ -48,6 +71,17 @@ jobs:
           echo "$BODY" > /tmp/checklist-body.md
           echo "body_file=/tmp/checklist-body.md" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve milestone title for assignment
+        id: milestone-title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # gh issue create --milestone requires the full milestone title, not the number
+          MILESTONE_NUMBER="${{ steps.milestone.outputs.number }}"
+          FULL_TITLE=$(gh api repos/${{ github.repository }}/milestones \
+            --jq ".[] | select(.number == ${MILESTONE_NUMBER}) | .title")
+          echo "full_title=${FULL_TITLE}" >> "$GITHUB_OUTPUT"
+
       - name: Create exit checklist Issue
         id: create-issue
         env:
@@ -56,9 +90,9 @@ jobs:
           ISSUE_URL=$(gh issue create \
             --title "Milestone ${{ steps.milestone.outputs.number }} Exit Checklist — blocks milestone closure" \
             --body-file "${{ steps.build-body.outputs.body_file }}" \
-            --assignee "@me" \
+            --assignee "PublicEnemage" \
             --label "horizon:immediate" \
-            --milestone "${{ steps.milestone.outputs.number }}")
+            --milestone "${{ steps.milestone-title.outputs.full_title }}")
           echo "issue_url=${ISSUE_URL}" >> "$GITHUB_OUTPUT"
           echo "Created exit checklist: ${ISSUE_URL}"
 
@@ -66,9 +100,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TRIGGER_NOTE=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TRIGGER_NOTE=" (manually triggered via workflow_dispatch — automatic trigger was missed)"
+          fi
+
           gh issue comment "${{ steps.create-issue.outputs.issue_url }}" \
-            --body "$(cat <<'EOF'
-          🤖 **Auto-created by milestone automation workflow**
+            --body "🤖 **Auto-created by milestone automation workflow**${TRIGGER_NOTE}
 
           This exit checklist was automatically created when Milestone ${{ steps.milestone.outputs.number }} was opened. It was generated from the template at \`docs/templates/milestone-exit-checklist.md\`.
 
@@ -77,6 +115,4 @@ jobs:
           - Unchecked items require a comment on this Issue with documented rationale
           - The compliance scan registry (\`docs/compliance/scan-registry.md\`) must contain a Milestone-exit entry referencing this Issue
 
-          See [docs/MILESTONE_RUNBOOK.md](../blob/main/docs/MILESTONE_RUNBOOK.md) for the complete milestone closure ceremony.
-          EOF
-          )"
+          See [docs/MILESTONE_RUNBOOK.md](../blob/main/docs/MILESTONE_RUNBOOK.md) for the complete milestone closure ceremony."


### PR DESCRIPTION
## Root Cause

All four milestones were created at **04:28:49–04:28:50Z** on 2026-04-16.
PR #17 (which added the workflow file to main) wasn't merged until **04:31:24Z**
— 2 minutes and 34 seconds later. The `milestone: created` webhook events fired
for all four milestones, but no workflow existed on the default branch to handle
them. GitHub dropped the events. The automation has zero runs in its history.

This would occur identically whether milestones are created via the GitHub UI
or `gh` CLI — the CLI uses the REST API which does fire the webhook. The issue
is purely timing: the workflow file must be on the default branch before the
milestone is created.

## Fixes

### 1. `workflow_dispatch` trigger (primary fix)

Adds manual trigger with two inputs:
- `milestone_number` — the milestone number (e.g. `3`)
- `milestone_name` — the theme name (e.g. `Scenario Engine`)

This allows creating missed exit checklists without deleting and recreating
milestones. After this PR merges, Milestones 3 and 4 can be handled by
running the workflow manually from the Actions tab.

### 2. Assignee fixed from `@me` to `PublicEnemage`

Under `GITHUB_TOKEN`, `--assignee "@me"` resolves to `github-actions[bot]`,
not to the repository owner. `MILESTONE_RUNBOOK.md` documents the checklist
as assigned to `@PublicEnemage`. The workflow was not doing that.

### 3. Milestone title extraction

Strips the `"Milestone N — "` prefix from the full milestone title to extract
just the theme name for the checklist body. Previously the full title string
would have appeared where `MILESTONE_NAME` was expected.

### 4. Milestone title resolution for `gh issue create`

`gh issue create --milestone` requires the full milestone title string, not
the number. Added an API call to resolve the title before creating the issue.

## After Merge

Run the workflow manually (Actions → Milestone Automation → Run workflow) for:
- Milestone 3 — Scenario Engine
- Milestone 4 — Human Cost Ledger

Milestone 2 exit checklist was already created manually as issue #59.

## Test plan

- [ ] Workflow file parses without errors (check Actions tab after merge)
- [ ] Manually trigger for Milestone 3 — verify issue created, assigned to @PublicEnemage, attached to Milestone 3, labelled `horizon:immediate`
- [ ] Manually trigger for Milestone 4 — same verification
- [ ] Confirm future `milestone: created` events trigger correctly by checking Actions tab when next milestone is opened