### PR TITLE
fix(frontend): handle collapsed quantiles in computeSteps for ordinal attributes

### DIFF
--- a/frontend/src/components/ChoroplethMap.tsx
+++ b/frontend/src/components/ChoroplethMap.tsx
@@ -18,6 +18,14 @@ interface Props {
   onEntityClick?: (entityId: string) => void;
 }
 
+// computeSteps returns five breakpoints [p0, p25, p50, p75, p100] used as
+// MapLibre step-expression thresholds. MapLibre requires strictly ascending
+// thresholds — duplicate values (collapsed quantiles) produce broken rendering.
+//
+// Collapsed quantiles occur for small-range ordinal attributes like economy_tier
+// (1–7) or income_group (1–5) when many countries share the same tier value.
+// In that case we fall back to evenly-spaced breakpoints across [min, max] so
+// colour variation is always visible regardless of distribution shape.
 function computeSteps(features: GeoJSONFeatureCollection["features"]): number[] {
   const values = features
     .map((f) => parseFloat(f.properties.attribute_value))
@@ -26,8 +34,27 @@ function computeSteps(features: GeoJSONFeatureCollection["features"]): number[] 
 
   if (values.length === 0) return [0, 1, 2, 3, 4];
 
+  const min = values[0];
+  const max = values[values.length - 1];
+  const range = max - min;
+
+  // Degenerate case: all values identical — return a dummy span so the step
+  // expression stays valid; the single-colour result is correct.
+  if (range === 0) return [min, min + 1, min + 2, min + 3, min + 4];
+
   const pct = (p: number) => values[Math.floor((p / 100) * (values.length - 1))];
-  return [pct(0), pct(25), pct(50), pct(75), pct(100)];
+  const raw = [pct(0), pct(25), pct(50), pct(75), pct(100)];
+
+  // If quantiles are not strictly ascending (collapsed distribution), fall back
+  // to four equal-width intervals spanning [min, max]. This ensures each colour
+  // band covers a distinct portion of the value range.
+  const isStrictlyAscending = raw.every((v, i) => i === 0 || v > raw[i - 1]);
+  if (!isStrictlyAscending) {
+    const step = range / 4;
+    return [min, min + step, min + 2 * step, min + 3 * step, max];
+  }
+
+  return raw;
 }
 
 export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick }: Props) {


### PR DESCRIPTION
## Summary

- `computeSteps()` in `ChoroplethMap.tsx` previously used raw percentile quantiles (p0/p25/p50/p75/p100) as MapLibre `step` expression thresholds
- For small-range ordinal attributes like `economy_tier` (1–7) and `income_group` (1–5), many countries share the same tier value, causing quantile breakpoints to collapse to equal values — invalid for MapLibre `step` expressions (requires strictly ascending thresholds)
- The result was a flat/uniform choropleth rendering for those attributes (all countries same colour)
- Fix: after computing raw quantiles, checks strict ascension; if not, falls back to four equal-width intervals spanning `[min, max]`
- Also adds a degenerate-range guard (`range === 0`) with a dummy span so the expression stays valid when all countries share the exact same value

## Pre-existing lint errors

`npm run lint` shows 20 pre-existing ESLint errors across `App.tsx`, `AttributeSelector.tsx`, `EntityDetailDrawer.tsx`, `ScenarioPanel.tsx`, `useMultiFrameworkOutput.ts`, and E2E test files. None are introduced by this change.

## Test plan

- [ ] Load the choropleth map and select `economy_tier` or `income_group` — countries should now render with visually distinct colour bands rather than a flat uniform colour
- [ ] Continuous-range attributes (e.g. `gdp_per_capita`, `unemployment_rate`) continue to use quantile breakpoints as before
- [ ] Single-value distributions (all countries same value) render without JS errors

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)