### PR TITLE
fix(api): step-alignment validation on GET /scenarios/compare — resolves #150

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -3,7 +3,7 @@
 Eight endpoints covering scenario configuration lifecycle and execution:
   POST   /scenarios                           — create scenario (status: pending)
   GET    /scenarios                           — list all scenarios (created_at desc)
-  GET    /scenarios/compare                   — delta between two final snapshots (ADR-004 D5)
+  GET    /scenarios/compare                   — snapshot delta; optional step alignment (ADR-004 D5)
   GET    /scenarios/{scenario_id}             — full detail with scheduled inputs
   DELETE /scenarios/{scenario_id}             — tombstone + cascade delete, returns 204
   POST   /scenarios/{scenario_id}/run         — execute pending scenario to completion
@@ -257,15 +257,22 @@ async def compare_scenarios(
     scenario_a: str,
     scenario_b: str,
     attr: str | None = None,
+    step: int | None = None,
 ) -> CompareResponse:
-    """Return attribute deltas between two scenarios at their final steps.
+    """Return attribute deltas between two scenarios.
 
     Computes delta = value_b - value_a for each shared entity and attribute.
-    Only entities and attributes present in both final snapshots are included.
+    Only entities and attributes present in both snapshots are included.
     Filter to a single attribute with `attr`. ADR-004 Decision 5.
 
+    `step` — when provided, both scenarios must have a snapshot at exactly
+    that step. Returns 404 identifying which scenario is missing the step.
+    When omitted, compares the final (highest-step) snapshot of each scenario.
+
     Returns 404 if either scenario is not found.
