### PR TITLE
chore(adr): renew ADR-001 through ADR-006 licenses to Milestone 8

### DIFF
--- a/docs/adr/ADR-001-simulation-core-data-model.md
+++ b/docs/adr/ADR-001-simulation-core-data-model.md
@@ -6,10 +6,25 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. No renewal triggers
+fired during Milestone 7. License Status confirmed CURRENT. M7 delivered:
+Defensive Programming section added to `CODING_STANDARDS.md` (Issue #224) —
+no changes to `MeasurementFramework` taxonomy, `DATA_STANDARDS.md §Units and
+Measurements`, or state representation contracts. `[SIM-INTEGRITY]` logging
+added to `propagation.py` and all four modules (Issues #243–#245) — engine-
+internal additions that do not alter the `Quantity` type structure,
+`SimulationEntity.attributes` store design, or `propagate_confidence`
+lower-of-two rule. `computeSteps()` collapsed-quantile fix (Issue #82) is a
+frontend rendering fix with no state representation changes. HCL deferred
+thresholds in Greece fixture (Issue #87) use the existing `deferred_thresholds`
+parameter — no backtesting integrity rule or schema change. License renewed
+for Milestone 8. Next scheduled review at Milestone 8 — Ecological and
+Governance Frameworks completion.
+
+**Previously reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
 fired during Milestone 6. License Status confirmed CURRENT. EcologicalModule
 and GovernanceModule (new in M6) produce Quantity-delta Events within the
 existing `affected_attributes` contract and do not alter the `Quantity` type

--- a/docs/adr/ADR-002-input-orchestration-layer.md
+++ b/docs/adr/ADR-002-input-orchestration-layer.md
@@ -6,10 +6,22 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. No renewal triggers
+fired during Milestone 7. License Status confirmed CURRENT. M7 delivered no
+changes to `ControlInput` type taxonomy, audit trail schema requirements, or
+`MeasurementFramework` tagging requirements. `[SIM-INTEGRITY]` logging
+additions in `propagation.py`, `runner.py`, and all four modules (Issues #223,
+#243–#245) are engine-internal additions that do not introduce new input
+channels, alter audit trail schema, or change how events carry uncertainty.
+Defensive Programming section in `CODING_STANDARDS.md` (Issue #224) is a
+standards addition with no effect on orchestration contracts. License renewed
+for Milestone 8. Next scheduled review at Milestone 8 — Ecological and
+Governance Frameworks completion.
+
+**Previously reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
 fired during Milestone 6. License Status confirmed CURRENT. No changes to
 `ControlInput` type taxonomy, audit trail schema requirements, or
 `MeasurementFramework` tagging requirements. Lebanon, Thailand, and Ecuador

--- a/docs/adr/ADR-003-geospatial-foundation.md
+++ b/docs/adr/ADR-003-geospatial-foundation.md
@@ -6,10 +6,20 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-21
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. No renewal triggers
+fired during Milestone 7. License Status confirmed CURRENT. M7 delivered no
+changes to GeoJSON-over-REST serving approach, PostGIS schema, CORS policy, or
+TerritorialValidator gate. The `computeSteps()` collapsed-quantile fix (Issue
+#82) is a client-side rendering improvement in `ChoroplethMap.tsx` that does
+not alter the choropleth API response format or GeoJSON contract. `[SIM-INTEGRITY]`
+logging additions are backend engine-internal changes with no impact on
+geospatial contracts. License renewed for Milestone 8. Next scheduled review
+at Milestone 8 — Ecological and Governance Frameworks completion.
+
+**Previously reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
 fired during Milestone 6. License Status confirmed CURRENT. No changes to
 GeoJSON-over-REST serving approach, PostGIS schema, CORS policy, or
 TerritorialValidator gate. M6 additions (EcologicalModule, GovernanceModule,

--- a/docs/adr/ADR-004-scenario-engine.md
+++ b/docs/adr/ADR-004-scenario-engine.md
@@ -6,13 +6,26 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-21
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
 **Engineering Lead accepted 2026-04-21.** Architecture decisions reviewed and
 approved. Implementation may proceed.
 
-**Last Reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. No renewal triggers
+fired during Milestone 7. License Status confirmed CURRENT. M7 delivered no
+changes to scenario storage format, backtesting threshold contract, advance
+protocol, or snapshot contract. HCL deferred thresholds added to the Greece
+fixture (Issue #87) use the existing `deferred_thresholds` param in
+`format_fidelity_report()` — no `backtesting_thresholds` table changes, no
+`threshold_type` enum extension, no scenario replay format alteration.
+`[SIM-INTEGRITY]` logging in `propagation.py` and `runner.py` (Issues #223,
+#243) is engine-internal and does not affect the scenario execution or
+backtesting API contract. engine_version gap (Issue #139) remains a
+documented known limitation. License renewed for Milestone 8. Next scheduled
+review at Milestone 8 — Ecological and Governance Frameworks completion.
+
+**Previously reviewed:** 2026-05-07 — Milestone 6 exit review. No renewal triggers
 fired during Milestone 6. License Status confirmed CURRENT. New backtesting
 migration files (Lebanon, Thailand, Ecuador DIRECTION_ONLY; Greece and
 Argentina MAGNITUDE rows) are data-layer additions within the existing

--- a/docs/adr/ADR-005-human-cost-ledger.md
+++ b/docs/adr/ADR-005-human-cost-ledger.md
@@ -6,7 +6,7 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
 **Decision 6 applied:** 2026-05-06 — GovernanceModule behavioral contract defined.
@@ -26,7 +26,19 @@ scope. Data sources for planetary boundary indicators added to
 percentile rank with mandatory API note for M6; boundary-normalized scoring
 deferred to M8. See Amendment 1 section at end of document.
 
-**Last Reviewed:** 2026-05-10 — Milestone 7 amendment (Issue #236). Decision 3
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. No renewal triggers
+fired during Milestone 7. License Status confirmed CURRENT. M7 delivered no
+changes to `MeasurementFramework` taxonomy, `CohortSpec` segmentation axes,
+`MDASeverity` enum, or radar chart normalization methodology. DEBUG logs added
+to `DemographicModule`, `MacroeconomicModule`, `EcologicalModule`, and
+`GovernanceModule` `compute()` methods (Issues #244, #245) are engine-internal
+additions that do not alter module output contracts, subscription lists, or
+Quantity-delta Event structure. Defensive Programming section in
+`CODING_STANDARDS.md` (Issue #224) is a standards addition with no effect on
+HCL framework taxonomy. License renewed for Milestone 8. Next scheduled
+review at Milestone 8 — Ecological and Governance Frameworks completion.
+
+**Previously reviewed:** 2026-05-10 — Milestone 7 amendment (Issue #236). Decision 3
 Validity Context updated: `comparison_operator` column added to `mda_thresholds`
 table (migration b3c9f2d1a7e5). Three of five registered thresholds were silently
 broken — MDAChecker treated all thresholds as lower bounds, causing `MDA-FIN-DEBT-GDP`,

--- a/docs/adr/ADR-006-uncertainty-quantification.md
+++ b/docs/adr/ADR-006-uncertainty-quantification.md
@@ -6,13 +6,27 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15
-**Valid Until:** Milestone 7 — Technical Foundation
+**Valid Until:** Milestone 8 — Ecological and Governance Frameworks
 **License Status:** CURRENT
 
 **Engineering Lead accepted 2026-05-02.** Architecture decisions reviewed and
 approved. Implementation may proceed for M5 scope.
 
-**Last Reviewed:** 2026-05-07 — Milestone 6 exit review. **Monte Carlo upgrade
+**Last Reviewed:** 2026-05-10 — Milestone 7 exit review. **Monte Carlo upgrade
+trigger re-evaluated.** Trigger condition: MAGNITUDE_WITHIN_20PCT on both
+Greece 2010–2012 AND Argentina 2001–2002. Greece MAGNITUDE calibration (Issue
+#221) was not resolved during M7 — pure accumulation model structural gap
+deferred to M8. **Trigger not met.** No other renewal triggers fired;
+`confidence_tier` propagation rule, MDA composite alert parameters,
+`QuantitySchema` API envelope, `backtesting_thresholds.threshold_type` enum,
+`IA1_CANONICAL_PHRASE`, and distribution-banding architectural boundary all
+unchanged during M7. Defensive Programming section in `CODING_STANDARDS.md`
+and `[SIM-INTEGRITY]` logging additions are engine-internal with no effect on
+uncertainty quantification contracts. License renewed for Milestone 8. Next
+scheduled review at Milestone 8 — Ecological and Governance Frameworks
+completion, when Greece MAGNITUDE calibration is expected following Issue #221.
+
+**Previously reviewed:** 2026-05-07 — Milestone 6 exit review. **Monte Carlo upgrade
 trigger evaluated.** Trigger condition: MAGNITUDE_WITHIN_20PCT on both Greece
 2010–2012 AND Argentina 2001–2002. Result at M6 exit: **1 of 2 required cases
 achieved.** Argentina step 2 (2002): PASS — model −10.55% vs actual −10.9%,


### PR DESCRIPTION
## Summary

M7 exit ADR license renewal for all six ADRs (ADR-001 through ADR-006).

For each ADR:
- `Valid Until` advanced from **Milestone 7 — Technical Foundation** to **Milestone 8 — Ecological and Governance Frameworks**
- New `Last Reviewed` entry dated **2026-05-10** (M7 exit review) inserted above the existing M6 entry
- Existing `Last Reviewed: 2026-05-07` (M6 exit) demoted to `Previously reviewed`

## M7 review notes — no triggers fired on any ADR

| ADR | What was checked | Result |
|---|---|---|
| ADR-001 | Quantity type, SimulationEntity.attributes store, propagate_confidence rule | No changes — `[SIM-INTEGRITY]` logging and computeSteps() fix are engine/frontend-internal |
| ADR-002 | ControlInput taxonomy, audit trail schema, uncertainty event tagging | No changes — logging additions introduce no new input channels or audit obligations |
| ADR-003 | GeoJSON-over-REST contract, PostGIS schema, CORS, TerritorialValidator | No changes — computeSteps() fix is client-side only |
| ADR-004 | Scenario storage format, threshold_type enum, advance protocol, snapshot contract | No changes — deferred HCL thresholds use existing deferred_thresholds param |
| ADR-005 | MeasurementFramework taxonomy, CohortSpec axes, MDASeverity enum, radar normalization | No changes — module DEBUG logs are engine-internal |
| ADR-006 | Monte Carlo upgrade trigger (MAGNITUDE_WITHIN_20PCT on Greece + Argentina) | **Trigger not met** — Greece #221 deferred to M8; all other contracts unchanged |

## ADR-005 special handling

ADR-005's existing `Last Reviewed` was a same-day M7 amendment entry (Issue #236, `comparison_operator` column fix) rather than the M6 exit review. It has been demoted to `Previously reviewed: 2026-05-10 — Milestone 7 amendment`. The new M7 exit review is now the `Last Reviewed` entry.

## References

Companion to PR #249 (M7 exit compliance scan, SCAN-021). References M7 exit checklist Issue #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)