### PR TITLE
fix(tombstone): Layer 1 engine_version gap — git hash storage + reconstruction version guard (#139)

### DIFF
--- a/backend/alembic/versions/c7f4a3e9d2b1_tombstone_git_commit_hash.py
+++ b/backend/alembic/versions/c7f4a3e9d2b1_tombstone_git_commit_hash.py
@@ -1,0 +1,42 @@
+"""tombstone git_commit_hash — Issue #139 Layer 1 (ADR-004 Decision 1 Amendment)
+
+Revision ID: c7f4a3e9d2b1
+Revises: b3c9f2d1a7e5
+Create Date: 2026-05-10
+
+Adds git_commit_hash TEXT (nullable) to scenario_deleted_tombstones.
+
+engine_version stores a human-readable semantic version string ("0.3.0") which
+is a declaration, not a verifiable pointer — it cannot be resolved to a specific
+engine artifact without an external convention. git_commit_hash provides the
+precise, unambiguous pointer: a git SHA-1 that identifies the exact engine state
+at tombstone write time.
+
+Nullable because tombstones written before this migration have no hash stored.
+check_reconstruction_compatibility() in app/api/scenarios.py treats a NULL hash
+as "hash not available" and falls back to semantic version comparison only.
+
+Layer 2 (Docker artifact convention for on-demand engine instantiation) is
+formally deferred to Milestone 9 — see ADR-004 Decision 1 Amendment.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c7f4a3e9d2b1"
+down_revision = "b3c9f2d1a7e5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scenario_deleted_tombstones",
+        sa.Column("git_commit_hash", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scenario_deleted_tombstones", "git_commit_hash")

--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
+import subprocess
 import uuid
 from decimal import Decimal
 from math import floor
@@ -55,8 +57,95 @@ from app.schemas import (
 from app.simulation.mda_checker import alerts_from_events_snapshot
 from app.simulation.repositories.quantity_serde import IA1_CANONICAL_PHRASE
 
+_log = logging.getLogger(__name__)
+
 # Engine version for tombstone records — must match app version in main.py.
 _ENGINE_VERSION = "0.3.0"
+
+
+def _resolve_git_commit_hash() -> str:
+    """Return the current git commit SHA-1, or 'unknown' if unavailable.
+
+    Called once at module load time. Fails gracefully in environments where
+    git is not available (Docker runtime without .git directory, CI without
+    full checkout, unit test environments).
+    """
+    try:
+        result = subprocess.check_output(  # noqa: S603
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+        return result.decode().strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+# Resolved once at import time. "unknown" when git is unavailable.
+_GIT_COMMIT_HASH: str = _resolve_git_commit_hash()
+
+
+def check_reconstruction_compatibility(
+    tombstone_engine_version: str,
+    tombstone_git_commit_hash: str | None,
+    *,
+    force_audit_override: bool = False,
+) -> None:
+    """Enforce engine version compatibility before any tombstone reconstruction.
+
+    Implements Issue #139 Layer 1: block reconstruction when the tombstone was
+    written by a different engine version than is currently deployed. The
+    reconstruction guarantee (ADR-004 Decision 1 Amendment, SA-11) is only valid
+    for same-version use — cross-version reconstruction silently produces different
+    outputs with no error under the old behaviour.
+
+    Comparison logic:
+      - Semantic version must match exactly.
+      - Git hash is compared only when both sides carry a real hash (neither is
+        None or "unknown"). A NULL tombstone hash (pre-migration tombstone) or an
+        "unknown" live hash (non-git environment) disables hash comparison and
+        falls back to semantic version comparison alone.
+
+    Args:
+        tombstone_engine_version: engine_version stored in the tombstone row.
+        tombstone_git_commit_hash: git_commit_hash stored in the tombstone row,
+            or None for tombstones written before migration c7f4a3e9d2b1.
+        force_audit_override: When True, log a WARNING instead of raising. Only
+            for explicit audit use cases where the caller accepts the discrepancy.
+
+    Raises:
+        HTTPException(409): when tombstone version does not match live engine and
+            force_audit_override is False.
+    """
+    version_match = tombstone_engine_version == _ENGINE_VERSION
+
+    # Hash comparison is meaningful only when both sides have a resolved hash.
+    both_hashes_known = (
+        tombstone_git_commit_hash is not None
+        and tombstone_git_commit_hash != "unknown"
+        and _GIT_COMMIT_HASH != "unknown"
+    )
+    hash_match = (not both_hashes_known) or (tombstone_git_commit_hash == _GIT_COMMIT_HASH)
+
+    if version_match and hash_match:
+        return
+
+    detail = (
+        f"Tombstone engine_version='{tombstone_engine_version}' "
+        f"(git_commit_hash={tombstone_git_commit_hash!r}) does not match "
+        f"live engine engine_version='{_ENGINE_VERSION}' "
+        f"(git_commit_hash={_GIT_COMMIT_HASH!r}). "
+        "Reconstruction against a different engine version may produce outputs "
+        "that differ from what the user originally saw (SA-11 determinism). "
+        "Pass force_audit_override=True only for explicit audit use cases where "
+        "the version discrepancy is understood and accepted."
+    )
+
+    if force_audit_override:
+        _log.warning("Audit override — reconstruction version mismatch: %s", detail)
+        return
+
+    raise HTTPException(status_code=409, detail=detail)
 
 router = APIRouter(tags=["scenarios"])
 
@@ -514,14 +603,16 @@ async def delete_scenario(
             """
             INSERT INTO scenario_deleted_tombstones
                 (scenario_id, name, configuration, scheduled_inputs,
-                 engine_version, original_created_at, deleted_at, deleted_by)
-            VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7)
+                 engine_version, git_commit_hash,
+                 original_created_at, deleted_at, deleted_by)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8)
             """,
             scenario_id,
             row["name"],
             json.dumps(cfg_raw),
             json.dumps(scheduled_inputs_snap),
             _ENGINE_VERSION,
+            _GIT_COMMIT_HASH,
             row["created_at"],
             "api",
         )

--- a/backend/tests/unit/test_tombstone_version_guard.py
+++ b/backend/tests/unit/test_tombstone_version_guard.py
@@ -1,0 +1,211 @@
+"""Unit tests for tombstone reconstruction version guard — Issue #139 Layer 1.
+
+Tests check_reconstruction_compatibility() and _resolve_git_commit_hash() from
+app/api/scenarios.py. No database required — all tests exercise pure logic.
+
+Coverage:
+  1. Matching version + matching hash → passes (no exception).
+  2. Matching version + NULL tombstone hash → passes (pre-migration tombstone).
+  3. Matching version + "unknown" live hash → passes (hash comparison skipped).
+  4. Matching version + "unknown" tombstone hash → passes (hash comparison skipped).
+  5. Version mismatch → HTTPException(409).
+  6. Version match + hash mismatch → HTTPException(409).
+  7. Version mismatch + force_audit_override=True → no exception, warning logged.
+  8. Hash mismatch + force_audit_override=True → no exception, warning logged.
+  9. 409 detail includes both tombstone and live engine_version strings.
+  10. 409 detail includes both tombstone and live git_commit_hash values.
+  11. _GIT_COMMIT_HASH is a non-empty string (either a hex SHA-1 or "unknown").
+  12. _GIT_COMMIT_HASH is either 40-char hex or "unknown" — no other values.
+  13. _ENGINE_VERSION is non-empty and matches the expected semver pattern.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.scenarios import (
+    _ENGINE_VERSION,
+    _GIT_COMMIT_HASH,
+    check_reconstruction_compatibility,
+)
+
+# Convenience aliases for the live values — tests that want to assert a "match"
+# pass these so they remain correct regardless of which version is deployed.
+_LIVE_VERSION = _ENGINE_VERSION
+_LIVE_HASH = _GIT_COMMIT_HASH
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: compatible tombstones should not raise
+# ---------------------------------------------------------------------------
+
+
+def test_matching_version_and_hash_passes() -> None:
+    """Identical version and hash — reconstruction is safe."""
+    check_reconstruction_compatibility(_LIVE_VERSION, _LIVE_HASH)
+
+
+def test_matching_version_null_hash_passes() -> None:
+    """NULL tombstone hash (pre-migration tombstone) — falls back to version only."""
+    check_reconstruction_compatibility(_LIVE_VERSION, None)
+
+
+def test_matching_version_unknown_live_hash_passes() -> None:
+    """When live hash is 'unknown', hash comparison is skipped."""
+    import unittest.mock as mock
+
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", "unknown"):
+        check_reconstruction_compatibility(_LIVE_VERSION, "abc123deadbeef")
+
+
+def test_matching_version_unknown_tombstone_hash_passes() -> None:
+    """When tombstone hash is 'unknown', hash comparison is skipped."""
+    check_reconstruction_compatibility(_LIVE_VERSION, "unknown")
+
+
+def test_matching_version_both_unknown_hash_passes() -> None:
+    """Both hashes unknown — version match alone is sufficient."""
+    import unittest.mock as mock
+
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", "unknown"):
+        check_reconstruction_compatibility(_LIVE_VERSION, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Version mismatch → HTTPException(409)
+# ---------------------------------------------------------------------------
+
+
+def test_version_mismatch_raises_409() -> None:
+    """Different engine_version → reconstruction blocked."""
+    with pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility("0.1.0", _LIVE_HASH)
+    assert exc_info.value.status_code == 409
+
+
+def test_version_mismatch_detail_includes_tombstone_version() -> None:
+    """409 detail must include the tombstone's engine_version for diagnostics."""
+    with pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility("0.1.0", None)
+    assert "0.1.0" in exc_info.value.detail
+
+
+def test_version_mismatch_detail_includes_live_version() -> None:
+    """409 detail must include the live engine_version for diagnostics."""
+    with pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility("0.1.0", None)
+    assert _LIVE_VERSION in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Hash mismatch → HTTPException(409)
+# ---------------------------------------------------------------------------
+
+
+def test_hash_mismatch_raises_409() -> None:
+    """Matching version but different git hash → reconstruction blocked."""
+    import unittest.mock as mock
+
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", "a" * 40), \
+            pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility(_LIVE_VERSION, "b" * 40)
+    assert exc_info.value.status_code == 409
+
+
+def test_hash_mismatch_detail_includes_tombstone_hash() -> None:
+    """409 detail must include the tombstone git_commit_hash."""
+    import unittest.mock as mock
+
+    tombstone_hash = "c" * 40
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", "d" * 40), \
+            pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility(_LIVE_VERSION, tombstone_hash)
+    assert tombstone_hash in exc_info.value.detail
+
+
+def test_hash_mismatch_detail_includes_live_hash() -> None:
+    """409 detail must include the live git_commit_hash."""
+    import unittest.mock as mock
+
+    live_hash = "e" * 40
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", live_hash), \
+            pytest.raises(HTTPException) as exc_info:
+        check_reconstruction_compatibility(_LIVE_VERSION, "f" * 40)
+    assert live_hash in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# force_audit_override=True → no raise, warning logged
+# ---------------------------------------------------------------------------
+
+
+def test_version_mismatch_with_audit_override_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """force_audit_override=True logs a WARNING instead of raising."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="app.api.scenarios"):
+        check_reconstruction_compatibility(
+            "0.1.0", None, force_audit_override=True
+        )
+    assert any("mismatch" in r.message.lower() for r in caplog.records)
+
+
+def test_hash_mismatch_with_audit_override_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """force_audit_override=True suppresses 409 even on hash mismatch."""
+    import logging
+    import unittest.mock as mock
+
+    with mock.patch("app.api.scenarios._GIT_COMMIT_HASH", "a" * 40), \
+            caplog.at_level(logging.WARNING, logger="app.api.scenarios"):
+        check_reconstruction_compatibility(
+            _LIVE_VERSION, "b" * 40, force_audit_override=True
+        )
+    assert any("mismatch" in r.message.lower() for r in caplog.records)
+
+
+def test_matching_version_with_audit_override_does_not_raise_or_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """force_audit_override=True on a compatible tombstone is a no-op."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="app.api.scenarios"):
+        check_reconstruction_compatibility(_LIVE_VERSION, _LIVE_HASH, force_audit_override=True)
+    assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+def test_git_commit_hash_is_non_empty_string() -> None:
+    """_GIT_COMMIT_HASH must always be a non-empty string."""
+    assert isinstance(_GIT_COMMIT_HASH, str)
+    assert len(_GIT_COMMIT_HASH) > 0
+
+
+def test_git_commit_hash_is_hex_sha1_or_unknown() -> None:
+    """_GIT_COMMIT_HASH is either a 40-char hex SHA-1 or the sentinel 'unknown'."""
+    assert _GIT_COMMIT_HASH == "unknown" or re.fullmatch(r"[0-9a-f]{40}", _GIT_COMMIT_HASH), (
+        f"_GIT_COMMIT_HASH has unexpected format: {_GIT_COMMIT_HASH!r}"
+    )
+
+
+def test_engine_version_is_non_empty() -> None:
+    """_ENGINE_VERSION must be a non-empty string."""
+    assert isinstance(_ENGINE_VERSION, str)
+    assert len(_ENGINE_VERSION) > 0
+
+
+def test_engine_version_matches_semver_pattern() -> None:
+    """_ENGINE_VERSION must follow MAJOR.MINOR.PATCH semver format."""
+    assert re.fullmatch(r"\d+\.\d+\.\d+", _ENGINE_VERSION), (
+        f"_ENGINE_VERSION does not match semver: {_ENGINE_VERSION!r}"
+    )

--- a/docs/adr/ADR-004-scenario-engine.md
+++ b/docs/adr/ADR-004-scenario-engine.md
@@ -182,50 +182,47 @@ The audit store requirement is an application-layer addition to the DELETE endpo
 
 **CONFLICT C-1 is resolved.** No further Engineering Lead action required on this conflict.
 
-#### Known Limitation — engine_version is a Declaration, Not a Verifiable Pointer (2026-04-24)
+#### Known Limitation — engine_version is a Declaration, Not a Verifiable Pointer (2026-04-24; partially resolved 2026-05-10)
 
 The reconstruction guarantee in the tombstone design rests on SA-11 determinism: same
 configuration + same scheduled inputs + same engine version → identical output. This
-guarantee has a boundary condition that is not yet enforced.
+guarantee has a boundary condition that was not enforced at M4. Issue #139 tracks the
+two-layer fix; Layer 1 is resolved at M7 and Layer 2 is formally deferred to M9.
 
-**The gap:** `engine_version` is currently stored as a semantic version string
-(`"0.3.0"`) hardcoded in `app/api/scenarios.py`. This is a *declaration* — it records
-what version was claimed at deletion time, but provides no mechanism to:
+**The original gap:** `engine_version` was stored as a semantic version string only —
+a *declaration* without a mechanism to verify the string against a specific artifact,
+instantiate a prior engine version on demand, or block cross-version reconstruction.
 
-1. Verify that the string corresponds to a specific, retrievable engine artifact.
-2. Instantiate that engine version at reconstruction time if it differs from the
-   current deployed version.
-3. Block or flag a reconstruction attempt when the tombstone version and the live
-   engine version do not match.
+**Layer 1 — RESOLVED (2026-05-10, migration c7f4a3e9d2b1, Issue #139):**
 
-**Why this matters at Milestone 4:** M4 will recalibrate propagation coefficients and
-add new simulation modules (Human Cost Ledger). A tombstone written under M3
-(`engine_version = "0.3.0"`) reconstructed against the M4 engine will produce
-different outputs than the user originally saw. The reconstruction guarantee silently
-fails — no error is raised, but the outputs are not reproducible.
+`git_commit_hash TEXT` (nullable) added to `scenario_deleted_tombstones`. At tombstone
+write time, `_resolve_git_commit_hash()` (in `app/api/scenarios.py`) executes
+`git rev-parse HEAD` and stores the SHA-1 alongside the semantic version string. Fails
+gracefully to `"unknown"` in environments without git access (Docker runtime, CI
+shallow clone). The field is NULL for tombstones written before this migration.
 
-**The conservative control posture:** Block reconstruction unconditionally when tombstone
-`engine_version` does not match the live engine version. Do not warn and proceed — the
-system has no visibility into how reconstructed outputs are used downstream, so a
-permissive response cannot be made safe by intent declaration. A logged exception
-override mechanism should exist for explicit audit use cases, but the default must be
-a hard block.
+`check_reconstruction_compatibility(tombstone_engine_version, tombstone_git_commit_hash)`
+(in `app/api/scenarios.py`) enforces the conservative control posture required by Issue
+#139: raises `HTTPException(409)` when the tombstone's engine version or git hash does
+not match the live engine. Hash comparison is skipped when either side is NULL or
+`"unknown"`, falling back to semantic version comparison. A `force_audit_override=True`
+keyword argument logs a WARNING instead of raising, for explicit audit use cases. This
+function must be called by any future reconstruction endpoint before executing.
 
-**The two-layer fix required (tracked in Issue #[TBD]):**
+**Layer 2 — FORMALLY DEFERRED to Milestone 9:**
 
-1. Replace the semantic version string with a git commit hash (or store both). A commit
-   hash is a precise, retrievable pointer that unambiguously identifies the engine state.
-   A semantic version string requires an external convention to resolve to a specific
-   artifact.
+Building the artifact convention (version-tagged Docker images or a git-pinned
+deployment mechanism for on-demand engine instantiation) requires infrastructure that
+is out of scope for M7 and M8. The Milestone 9 scope (methodology publication and
+external contributor infrastructure) is the earliest point where the deployment
+mechanism and the reconstruction endpoint can be co-designed. The tombstone already has
+the right shape; the resolution mechanism does not yet exist. This deferral is the
+documented rationale required by the M7 exit checklist.
 
-2. Build the artifact convention: version-tagged Docker images or a git-pinned
-   deployment mechanism that allows a specific engine version to be instantiated on
-   demand for reconstruction. The tombstone already has the right shape; the resolution
-   mechanism does not yet exist.
-
-**Status:** Open architectural gap. Tracked in Issue #139.
-The tombstone remains sound as an audit record; the reconstruction guarantee is
-accurate for same-version use and undeclared for cross-version use.
+**Current status:** Layer 1 done. The tombstone is sound as an audit record and as a
+reconstruction input. `check_reconstruction_compatibility()` enforces the version guard
+at any future reconstruction call site. Layer 2 (on-demand engine instantiation) is
+deferred to M9 with this entry as the formal record.
 
 ---
 

--- a/docs/schema/database.yml
+++ b/docs/schema/database.yml
@@ -445,7 +445,20 @@ tables:
       engine_version:
         type: text
         nullable: false
-        description: Engine version string at deletion time. e.g. "0.3.0".
+        description: >
+          Semantic version string at deletion time (e.g. "0.3.0"). Declaration only —
+          not a verifiable artifact pointer without git_commit_hash. Used by
+          check_reconstruction_compatibility() as the primary version comparison.
+      git_commit_hash:
+        type: text
+        nullable: true
+        description: >
+          Git SHA-1 of the engine at tombstone write time, or "unknown" if git was
+          unavailable at module load. NULL for tombstones written before migration
+          c7f4a3e9d2b1 (Issue #139 Layer 1). Provides a precise, unambiguous pointer
+          to the exact engine state. check_reconstruction_compatibility() uses this
+          for hash comparison when both sides carry a real hash; falls back to
+          semantic version comparison when either side is NULL or "unknown".
       original_created_at:
         type: "timestamp with time zone"
         nullable: false


### PR DESCRIPTION
## Summary

- Adds `git_commit_hash TEXT` (nullable) to `scenario_deleted_tombstones` (migration `c7f4a3e9d2b1`)
- `_resolve_git_commit_hash()` runs `git rev-parse HEAD` at module load, stored in `_GIT_COMMIT_HASH` — falls back to `"unknown"` gracefully in Docker runtime / shallow CI
- DELETE endpoint now stores both `engine_version` and `git_commit_hash` in the tombstone
- `check_reconstruction_compatibility(tombstone_engine_version, tombstone_git_commit_hash)` raises `HTTPException(409)` on version or hash mismatch — must be called by any future reconstruction endpoint
- Hash comparison skipped when either side is `NULL` or `"unknown"` (pre-migration tombstones, non-git envs); falls back to semantic version comparison
- `force_audit_override=True` logs `WARNING` instead of raising — for explicit audit use cases
- ADR-004 Decision 1 Amendment Known Limitation updated: Layer 1 done, Layer 2 (Docker artifact / on-demand engine instantiation) formally deferred to M9
- `docs/schema/database.yml` updated in same commit

## M7 exit criterion satisfied

> "engine_version gap #139 resolved or formally deferred with ADR entry"

Layer 1 is resolved. Layer 2 deferral is documented in ADR-004 with rationale and target milestone.

## Test plan

- [x] 18 new unit tests in `test_tombstone_version_guard.py` — all comparison paths, `force_audit_override`, module constant format assertions
- [x] 726/726 unit tests pass
- [x] `ruff check` clean on all changed files

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)