-    Returns 409 if either scenario has no snapshots yet.
+    Returns 404 if `step` is provided and either scenario has no snapshot at
+    that step (with a message identifying the missing scenario).
+    Returns 409 if `step` is omitted and either scenario has no snapshots yet.
     """
     for sid in (scenario_a, scenario_b):
         row = await conn.fetchrow(
@@ -276,27 +283,56 @@ async def compare_scenarios(
                 status_code=404, detail=f"Scenario '{sid}' not found."
             )
 
-    snap_a = await conn.fetchrow(
-        "SELECT step, state_data FROM scenario_state_snapshots "
-        "WHERE scenario_id = $1 ORDER BY step DESC LIMIT 1",
-        scenario_a,
-    )
-    snap_b = await conn.fetchrow(
-        "SELECT step, state_data FROM scenario_state_snapshots "
-        "WHERE scenario_id = $1 ORDER BY step DESC LIMIT 1",
-        scenario_b,
-    )
-
-    if snap_a is None:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Scenario '{scenario_a}' has no snapshots. Run it first.",
+    if step is not None:
+        snap_a = await conn.fetchrow(
+            "SELECT step, state_data FROM scenario_state_snapshots "
+            "WHERE scenario_id = $1 AND step = $2",
+            scenario_a,
+            step,
         )
-    if snap_b is None:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Scenario '{scenario_b}' has no snapshots. Run it first.",
+        if snap_a is None:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Scenario '{scenario_a}' has no snapshot at step {step}. "
+                    "Advance the scenario to this step before comparing."
+                ),
+            )
+        snap_b = await conn.fetchrow(
+            "SELECT step, state_data FROM scenario_state_snapshots "
+            "WHERE scenario_id = $1 AND step = $2",
+            scenario_b,
+            step,
         )
+        if snap_b is None:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Scenario '{scenario_b}' has no snapshot at step {step}. "
+                    "Advance the scenario to this step before comparing."
+                ),
+            )
+    else:
+        snap_a = await conn.fetchrow(
+            "SELECT step, state_data FROM scenario_state_snapshots "
+            "WHERE scenario_id = $1 ORDER BY step DESC LIMIT 1",
+            scenario_a,
+        )
+        snap_b = await conn.fetchrow(
+            "SELECT step, state_data FROM scenario_state_snapshots "
+            "WHERE scenario_id = $1 ORDER BY step DESC LIMIT 1",
+            scenario_b,
+        )
+        if snap_a is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Scenario '{scenario_a}' has no snapshots. Run it first.",
+            )
+        if snap_b is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Scenario '{scenario_b}' has no snapshots. Run it first.",
+            )
 
     state_a: dict[str, Any] = snap_a["state_data"]
     state_b: dict[str, Any] = snap_b["state_data"]

--- a/backend/tests/unit/test_compare_step_alignment.py
+++ b/backend/tests/unit/test_compare_step_alignment.py
@@ -1,0 +1,116 @@
+"""Unit tests for GET /scenarios/compare step-alignment validation — Issue #150.
+
+Covers:
+  - step provided, both scenarios have it → CompareResponse with correct steps
+  - step provided, scenario_a missing it → 404 identifying scenario_a
+  - step provided, scenario_b missing it → 404 identifying scenario_b
+  - step omitted → existing final-snapshot behavior (step_a/step_b from DB)
+
+All tests run without a database connection using AsyncMock.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.scenarios import compare_scenarios
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_SCENARIO_ROW_A = {"scenario_id": "aaa"}
+_SCENARIO_ROW_B = {"scenario_id": "bbb"}
+
+_STATE = {
+    "GRC": {
+        "gdp": {
+            "_envelope_version": "1",
+            "value": "200",
+            "unit": "USD",
+            "variable_type": "monetary",
+            "confidence_tier": 2,
+            "observation_date": None,
+            "source_registry_id": None,
+            "measurement_framework": None,
+        }
+    }
+}
+
+
+def _snap(step: int) -> dict:
+    return {"step": step, "state_data": json.dumps(_STATE)}
+
+
+def _make_conn(*side_effects) -> AsyncMock:
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(side_effect=list(side_effects))
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_step_provided_both_present_returns_compare_response() -> None:
+    conn = _make_conn(
+        _SCENARIO_ROW_A,  # existence check scenario_a
+        _SCENARIO_ROW_B,  # existence check scenario_b
+        _snap(3),          # snapshot at step=3 for scenario_a
+        _snap(3),          # snapshot at step=3 for scenario_b
+    )
+    result = await compare_scenarios(conn=conn, scenario_a="aaa", scenario_b="bbb", step=3)
+    assert result.scenario_a_id == "aaa"
+    assert result.scenario_b_id == "bbb"
+    assert result.step_a == 3
+    assert result.step_b == 3
+    assert "GRC" in result.deltas
+
+
+@pytest.mark.asyncio
+async def test_step_provided_scenario_a_missing_returns_404() -> None:
+    conn = _make_conn(
+        _SCENARIO_ROW_A,
+        _SCENARIO_ROW_B,
+        None,  # scenario_a has no snapshot at step=5
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await compare_scenarios(conn=conn, scenario_a="aaa", scenario_b="bbb", step=5)
+    assert exc_info.value.status_code == 404
+    assert "aaa" in exc_info.value.detail
+    assert "5" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_step_provided_scenario_b_missing_returns_404() -> None:
+    conn = _make_conn(
+        _SCENARIO_ROW_A,
+        _SCENARIO_ROW_B,
+        _snap(5),  # scenario_a has step=5
+        None,       # scenario_b has no snapshot at step=5
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await compare_scenarios(conn=conn, scenario_a="aaa", scenario_b="bbb", step=5)
+    assert exc_info.value.status_code == 404
+    assert "bbb" in exc_info.value.detail
+    assert "5" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_no_step_uses_final_snapshots() -> None:
+    conn = _make_conn(
+        _SCENARIO_ROW_A,
+        _SCENARIO_ROW_B,
+        _snap(10),  # final snapshot for scenario_a (step 10)
+        _snap(8),   # final snapshot for scenario_b (step 8)
+    )
+    result = await compare_scenarios(conn=conn, scenario_a="aaa", scenario_b="bbb")
+    assert result.step_a == 10
+    assert result.step_b == 8
+    assert result.scenario_a_id == "aaa"
+    assert result.scenario_b_id == "bbb"


### PR DESCRIPTION
## Summary

- Adds optional `step` query parameter to `GET /scenarios/compare`
- When `step` is provided, validates both scenarios have a snapshot at exactly that step; returns 404 identifying the missing scenario if not
- When `step` is omitted, existing behavior is preserved (compare final snapshots; 409 if no snapshots exist)
- Fail-fast ordering: `snap_a` is checked before `snap_b` is even queried, avoiding an unnecessary DB round-trip

## Behavior

| `step` param | scenario_a has it | scenario_b has it | Result |
|---|---|---|---|
| provided | ✓ | ✓ | `CompareResponse` with `step_a = step_b = step` |
| provided | ✗ | — | 404 identifying `scenario_a` and step number |
| provided | ✓ | ✗ | 404 identifying `scenario_b` and step number |
| omitted | any | any | existing final-snapshot behavior unchanged |

## Test Plan

- [ ] `pytest backend/tests/unit/test_compare_step_alignment.py -v` — 4 new tests pass
- [ ] `pytest backend/tests/unit/ -q` — 363 tests passing
- [ ] `ruff check backend/app/api/scenarios.py` — clean

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)