### PR TITLE
fix(lint): two CI failures — ruff import order + mypy unused-ignore in scenarios.py

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -625,7 +625,7 @@ async def list_snapshots(
         if isinstance(state_raw, str):
             state_raw = json.loads(state_raw)
         state_dict: dict[str, Any] = state_raw if isinstance(state_raw, dict) else {}
-        modules_active: list[str] = state_dict.get("_modules_active", [])  # type: ignore[assignment]
+        modules_active: list[str] = state_dict.get("_modules_active", [])
         if not isinstance(modules_active, list):
             modules_active = []
         timestep = row["timestep"]

--- a/backend/tests/unit/test_compare_step_alignment.py
+++ b/backend/tests/unit/test_compare_step_alignment.py
@@ -14,9 +14,9 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 
 from app.api.scenarios import compare_scenarios
-from fastapi import HTTPException
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -45,7 +45,7 @@ def _snap(step: int) -> dict:
     return {"step": step, "state_data": json.dumps(_STATE)}
 
 
-def _make_conn(*side_effects) -> AsyncMock:
+def _make_conn(*side_effects: dict[str, object] | None) -> AsyncMock:
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=list(side_effects))
     return conn


### PR DESCRIPTION
## Summary

Fixes two independent lint CI failures affecting `main`.

**Fix 1 — ruff I001 + ANN002** (`tests/unit/test_compare_step_alignment.py`)
From run [24922902645](https://github.com/PublicEnemage/worldsim/actions/runs/24922902645/job/72987640935) on `feat/scenario-selector-ui` (merged):
- `I001`: `from fastapi import HTTPException` was placed after the first-party `from app.api.scenarios` import — moved above it (isort: third-party before local)
- `ANN002`: `*side_effects` had no type annotation — typed as `dict[str, object] | None`, covering the actual values in every test call; avoids `Any` to satisfy ANN401

**Fix 2 — mypy unused-ignore** (`app/api/scenarios.py:628`)
From run [24922275063](https://github.com/PublicEnemage/worldsim/actions/runs/24922275063/job/72985852996) on `feat/snapshot-envelope-v2-modules-active` (merged):
- `unused-ignore`: `dict[str, Any].get()` returns `Any`, which mypy considers directly assignable to `list[str]` — the `# type: ignore[assignment]` was never raising an error, so mypy flags the comment itself as unused. Removed.

No issue required — both are purely mechanical lint fixes per CLAUDE.md pre-PR checklist exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)