### PR TITLE
fix(ci): initialize asyncpg pool in backtesting conftest — resolves Issue #136

### DIFF
--- a/backend/tests/backtesting/conftest.py
+++ b/backend/tests/backtesting/conftest.py
@@ -1,0 +1,42 @@
+"""Backtesting conftest — asyncpg pool lifecycle.
+
+httpx.ASGITransport does not trigger the FastAPI lifespan startup handler, so
+the asyncpg pool is never initialised when tests use ASGITransport directly.
+This conftest fills that gap: it calls create_asyncpg_pool() once at session
+start and close_asyncpg_pool() at session end, matching the behaviour of the
+production lifespan handler in app/main.py.
+
+asyncpg 0.30 pools are not bound to the event loop in which they were created.
+Connections acquired by function-scoped test loops work correctly against a
+pool initialised in a separate asyncio.run() call. Issue #136.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+_DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _asyncpg_pool_lifecycle() -> Generator[None, None, None]:
+    """Initialize the asyncpg pool before the backtesting session.
+
+    Skips the entire session when DATABASE_URL is not set, so backtesting
+    tests continue to skip gracefully in environments without a database.
+    """
+    if not _DATABASE_URL:
+        pytest.skip("DATABASE_URL not set — skipping backtesting session")
+        return  # unreachable; satisfies type checker
+
+    from app.db.connection import close_asyncpg_pool, create_asyncpg_pool
+
+    asyncio.run(create_asyncpg_pool())
+    yield
+    asyncio.run(close_asyncpg_pool())


### PR DESCRIPTION
## Summary

- Adds `backend/tests/backtesting/conftest.py` with a session-scoped autouse fixture `_asyncpg_pool_lifecycle`
- The fixture calls `create_asyncpg_pool()` via `asyncio.run()` before the backtesting session and `close_asyncpg_pool()` after
- Skips the entire session gracefully when `DATABASE_URL` is not set

## Root cause

`httpx.ASGITransport(app=app)` sends requests directly to the ASGI callable without invoking the FastAPI lifespan context manager. The lifespan handler in `app/main.py` is the only place `create_asyncpg_pool()` is called in production. In the backtesting CI job, no code ever initialized the pool, so every database call raised `RuntimeError: asyncpg pool is not initialised`.

## Why `asyncio.run()` is safe here

asyncpg 0.30 pools are not bound to the event loop in which they were created. When a test's function-scoped event loop calls `await pool.acquire()`, asyncpg creates a new connection bound to that loop. The pool initialized by a separate `asyncio.run()` call is usable from any subsequent loop.

## Test plan

- [x] `pytest tests/backtesting/` without `DATABASE_URL` — all 4 tests skip
- [x] `pytest tests/unit/` — 337 tests pass, no regressions
- [x] `ruff check tests/backtesting/conftest.py` — clean
- [ ] CI backtesting job with live PostGIS — expected to pass after this fix

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)