### PR TITLE
docs(roadmap): expand milestone sequence to M9–M13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,13 +493,15 @@ Full agent profiles and operational agent definitions: `docs/agents/domain-intel
 
 ## What We Are Building First
 
-M0–M5 complete (v0.1.0–v0.5.0). ADRs 001–006 current. See GitHub Releases
+M0–M7 complete (v0.1.0–v0.7.0). ADRs 001–006 current. See GitHub Releases
 for full delivery history.
 
-**Milestone 6 — Backtesting Coverage Expansion (Current)**
-- Five historical backtesting cases with DIRECTION_ONLY and MAGNITUDE thresholds
-- Backtesting fidelity dashboard surfacing case-by-case pass/fail in the UI
-- MAGNITUDE threshold calibration against historical outturns
+**Milestone 8 — Ecological and Governance Frameworks (Current)**
+- All four radar chart axes live with real data
+- Ecological Module complete; Governance Module complete
+- Coffin Corner / Policy Maneuver Margin Zone 1 indicator
+- MDA extended to ecological and governance indicators
+- End-of-milestone demo: all four radar axes simultaneously
 
 Each milestone is a vertical slice — working software at every stage,
 not infrastructure waiting for features.
@@ -508,34 +510,12 @@ not infrastructure waiting for features.
 
 ## Milestone Roadmap
 
-**Milestone 5 — Calibration and Uncertainty (Complete — v0.5.0)**
-Core deliverable: Simulation outputs as distributions; MacroeconomicModule
-with regime-dependent multipliers; Argentina 2001-2002 second backtesting
-case; DISTRIBUTION_COMBINED threshold infrastructure. See GitHub Releases for
-full delivery record.
+**Milestone 7 — Technical Foundation (Complete — v0.7.0)**
+Core deliverable: P0 technical debt resolved; compliance scan clean;
+defensive programming standards codified. See GitHub Releases for full
+delivery record.
 
-**Milestone 6 — Backtesting Coverage Expansion (Current)**
-Core deliverable: Five historical cases at calibrated fidelity thresholds;
-Ecological and Governance Modules initial implementation.
-
-Scope:
-- Three additional backtesting cases (five total including Greece and Argentina)
-- MAGNITUDE threshold calibration against historical outturns
-- Ecological Module initial implementation (planetary boundary proximity)
-- Governance Module initial implementation (institutional quality indicators)
-- Backtesting fidelity dashboard in the UI
-
-**Milestone 7 — Technical Foundation**
-Core deliverable: Resolve P0 deferred technical debt before Ecological and
-Governance Modules require a clean foundation.
-
-Exit criteria:
-- P0 deferred items resolved (datetime.utcnow() deprecations, engine_version
-  gap #139 resolved or formally deferred with ADR entry)
-- Compliance scan clean at milestone exit
-- All issues from M5/M6 deferred-to-M7 list triaged and closed or re-scoped
-
-**Milestone 8 — Ecological and Governance Frameworks**
+**Milestone 8 — Ecological and Governance Frameworks (Current)**
 Core deliverable: All four radar axes live; ecological and governance
 composite scores non-null for the first time.
 
@@ -543,16 +523,38 @@ Scope:
 - Ecological Module complete (planetary boundaries, natural capital depletion)
 - Governance Module complete (institutional quality, political freedom, rule of law)
 - All four radar chart axes live with real data
+- Coffin Corner indicator: Policy Maneuver Margin Zone 1 widget
+- MDA threshold system extended to ecological and governance indicators
 - ADR-005 reviewed and extended for Ecological/Governance framework coverage
+- End-of-milestone demo scenario (Greece 2010–2012 candidate)
 
-**Milestone 9 — Methodology Publication**
-Core deliverable: Methodology publication and external validation;
-Technical Steering Committee formation.
+**Milestone 9 — Standards Foundation**
+Core deliverable: Canonical unit registry, field-level data certification,
+and legibility framework. STD-REVIEW-004 gaps resolved.
 
 Scope:
-- Methodology publication and external validation
-- Technical Steering Committee formation
-- External contributor infrastructure
+- Canonical unit registry replacing `unit="dimensionless"` placeholders
+- Field-level certification chain and data admission tests
+- WGI territorial conventions documented
+- Legibility baseline audit and North Star legibility section
+- Domain Intelligence Council blind stakeholder interviews
+- M7 orphan issues triaged and closed
+
+**Milestone 10 — Engine Integrity and Backtesting**
+Core deliverable: Mean-reversion channels, Ecuador backtesting case,
+sparse matrix propagation foundation, interpretability tooling suite.
+
+**Milestone 11 — Political Economy and Conditionality**
+Core deliverable: IMF conditionality modeling, political feasibility
+constraints, elite capture dynamics, debt sustainability extension.
+
+**Milestone 12 — Analyst Tooling and External Sector**
+Core deliverable: Trade and external sector module; analyst tooling
+polished; branch protection and second governance account established.
+
+**Milestone 13 — Methodology Publication**
+Core deliverable: Methodology publication and external validation;
+Technical Steering Committee formation; public launch.
 
 Full roadmap: `docs/roadmap/milestone-roadmap-m6-m8.md`
 

--- a/docs/roadmap/milestone-roadmap-m6-m8.md
+++ b/docs/roadmap/milestone-roadmap-m6-m8.md
@@ -1,9 +1,13 @@
-# Milestone Roadmap — M6 through M8
+# Milestone Roadmap — M6 through M13
 
 > Extracted from CLAUDE.md at M4 exit (2026-04-26). Updated at M7 exit
-> (2026-05-10) to correct M7 theme and cascade M8/M9. CLAUDE.md carries the
-> current milestone inline; this file carries the committed scope for
-> M6 through M9. GitHub Milestones carry the live issue lists.
+> (2026-05-10) to correct M7 theme and expand to M9–M13 sequence.
+> CLAUDE.md carries the current milestone inline; this file carries the
+> committed scope. GitHub Milestones carry the live issue lists.
+>
+> M9–M13 sequence approved 2026-05-11. Old M9 (Methodology Publication)
+> renumbered to M13 to make room for four intermediate milestones that
+> absorb ~77 issues that had accumulated without milestone assignment.
 
 ---
 
@@ -76,7 +80,92 @@ module contracts — reviewed at M8 entry)
 
 ---
 
-## Milestone 9 — Methodology Publication and External Validation
+## Milestone 9 — Standards Foundation
+
+**Core deliverable:** Canonical unit registry, field-level data certification,
+and legibility framework established. Methodological integrity gaps from
+STD-REVIEW-004 and ARCH-REVIEW-005 resolved before M10 engine work begins.
+
+**Scope:**
+- Canonical unit registry: replace `unit="dimensionless"` placeholders
+  with registered physical units (Issues #255, #256 gate)
+- Field-level certification chain: `source_registry.admission_status` field
+  per approved-sources.md; mandatory data admission tests (Issue #253)
+- WGI territorial conventions documented in DATA_STANDARDS.md (Issue #43 area)
+- Legibility baseline audit: all user-visible text meets analyst-comprehension
+  bar (Issue #255)
+- North Star legibility section added to CLAUDE.md (Issue #256)
+- Standards Review STD-REVIEW-004 gaps closed (Issues #255–#257)
+- Domain Intelligence Council blind stakeholder interviews completed (#235)
+- M7 orphan issues triaged and closed or formally re-scoped
+
+**Pre-implementation gates:** Issues #255, #256, #257, #235 must be resolved
+before M9 implementation begins.
+
+**Dependencies:** Milestone 8 (M9 standards work assumes M8 ecological and
+governance indicators are live — the unit registry must cover real indicators).
+
+---
+
+## Milestone 10 — Engine Integrity and Backtesting
+
+**Core deliverable:** Mean-reversion channels operational, Ecuador backtesting
+case added, sparse matrix propagation foundation in place, interpretability
+tooling suite available to contributors.
+
+**Scope:**
+- Mean-reversion channel (`trend_growth` seeded attribute, Issue #221)
+- Ecuador as second Monte Carlo scenario case
+- ADR-007 sparse matrix propagation implementation
+- Interpretability tooling: propagation trace, equivalence harness, matrix
+  visualizer, sparse profiler (Issue #216)
+- Engine version gap Issue #139 formally resolved (ADR entry or closed)
+- Decimal↔float precision boundary tests hardened
+
+**Dependencies:** Milestone 9 (unit registry and data certification must be
+clean before new backtesting cases are added).
+
+---
+
+## Milestone 11 — Political Economy and Conditionality
+
+**Core deliverable:** IMF conditionality modeling, political feasibility
+constraints, and elite capture dynamics available for scenario analysis.
+Debt sustainability module extended for multi-creditor scenarios.
+
+**Scope:**
+- Political Module: electoral calendar, coalition stability, legitimacy cascade
+- IMF conditionality impact modeling: policy-space constraint propagation
+- Elite capture indicators: concentration of institutional authority,
+  dissent tolerance, policy-reality divergence
+- Debt sustainability extension: multi-creditor, cross-default triggers
+- Fiscal Module: political feasibility constraint on spending paths
+
+**Dependencies:** Milestone 10 (engine integrity work must be complete
+before political economy feedback loops are added to the propagation graph).
+
+---
+
+## Milestone 12 — Analyst Tooling and External Sector
+
+**Core deliverable:** Trade and external sector module live; analyst tooling
+(propagation trace, export, comparison) polished; governance and branch
+protection established.
+
+**Scope:**
+- Trade Module: current account, trade balance, terms of trade dynamics
+- External sector: capital flows, FDI, remittance channel
+- Analyst tooling: scenario comparison, data export, backtesting dashboard
+  improvements
+- Governance: branch protection on `main`, second governance account (#3, #6)
+- Scenario comparison view: side-by-side multi-scenario radar
+
+**Dependencies:** Milestone 11 (political economy channels feed external
+sector dynamics — trade policy is a political decision).
+
+---
+
+## Milestone 13 — Methodology Publication and External Validation
 
 **Core deliverable:** The simulation's methodology is publicly documented
 and validated by at least one external domain reviewer.
@@ -88,12 +177,12 @@ and validated by at least one external domain reviewer.
   debt specialist reviews the methodology and signs off on the human
   development framework implementation
 - `docs/POLICY.md` updated to reflect all methodology positions taken
-  through M8, with the external reviewer's name and affiliation
+  through M12, with the external reviewer's name and affiliation
 - Technical Steering Committee formation initiated (first institutional
   user engagement sought)
 - Public launch preparation: README, CONTRIBUTING.md, and POLICY.md
   written for external contributors, not just internal agents
 
-**Dependencies:** Milestones 5–8 (methodology cannot be published before
+**Dependencies:** Milestones 5–12 (methodology cannot be published before
 the core modules are implemented and validated); external reviewer
-recruited no later than M8 midpoint
+recruited no later than M12 midpoint


### PR DESCRIPTION
## Summary

- Renames old M9 (Methodology Publication) to M13, making room for M9–M12
- Creates four new GitHub milestones: M9 Standards Foundation, M10 Engine Integrity and Backtesting, M11 Political Economy and Conditionality, M12 Analyst Tooling and External Sector
- Bulk-assigns ~77 orphaned issues across M9–M12 per approved allocation plan
- Updates `CLAUDE.md` current milestone from M6 to M8; expands Milestone Roadmap section to cover M9–M13
- Extends `docs/roadmap/milestone-roadmap-m6-m8.md` with full scope definitions for M9–M13

## Related

Issue allocation summary:
- M9: 31 issues (standards, legibility, data certification, orphan triage)
- M10: 16 issues (engine integrity, backtesting, interpretability tooling)
- M11: 10 issues (political economy, conditionality, fiscal module)
- M12: 11 issues (external sector, analyst tooling, governance)
- M8 additions: #233 moved in; #153 to M12, #216 to M10

Also in this session: 5 new M8 UX issues filed (#265–#269); duplicates #32, #94, #101 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)