### PR TITLE
fix(ci): upgrade actions/checkout from v4 to v6 — Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,7 +40,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/milestone-automation.yml
+++ b/.github/workflows/milestone-automation.yml
@@ -37,7 +37,7 @@ jobs:
   create-exit-checklist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve milestone metadata
         id: milestone


### PR DESCRIPTION
## Problem

The milestone automation run at https://github.com/PublicEnemage/worldsim/actions/runs/24634880136
produced this warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4. Actions will be forced to run
> with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed
> from the runner on **September 16th, 2026**.

The forced cutover is 6 weeks away. All three workflows using `actions/checkout@v4`
will begin failing or producing warnings on every run unless updated.

## Fix

Updated all four `actions/checkout@v4` references to `actions/checkout@v6`:

| File | Occurrences |
|------|------------|
| `.github/workflows/ci.yml` | 3 (test-backend, lint, compliance-scan jobs) |
| `.github/workflows/milestone-automation.yml` | 1 |

`actions/checkout@v6.0.2` (released 2026-01-09) is the current latest release
and runs on Node.js 24.

## Test plan

- [ ] CI workflow passes on this PR (uses the updated checkout action)
- [ ] No Node.js deprecation warning appears in the Actions log after merge
- [ ] All three CI jobs (test-backend, lint, compliance-scan) complete successfully