### PR TITLE
fix: [SIM-INTEGRITY] warnings and DEBUG logs for propagation silent failures (#243 #244 #245)

### DIFF
--- a/backend/app/simulation/engine/propagation.py
+++ b/backend/app/simulation/engine/propagation.py
@@ -16,8 +16,9 @@ Architecture contracts (ADR-001):
   confidence_tier uses the lower-of-two rule across accumulated inputs.
 - STOCK variable deltas replace the current attribute value; FLOW, RATIO,
   and DIMENSIONLESS deltas accumulate additively on the existing value.
-- Deltas for entity_ids not present in state.entities are silently dropped.
-  A relationship may reference an entity outside the active resolution scope.
+- Deltas for entity_ids not present in state.entities are dropped with a
+  [SIM-INTEGRITY] WARNING. A relationship may reference an entity outside the
+  active resolution scope; the warning makes this observable in CI logs.
 
 Amendment 1 (SCR-001): _DeltaAccumulator and all delta arithmetic updated
 from dict[str, float] to dict[str, Quantity]. Attenuation scales
@@ -27,6 +28,7 @@ the lower-of-two rule. _build_next_state applies STOCK/FLOW semantics.
 
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 
 from app.simulation.engine.models import (
@@ -36,6 +38,8 @@ from app.simulation.engine.models import (
     SimulationState,
 )
 from app.simulation.engine.quantity import Quantity, VariableType
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -229,6 +233,15 @@ def _accumulate(
     entity_deltas = accumulator[entity_id]
     for key, delta in deltas.items():
         if key in entity_deltas:
+            if delta.variable_type == VariableType.STOCK:
+                _log.warning(
+                    "[SIM-INTEGRITY] Two STOCK events for entity_id=%r attribute=%r "
+                    "in the same step — values will be summed, not replaced. "
+                    "STOCK semantics expect a single absolute-level event per "
+                    "attribute per step.",
+                    entity_id,
+                    key,
+                )
             existing = entity_deltas[key]
             entity_deltas[key] = Quantity(
                 value=existing.value + delta.value,
@@ -276,6 +289,15 @@ def _build_next_state(
         New SimulationState with updated entity attribute values.
     """
     new_entities: dict[str, SimulationEntity] = {}
+
+    for entity_id in accumulator:
+        if entity_id not in state.entities:
+            _log.warning(
+                "[SIM-INTEGRITY] Accumulated delta for entity_id=%r absent from "
+                "state.entities — delta dropped. Check relationship scope or "
+                "whether the entity was tombstoned.",
+                entity_id,
+            )
 
     for entity_id, entity in state.entities.items():
         new_attrs: dict[str, Quantity] = dict(entity.attributes)

--- a/backend/app/simulation/modules/demographic/module.py
+++ b/backend/app/simulation/modules/demographic/module.py
@@ -10,6 +10,7 @@ changes appear with a structural delay in real economies.
 """
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -25,6 +26,8 @@ from app.simulation.modules.demographic.elasticities import ELASTICITY_REGISTRY
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+_log = logging.getLogger(__name__)
 
 _SUBSCRIBED_EVENTS = frozenset({
     "gdp_growth_change",
@@ -59,6 +62,12 @@ class DemographicModule(SimulationModule):
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
         ]
         if not prior_events:
+            _log.debug(
+                "%s: no subscribed events for entity_id=%r at timestep=%r — returning []",
+                type(self).__name__,
+                entity.id,
+                timestep,
+            )
             return []
 
         result: list[Event] = []

--- a/backend/app/simulation/modules/ecological/module.py
+++ b/backend/app/simulation/modules/ecological/module.py
@@ -30,6 +30,7 @@ ecological effects are silently absent. Enforcement tracked in Issue #211 (M7).
 """
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,8 @@ from app.simulation.modules.ecological.elasticities import ECOLOGICAL_ELASTICITY
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+_log = logging.getLogger(__name__)
 
 _SUBSCRIBED_EVENTS = frozenset({
     "gdp_growth_change",
@@ -84,6 +87,12 @@ class EcologicalModule(SimulationModule):
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
         ]
         if not prior_events:
+            _log.debug(
+                "%s: no subscribed events for entity_id=%r at timestep=%r — returning []",
+                type(self).__name__,
+                entity.id,
+                timestep,
+            )
             return []
 
         # Accumulate deltas per indicator across all prior events.

--- a/backend/app/simulation/modules/governance/module.py
+++ b/backend/app/simulation/modules/governance/module.py
@@ -14,6 +14,7 @@ governance effects are silently absent. Enforcement tracked in Issue #211 (M7).
 """
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,8 @@ from app.simulation.modules.governance.elasticities import GOVERNANCE_ELASTICITY
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+_log = logging.getLogger(__name__)
 
 _SUBSCRIBED_EVENTS = frozenset({
     "gdp_growth_change",
@@ -61,6 +64,12 @@ class GovernanceModule(SimulationModule):
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
         ]
         if not prior_events:
+            _log.debug(
+                "%s: no subscribed events for entity_id=%r at timestep=%r — returning []",
+                type(self).__name__,
+                entity.id,
+                timestep,
+            )
             return []
 
         # Accumulate deltas per indicator across all prior events.

--- a/backend/app/simulation/modules/macroeconomic/module.py
+++ b/backend/app/simulation/modules/macroeconomic/module.py
@@ -17,6 +17,7 @@ the single GDP→demographic path.
 """
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -31,6 +32,8 @@ from app.simulation.engine.quantity import Quantity, VariableType
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Module constants (ADR-006 Decision 1 / Decision 8)
@@ -92,6 +95,12 @@ class MacroeconomicModule(SimulationModule):
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
         ]
         if not prior_events:
+            _log.debug(
+                "%s: no subscribed events for entity_id=%r at timestep=%r — returning []",
+                type(self).__name__,
+                entity.id,
+                timestep,
+            )
             return []
 
         current_gdp_growth = entity.get_attribute_value("gdp_growth", Decimal("0"))

--- a/backend/tests/unit/test_demographic_module.py
+++ b/backend/tests/unit/test_demographic_module.py
@@ -14,8 +14,13 @@ Coverage:
 """
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 from app.simulation.modules.demographic.cohort import (
     AgeBand,
@@ -291,3 +296,25 @@ def test_demographic_events_tagged_human_development() -> None:
     ts = datetime(2011, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
     events = module.compute(state.entities["GRC"], state, ts)
     assert all(e.framework == MeasurementFramework.HUMAN_DEVELOPMENT for e in events)
+
+
+# ---------------------------------------------------------------------------
+# DEBUG log on empty prior_events — Issue #245
+# ---------------------------------------------------------------------------
+
+
+def test_demographic_module_logs_debug_on_no_prior_events(caplog: pytest.LogCaptureFixture) -> None:
+    """DemographicModule must emit a DEBUG log when prior_events is empty (Issue #245)."""
+    ts = datetime(2011, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    state = _make_state("GRC", entity_type="country", prior_events=[])
+    module = DemographicModule(cohort_resolution_entity_ids=["GRC"])
+    entity = state.entities["GRC"]
+    with caplog.at_level(logging.DEBUG, logger="app.simulation.modules.demographic.module"):
+        result = module.compute(entity, state, ts)
+
+    assert result == []
+    assert any(
+        "no subscribed events" in r.message and "GRC" in r.message
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"

--- a/backend/tests/unit/test_ecological_module.py
+++ b/backend/tests/unit/test_ecological_module.py
@@ -23,8 +23,13 @@ All tests run without a database connection.
 """
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 from app.simulation.engine.models import (
     Event,
@@ -522,3 +527,45 @@ def test_ecological_not_in_unimplemented_frameworks() -> None:
         "'ecological' is still in _UNIMPLEMENTED_FRAMEWORKS — "
         "must be removed when EcologicalModule is wired in"
     )
+
+
+# ---------------------------------------------------------------------------
+# DEBUG log on empty prior_events — Issue #245
+# ---------------------------------------------------------------------------
+
+
+def test_ecological_module_logs_debug_on_no_prior_events(caplog: pytest.LogCaptureFixture) -> None:
+    """EcologicalModule must emit a DEBUG log when prior_events is empty (Issue #245)."""
+    from app.simulation.engine.models import ResolutionConfig, ScenarioConfig, SimulationState
+    from app.simulation.modules.ecological.module import EcologicalModule
+
+    entity = SimulationEntity(
+        id="GRC",
+        entity_type="country",
+        attributes={},
+        metadata={},
+    )
+    state = SimulationState(
+        timestep=datetime(2010, 1, 1, tzinfo=UTC),
+        resolution=ResolutionConfig(),
+        entities={"GRC": entity},
+        relationships=[],
+        events=[],  # no prior events
+        scenario_config=ScenarioConfig(
+            scenario_id="test",
+            name="Test",
+            description="",
+            start_date=datetime(2010, 1, 1, tzinfo=UTC),
+            end_date=datetime(2013, 1, 1, tzinfo=UTC),
+        ),
+    )
+    module = EcologicalModule()
+    with caplog.at_level(logging.DEBUG, logger="app.simulation.modules.ecological.module"):
+        result = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+
+    assert result == []
+    assert any(
+        "no subscribed events" in r.message and "GRC" in r.message
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"

--- a/backend/tests/unit/test_governance_module.py
+++ b/backend/tests/unit/test_governance_module.py
@@ -14,8 +14,13 @@ Coverage:
 """
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 from app.simulation.modules.governance.elasticities import GOVERNANCE_ELASTICITY_REGISTRY
 from app.simulation.modules.governance.module import _SUBSCRIBED_EVENTS, GovernanceModule
@@ -305,3 +310,25 @@ def test_registry_event_types_are_subscribed() -> None:
         assert row.event_type in _SUBSCRIBED_EVENTS, (
             f"Registry entry event_type '{row.event_type}' not in _SUBSCRIBED_EVENTS"
         )
+
+
+# ---------------------------------------------------------------------------
+# DEBUG log on empty prior_events — Issue #245
+# ---------------------------------------------------------------------------
+
+
+def test_governance_module_logs_debug_on_no_prior_events(caplog: pytest.LogCaptureFixture) -> None:
+    """GovernanceModule must emit a DEBUG log when prior_events is empty (Issue #245)."""
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    state = _make_state("GRC", prior_events=[])
+    module = GovernanceModule()
+    entity = state.entities["GRC"]
+    with caplog.at_level(logging.DEBUG, logger="app.simulation.modules.governance.module"):
+        result = module.compute(entity, state, ts)
+
+    assert result == []
+    assert any(
+        "no subscribed events" in r.message and "GRC" in r.message
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"

--- a/backend/tests/unit/test_macroeconomic_module.py
+++ b/backend/tests/unit/test_macroeconomic_module.py
@@ -24,8 +24,13 @@ Coverage:
 """
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 from app.simulation.engine.models import (
     Event,
@@ -511,3 +516,25 @@ def test_regime_change_event_tagged_financial() -> None:
     events = module.compute(state.entities["GRC"], state, _TS)
     regime_event = next(e for e in events if e.event_type == "regime_change")
     assert regime_event.framework == MeasurementFramework.FINANCIAL
+
+
+# ---------------------------------------------------------------------------
+# DEBUG log on empty prior_events — Issue #245
+# ---------------------------------------------------------------------------
+
+
+def test_macroeconomic_module_logs_debug_on_no_prior_events(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MacroeconomicModule must emit a DEBUG log when prior_events is empty (Issue #245)."""
+    state = _make_state(entity_id="GRC", prior_events=[])
+    module = MacroeconomicModule()
+    with caplog.at_level(logging.DEBUG, logger="app.simulation.modules.macroeconomic.module"):
+        result = module.compute(state.entities["GRC"], state, _TS)
+
+    assert result == []
+    assert any(
+        "no subscribed events" in r.message and "GRC" in r.message
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"

--- a/backend/tests/unit/test_propagation.py
+++ b/backend/tests/unit/test_propagation.py
@@ -17,6 +17,7 @@ All Quantity deltas default to VariableType.RATIO so propagation
 semantics (additive accumulation) are preserved for existing test cases.
 """
 
+import logging
 from datetime import datetime
 from decimal import Decimal
 
@@ -34,6 +35,8 @@ from app.simulation.engine.models import (
 )
 from app.simulation.engine.propagation import propagate
 from app.simulation.engine.quantity import Quantity, VariableType
+
+_PROPAGATION_LOGGER = "app.simulation.engine.propagation"
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -765,3 +768,163 @@ class TestPropagateStateStructure:
         })
         result = propagate(state, [_event("BOL", {"gdp": -1.0})])
         assert set(result.entities.keys()) == {"BOL", "BRA", "GRC"}
+
+
+# ---------------------------------------------------------------------------
+# [SIM-INTEGRITY] warning tests — Issue #243 and #244
+# ---------------------------------------------------------------------------
+
+
+class TestDroppedDeltaWarning:
+    """Issue #243 — propagation warns when accumulated delta targets absent entity."""
+
+    def test_warning_fires_for_absent_entity(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Delta targeting entity_id not in state.entities must emit [SIM-INTEGRITY] WARNING."""
+        # "BOL" is in the event but not in state.entities
+        state = _state({"BRA": _entity("BRA")})
+        event = _event("BOL", {"gdp": -0.05})
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, [event])
+        assert any(
+            "[SIM-INTEGRITY]" in r.message and "BOL" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), (
+            "Expected [SIM-INTEGRITY] warning naming 'BOL'. "
+            f"Got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_warning_names_the_missing_entity_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning message must contain the absent entity_id."""
+        state = _state({"BRA": _entity("BRA")})
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, [_event("GHOST_ENTITY", {"gdp": -0.1})])
+        messages = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        )
+        assert "GHOST_ENTITY" in messages
+
+    def test_simulation_continues_after_dropped_delta_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Dropped delta must not raise — warning only, simulation continues."""
+        state = _state({"BRA": _entity("BRA", gdp=0.02)})
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            result = propagate(state, [_event("ABSENT", {"gdp": -0.05})])
+        # BRA unaffected; result has same entities
+        assert "BRA" in result.entities
+        assert float(result.entities["BRA"].get_attribute_value("gdp")) == pytest.approx(0.02)
+
+    def test_no_warning_when_entity_is_present(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No [SIM-INTEGRITY] warning when source entity exists in state."""
+        state = _state({"BOL": _entity("BOL", gdp=0.0)})
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, [_event("BOL", {"gdp": -0.05})])
+        sim_integrity_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "[SIM-INTEGRITY]" in r.message
+        ]
+        assert not sim_integrity_warnings
+
+
+class TestStockConflictWarning:
+    """Issue #244 — propagation warns when two STOCK events target the same attribute."""
+
+    def _stock_event(
+        self, source: str, attr: str, value: float, event_id: str = "evt-stock"
+    ) -> Event:
+        return Event(
+            event_id=event_id,
+            source_entity_id=source,
+            event_type="stock_update",
+            affected_attributes={attr: _q(value, variable_type=VariableType.STOCK)},
+            propagation_rules=[],
+            timestep_originated=datetime(2020, 1, 1),
+            framework=MeasurementFramework.FINANCIAL,
+        )
+
+    def test_warning_fires_for_stock_conflict(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two STOCK events on same entity+attribute must emit [SIM-INTEGRITY] WARNING."""
+        state = _state({"GRC": _entity("GRC", debt_gdp=1.7)})
+        events = [
+            self._stock_event("GRC", "debt_gdp", 1.8, "evt-1"),
+            self._stock_event("GRC", "debt_gdp", 1.9, "evt-2"),
+        ]
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, events)
+        assert any(
+            "[SIM-INTEGRITY]" in r.message and "debt_gdp" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ), (
+            "Expected [SIM-INTEGRITY] STOCK conflict warning. "
+            f"Got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_warning_names_attribute_and_entity(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """STOCK conflict warning must name both entity_id and attribute key."""
+        state = _state({"GRC": _entity("GRC", reserves=50.0)})
+        events = [
+            self._stock_event("GRC", "reserves", 45.0, "evt-a"),
+            self._stock_event("GRC", "reserves", 40.0, "evt-b"),
+        ]
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, events)
+        messages = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        )
+        assert "GRC" in messages
+        assert "reserves" in messages
+
+    def test_simulation_continues_after_stock_conflict_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """STOCK conflict must not raise — warning only, simulation continues."""
+        state = _state({"GRC": _entity("GRC", debt_gdp=1.7)})
+        events = [
+            self._stock_event("GRC", "debt_gdp", 1.8, "evt-1"),
+            self._stock_event("GRC", "debt_gdp", 1.9, "evt-2"),
+        ]
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            result = propagate(state, events)
+        assert "GRC" in result.entities
+
+    def test_no_warning_for_single_stock_event(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A single STOCK event on an attribute must not trigger a STOCK conflict warning."""
+        state = _state({"GRC": _entity("GRC", debt_gdp=1.7)})
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, [self._stock_event("GRC", "debt_gdp", 1.8)])
+        stock_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "STOCK" in r.message
+        ]
+        assert not stock_warnings
+
+    def test_no_warning_for_ratio_conflict(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two RATIO events on the same attribute are expected (additive) — no warning."""
+        state = _state({"GRC": _entity("GRC", gdp=0.0)})
+        events = [
+            _event("GRC", {"gdp": -0.05}),
+            _event("GRC", {"gdp": -0.03}),
+        ]
+        with caplog.at_level(logging.WARNING, logger=_PROPAGATION_LOGGER):
+            propagate(state, events)
+        stock_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "STOCK" in r.message
+        ]
+        assert not stock_warnings


### PR DESCRIPTION
## Summary

Implements all three fix issues from the Issue #224 silent failure audit:

- **#243** — `propagation._build_next_state`: `[SIM-INTEGRITY]` WARNING when an accumulated delta targets an entity_id absent from `state.entities`. Previously silent drop; now observable with entity_id in CI logs.
- **#244** — `propagation._accumulate`: `[SIM-INTEGRITY]` WARNING when two STOCK events target the same entity+attribute in the same step. STOCK semantics expect one absolute-level event per attribute per step; summing two is architecturally unexpected. Semantic resolution deferred to M8; the warning is the immediate fix.
- **#245** — `EcologicalModule`, `GovernanceModule`, `MacroeconomicModule`, `DemographicModule`: DEBUG log when `compute()` returns `[]` due to no subscribed events in `state.events`. Enables per-step tracing. Structural-absence WARNING (MacroeconomicModule not wired) remains Issue #211.

## Test plan

- [ ] `ruff check` passes on all 10 changed files
- [ ] `TestDroppedDeltaWarning` (4 tests): warning fires and names entity_id, simulation continues, no false positive for present entity
- [ ] `TestStockConflictWarning` (6 tests): warning fires and names entity+attribute, simulation continues, no false positive for single STOCK event, no false positive for RATIO conflicts
- [ ] `test_ecological_module_logs_debug_on_no_prior_events` — DEBUG log fires with entity_id
- [ ] `test_governance_module_logs_debug_on_no_prior_events` — same
- [ ] `test_macroeconomic_module_logs_debug_on_no_prior_events` — same
- [ ] `test_demographic_module_logs_debug_on_no_prior_events` — same

Closes #243
Closes #244
Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)