### PR TITLE
feat(frontend): scenario selector UI — resolves #165

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,3 +41,238 @@ body,
   flex: 1;
   overflow: hidden;
 }
+
+/* Scenario toggle button in header */
+.scenario-toggle-btn {
+  padding: 4px 10px;
+  font-size: 13px;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.scenario-toggle-btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.scenario-toggle-btn--open {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+/* Scenario panel */
+.scenario-panel {
+  background: #122a45;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.scenario-panel-inner {
+  display: flex;
+  gap: 0;
+  padding: 12px 20px;
+  min-height: 100px;
+}
+
+.scenario-panel-section {
+  flex: 1;
+  min-width: 0;
+  color: #d0dce8;
+  font-size: 13px;
+}
+
+.scenario-panel-section--create {
+  flex: 0 0 280px;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  padding-left: 20px;
+  margin-left: 16px;
+}
+
+.scenario-panel-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8aa8c4;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.scenario-panel-refresh {
+  background: none;
+  border: none;
+  color: #8aa8c4;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+.scenario-panel-refresh:hover {
+  color: #d0dce8;
+}
+
+.scenario-panel-empty {
+  color: #5a7a95;
+  font-style: italic;
+  font-size: 12px;
+}
+
+.scenario-panel-error {
+  color: #f87171;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.scenario-panel-success {
+  color: #6ee7b7;
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+/* Scenario list rows */
+.scenario-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.scenario-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  gap: 8px;
+}
+
+.scenario-row--primary {
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.scenario-row--second {
+  background: rgba(16, 185, 129, 0.15);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.scenario-row-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.scenario-row-name {
+  font-size: 13px;
+  color: #e2eaf2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scenario-row-status {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.scenario-row-status--pending { background: rgba(251, 191, 36, 0.2); color: #fbbf24; }
+.scenario-row-status--running { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
+.scenario-row-status--completed { background: rgba(16, 185, 129, 0.2); color: #34d399; }
+.scenario-row-status--failed { background: rgba(239, 68, 68, 0.2); color: #f87171; }
+
+.scenario-row-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+/* Scenario buttons */
+.scenario-btn {
+  padding: 3px 9px;
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #d0dce8;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.scenario-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.scenario-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.scenario-btn--active {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #93c5fd;
+}
+
+.scenario-btn--compare.scenario-btn--active {
+  background: rgba(16, 185, 129, 0.25);
+  border-color: rgba(16, 185, 129, 0.5);
+  color: #6ee7b7;
+}
+
+/* Create form */
+.scenario-create-form {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.scenario-create-input {
+  flex: 1;
+  padding: 4px 8px;
+  font-size: 13px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e2eaf2;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  outline: none;
+  min-width: 0;
+}
+
+.scenario-create-input::placeholder {
+  color: #5a7a95;
+}
+
+.scenario-create-input:focus {
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.scenario-btn--create {
+  background: rgba(59, 130, 246, 0.3);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: #93c5fd;
+  flex-shrink: 0;
+}
+
+.scenario-btn--create:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.45);
+}
+
+.scenario-create-hint {
+  font-size: 11px;
+  color: #4a6a85;
+  margin-top: 4px;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,19 +3,30 @@ import AttributeSelector from "./components/AttributeSelector";
 import ChoroplethMap from "./components/ChoroplethMap";
 import DeltaChoropleth from "./components/DeltaChoropleth";
 import ScenarioControls from "./components/ScenarioControls";
+import ScenarioPanel from "./components/ScenarioPanel";
 import "./App.css";
 
 const DEFAULT_ATTRIBUTE = "population_total";
 
 export default function App() {
   const [attributeName, setAttributeName] = useState(DEFAULT_ATTRIBUTE);
-  const [selectedScenarioId] = useState<string | null>(null);
+  const [selectedScenarioId, setSelectedScenarioId] = useState<string | null>(null);
+  const [selectedScenarioName, setSelectedScenarioName] = useState<string | null>(null);
+  const [selectedScenarioSteps, setSelectedScenarioSteps] = useState<number>(3);
   const [currentStep, setCurrentStep] = useState<number | null>(null);
   const [compareMode, setCompareMode] = useState(false);
-  const [secondScenarioId] = useState<string | null>(null);
+  const [secondScenarioId, setSecondScenarioId] = useState<string | null>(null);
+  const [panelOpen, setPanelOpen] = useState(false);
 
   const handleStepChange = (step: number, _isComplete: boolean) => {
     setCurrentStep(step);
+  };
+
+  const handleSelectScenario = (id: string, name: string, totalSteps: number) => {
+    setSelectedScenarioId(id);
+    setSelectedScenarioName(name);
+    setSelectedScenarioSteps(totalSteps);
+    setCurrentStep(null);
   };
 
   const showDelta = compareMode && selectedScenarioId !== null && secondScenarioId !== null;
@@ -25,7 +36,7 @@ export default function App() {
       <header className="app-header">
         <h1 className="app-title">WorldSim</h1>
         <AttributeSelector onChange={setAttributeName} />
-        <label style={{ marginLeft: 12, fontSize: 13 }}>
+        <label style={{ marginLeft: 4, fontSize: 13 }}>
           <input
             type="checkbox"
             checked={compareMode}
@@ -34,14 +45,37 @@ export default function App() {
           />
           Compare scenarios
         </label>
+        <button
+          className={`scenario-toggle-btn${panelOpen ? " scenario-toggle-btn--open" : ""}`}
+          onClick={() => setPanelOpen((v) => !v)}
+        >
+          Scenarios {panelOpen ? "▲" : "▼"}
+        </button>
         {selectedScenarioId && (
-          <ScenarioControls
-            scenarioId={selectedScenarioId}
-            totalSteps={3}
-            onStepChange={handleStepChange}
-          />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            {selectedScenarioName && (
+              <span style={{ fontSize: 13, opacity: 0.85, maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {selectedScenarioName}
+              </span>
+            )}
+            <ScenarioControls
+              scenarioId={selectedScenarioId}
+              totalSteps={selectedScenarioSteps}
+              onStepChange={handleStepChange}
+            />
+          </div>
         )}
       </header>
+
+      {panelOpen && (
+        <ScenarioPanel
+          selectedScenarioId={selectedScenarioId}
+          secondScenarioId={secondScenarioId}
+          onSelectScenario={handleSelectScenario}
+          onSelectSecondScenario={setSecondScenarioId}
+        />
+      )}
+
       <main className="app-main">
         {showDelta ? (
           <DeltaChoropleth

--- a/frontend/src/components/ScenarioPanel.tsx
+++ b/frontend/src/components/ScenarioPanel.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect, useCallback } from "react";
+import type { ScenarioDetailResponse, ScenarioResponse } from "../types";
+
+const API_BASE = "http://localhost:8000/api/v1";
+
+interface Props {
+  selectedScenarioId: string | null;
+  secondScenarioId: string | null;
+  onSelectScenario: (id: string, name: string, totalSteps: number) => void;
+  onSelectSecondScenario: (id: string) => void;
+}
+
+export default function ScenarioPanel({
+  selectedScenarioId,
+  secondScenarioId,
+  onSelectScenario,
+  onSelectSecondScenario,
+}: Props) {
+  const [scenarios, setScenarios] = useState<ScenarioResponse[]>([]);
+  const [listError, setListError] = useState<string | null>(null);
+  const [createName, setCreateName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createSuccess, setCreateSuccess] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchScenarios = useCallback(async () => {
+    setListError(null);
+    try {
+      const res = await fetch(`${API_BASE}/scenarios`);
+      if (res.ok) {
+        setScenarios(await res.json() as ScenarioResponse[]);
+      } else {
+        setListError(`Could not load scenarios (${res.status}).`);
+      }
+    } catch {
+      setListError("Network error — could not load scenarios.");
+    }
+  }, []);
+
+  useEffect(() => { void fetchScenarios(); }, [fetchScenarios]);
+
+  const handleSelectPrimary = async (scenario: ScenarioResponse) => {
+    try {
+      const res = await fetch(
+        `${API_BASE}/scenarios/${encodeURIComponent(scenario.scenario_id)}`
+      );
+      if (res.ok) {
+        const detail = await res.json() as ScenarioDetailResponse;
+        onSelectScenario(scenario.scenario_id, scenario.name, detail.configuration.n_steps);
+      } else {
+        onSelectScenario(scenario.scenario_id, scenario.name, 3);
+      }
+    } catch {
+      onSelectScenario(scenario.scenario_id, scenario.name, 3);
+    }
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = createName.trim();
+    if (!name) return;
+    setCreating(true);
+    setCreateError(null);
+    setCreateSuccess(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/scenarios`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          description: null,
+          configuration: {
+            entities: ["GRC"],
+            n_steps: 3,
+            timestep_label: "annual",
+            initial_attributes: {},
+          },
+          scheduled_inputs: [],
+        }),
+      });
+
+      if (res.ok) {
+        setCreateSuccess(`"${name}" created.`);
+        setCreateName("");
+        void fetchScenarios();
+      } else {
+        const body = await res.json().catch(() => ({})) as { detail?: string };
+        setCreateError(body?.detail ?? `Error ${res.status}.`);
+      }
+    } catch {
+      setCreateError("Network error — could not create scenario.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="scenario-panel">
+      <div className="scenario-panel-inner">
+        {/* Scenario list */}
+        <div className="scenario-panel-section">
+          <div className="scenario-panel-section-title">
+            Scenarios
+            <button
+              className="scenario-panel-refresh"
+              onClick={() => void fetchScenarios()}
+              title="Refresh list"
+            >
+              ↻
+            </button>
+          </div>
+
+          {listError && (
+            <div className="scenario-panel-error">{listError}</div>
+          )}
+
+          {scenarios.length === 0 && !listError && (
+            <div className="scenario-panel-empty">No scenarios yet — create one below.</div>
+          )}
+
+          {scenarios.length > 0 && (
+            <div className="scenario-list">
+              {scenarios.map((s) => {
+                const isPrimary = s.scenario_id === selectedScenarioId;
+                const isSecond = s.scenario_id === secondScenarioId;
+                return (
+                  <div
+                    key={s.scenario_id}
+                    className={`scenario-row${isPrimary ? " scenario-row--primary" : ""}${isSecond ? " scenario-row--second" : ""}`}
+                  >
+                    <div className="scenario-row-info">
+                      <span className="scenario-row-name">{s.name}</span>
+                      <span className={`scenario-row-status scenario-row-status--${s.status}`}>
+                        {s.status}
+                      </span>
+                    </div>
+                    <div className="scenario-row-actions">
+                      <button
+                        className={`scenario-btn${isPrimary ? " scenario-btn--active" : ""}`}
+                        onClick={() => void handleSelectPrimary(s)}
+                        title="Select as primary scenario"
+                      >
+                        {isPrimary ? "✓ Primary" : "Select"}
+                      </button>
+                      <button
+                        className={`scenario-btn scenario-btn--compare${isSecond ? " scenario-btn--active" : ""}`}
+                        onClick={() => onSelectSecondScenario(s.scenario_id)}
+                        title="Select as comparison scenario"
+                      >
+                        {isSecond ? "✓ Compare" : "+ Compare"}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Create form */}
+        <div className="scenario-panel-section scenario-panel-section--create">
+          <div className="scenario-panel-section-title">New Scenario</div>
+          <form className="scenario-create-form" onSubmit={(e) => void handleCreate(e)}>
+            <input
+              className="scenario-create-input"
+              type="text"
+              placeholder="Scenario name"
+              value={createName}
+              onChange={(e) => {
+                setCreateName(e.target.value);
+                setCreateSuccess(null);
+                setCreateError(null);
+              }}
+              disabled={creating}
+            />
+            <button
+              className="scenario-btn scenario-btn--create"
+              type="submit"
+              disabled={creating || !createName.trim()}
+            >
+              {creating ? "Creating…" : "Create"}
+            </button>
+          </form>
+          {createSuccess && (
+            <div className="scenario-panel-success">{createSuccess}</div>
+          )}
+          {createError && (
+            <div className="scenario-panel-error">{createError}</div>
+          )}
+          <div className="scenario-create-hint">
+            Creates a GRC scenario with 3 annual steps.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -57,6 +57,27 @@ export interface CompareResponse {
   deltas: Record<string, Record<string, DeltaRecord>>;
 }
 
+export interface ScenarioResponse {
+  scenario_id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  version: number;
+  created_at: string;
+}
+
+export interface ScenarioConfigSchema {
+  entities: string[];
+  initial_attributes: Record<string, unknown>;
+  n_steps: number;
+  timestep_label: string;
+}
+
+export interface ScenarioDetailResponse extends ScenarioResponse {
+  configuration: ScenarioConfigSchema;
+  scheduled_inputs: unknown[];
+}
+
 export interface DeltaChoroplethFeatureProperties {
   entity_id: string;
   name: string;


### PR DESCRIPTION
## Summary

- **Restores `setSelectedScenarioId` and `setSecondScenarioId`** — both were dropped in a TS6133 unused-variable fix during M3, leaving `ScenarioControls` and `DeltaChoropleth` permanently unreachable from the browser
- **New `ScenarioPanel.tsx`** — collapsible panel toggled by a "Scenarios ▼/▲" button in the app header
- **`selectedScenarioName` displayed** in the header next to `ScenarioControls` when a scenario is active

## ScenarioPanel features

**Scenario list**
- Fetches `GET /api/v1/scenarios` on mount; refresh button to reload
- Displays scenario name + status badge (pending / running / completed / failed)
- **Select** button: sets as primary scenario (fetches detail to read `n_steps`, passes to `ScenarioControls`)
- **+ Compare** button: sets as `secondScenarioId` for delta choropleth
- Active selections highlighted distinctly (blue = primary, green = compare)

**Create form**
- Name text input + Create button
- POSTs `{ entities: ["GRC"], n_steps: 3, timestep_label: "annual" }` — minimal valid configuration
- Shows success message and refreshes list after creation
- Shows error detail from API on failure

## Test Plan

- [ ] `npm run build` in `frontend/` — TypeScript build clean (0 errors) ✓
- [ ] Open browser, click "Scenarios ▼" — panel appears below header
- [ ] Create a scenario — success message shown, list refreshes
- [ ] Click "Select" on a scenario — name appears in header, ScenarioControls visible
- [ ] Click "Next Step ▶" — advances scenario (requires backend running)
- [ ] Select a second scenario with "+ Compare", enable "Compare scenarios" checkbox — DeltaChoropleth renders
- [ ] Click "Scenarios ▲" — panel collapses, map fills full height

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)