### PR TITLE
fix(legibility): replace contextlib.suppress with [SIM-INTEGRITY] warning (#279); fix _accumulate() docstring (#280)

### DIFF
--- a/backend/app/simulation/engine/propagation.py
+++ b/backend/app/simulation/engine/propagation.py
@@ -219,9 +219,20 @@ def _accumulate(
     Multiple calls for the same entity accumulate contributions additively.
     This is the mechanism by which converging propagation paths accumulate.
 
-    confidence_tier lower-of-two rule: the accumulated tier is the minimum
-    of all contributing tiers. This is a conservative policy approximation,
-    not a statistical formula — see propagate_confidence() docstring.
+    confidence_tier lower-of-two rule: the accumulated tier is the **maximum**
+    of all contributing tier numbers. Higher tier number = lower confidence
+    quality; the output inherits the worst-quality input's tier. This is a
+    conservative policy approximation, not a statistical formula.
+
+    STOCK conflict (known interim behavior, pending M8 fix — Issue #280):
+    When two STOCK deltas target the same entity+attribute in one step, a
+    [SIM-INTEGRITY] WARNING is emitted and the values are **summed** rather
+    than the second replacing the first. STOCK semantics expect a single
+    absolute-level event per attribute per step; summing two absolute levels
+    is incorrect. The WARNING exists precisely because this state should not
+    occur — if it does, the emitting modules have a deduplication gap. The
+    summing behavior is an interim fallback to avoid silent data loss; it is
+    not the correct STOCK resolution and should not be relied on.
 
     Args:
         accumulator: Mutable accumulator mapping entity_id to attr deltas.

--- a/backend/app/simulation/web_scenario_runner.py
+++ b/backend/app/simulation/web_scenario_runner.py
@@ -19,11 +19,12 @@ timestep is derived from configuration; if absent, defaults to 2000-01-01 UTC.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from dataclasses import dataclass, replace
 from datetime import UTC
 from datetime import datetime as _datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
 import asyncpg  # noqa: TCH002 — used in method signatures at runtime
@@ -65,6 +66,8 @@ if TYPE_CHECKING:
 # `datetime` and `SimulationState` above are annotation-only (PEP 563).
 # `_reconstruct_state_from_snapshot` imports engine models locally at runtime.
 
+
+_log = logging.getLogger(__name__)
 
 # Engine version recorded in tombstone records.
 _ENGINE_VERSION = "0.3.0"
@@ -703,12 +706,20 @@ async def _reconstruct_state_from_snapshot(
 
         attributes = {}
         if isinstance(attr_data, dict):
-            import contextlib  # noqa: PLC0415
-
             for attr_key, envelope in attr_data.items():
                 if isinstance(envelope, dict):
-                    with contextlib.suppress(ValueError, KeyError):
+                    try:
                         attributes[attr_key] = quantity_from_jsonb(envelope)
+                    except (ValueError, KeyError, InvalidOperation) as exc:
+                        _log.warning(
+                            "[SIM-INTEGRITY] Failed to deserialize attribute %r for "
+                            "entity_id=%r from snapshot — attribute skipped. "
+                            "envelope_keys=%r exc=%r",
+                            attr_key,
+                            entity_id,
+                            list(envelope.keys()),
+                            exc,
+                        )
 
         entities[entity_id] = SimulationEntity(
             id=entity_id,

--- a/backend/tests/unit/test_propagation.py
+++ b/backend/tests/unit/test_propagation.py
@@ -477,7 +477,9 @@ class TestPropagateConfidenceTier:
         assert bra_tier == 2  # preserved through attenuation
 
     def test_accumulation_applies_lower_of_two_to_confidence_tier(self) -> None:
-        # Two events on the same attribute: lower tier wins
+        # Two events on the same attribute: worst confidence wins.
+        # "Lower-of-two" means lower confidence quality, which is the HIGHER
+        # tier number (tier 4 is worse than tier 1). Implementation uses max().
         state = _state({"BOL": _entity("BOL")})
         events = [
             Event(
@@ -501,7 +503,45 @@ class TestPropagateConfidenceTier:
         ]
         result = propagate(state, events)
         tier = result.entities["BOL"].get_attribute("gdp_growth").confidence_tier  # type: ignore[union-attr]
-        assert tier == 4  # lower-of-two: min(1, 4) = 4
+        assert tier == 4  # max(1, 4) = 4 — worst quality (highest tier number) wins
+
+    def test_confidence_tier_lower_of_two_uses_max_not_min(self) -> None:
+        """Issue #280: lower-of-two rule is max(tier_a, tier_b), not min().
+
+        Higher tier number = lower confidence quality. The accumulated tier
+        must be the maximum (worst) of all contributing tiers. If this test
+        fails it means the implementation was changed to min(), which would
+        silently make derived outputs appear higher-confidence than they are.
+        """
+        state = _state({"BOL": _entity("BOL")})
+        events = [
+            Event(
+                event_id="high-conf",
+                source_entity_id="BOL",
+                event_type="shock",
+                affected_attributes={"gdp_growth": _q(0.01, confidence_tier=1)},
+                propagation_rules=[],
+                timestep_originated=datetime(2020, 1, 1),
+                framework=MeasurementFramework.FINANCIAL,
+            ),
+            Event(
+                event_id="low-conf",
+                source_entity_id="BOL",
+                event_type="shock",
+                affected_attributes={"gdp_growth": _q(0.01, confidence_tier=5)},
+                propagation_rules=[],
+                timestep_originated=datetime(2020, 1, 1),
+                framework=MeasurementFramework.FINANCIAL,
+            ),
+        ]
+        result = propagate(state, events)
+        tier = result.entities["BOL"].get_attribute("gdp_growth").confidence_tier  # type: ignore[union-attr]
+        # Must be 5 (worst quality wins), not 1 (which would be min())
+        assert tier == 5, (
+            f"Expected tier 5 (max of 1 and 5 — worst confidence wins). Got {tier}. "
+            "The lower-of-two rule uses max(tier_a, tier_b), not min()."
+        )
+        assert tier != 1, "tier==1 would mean min() was used — that silently overstates confidence"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_web_scenario_runner.py
+++ b/backend/tests/unit/test_web_scenario_runner.py
@@ -7,6 +7,9 @@ Tests cover:
   IA-1 disclosure: ia1_disclosure is always set and contains the canonical phrase
   quantity_to_jsonb_envelope: field types and _envelope_version
   quantity_from_schema: field type restoration (Decimal, int, date not string)
+  Issue #279: _reconstruct_state_from_snapshot deserialization failures emit
+              [SIM-INTEGRITY] WARNING with entity/attr context and skip the
+              bad attribute without dropping the entity.
 
 All tests run without a database connection. DB-dependent paths use MagicMock /
 AsyncMock to simulate asyncpg behaviour.
@@ -14,6 +17,7 @@ AsyncMock to simulate asyncpg behaviour.
 from __future__ import annotations
 
 import json
+import logging
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any
@@ -592,3 +596,108 @@ def test_snapshot_record_m3_snapshot_has_empty_modules_active() -> None:
         modules_active=modules_active,
     )
     assert record.modules_active == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #279: _reconstruct_state_from_snapshot deserialization warning
+# ---------------------------------------------------------------------------
+
+_WSR_LOGGER = "app.simulation.web_scenario_runner"
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_snapshot_warns_on_malformed_envelope(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #279: malformed envelope emits [SIM-INTEGRITY] WARNING naming entity and attr."""
+    from app.simulation.web_scenario_runner import _reconstruct_state_from_snapshot  # noqa: PLC0415
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {"entity_id": "GRC", "entity_type": "country", "metadata": "{}"},
+    ])
+
+    # Envelope is missing required fields — QuantitySchema.from_jsonb fills defaults,
+    # then Decimal("") raises InvalidOperation. Caught as a deserialization failure.
+    bad_envelope = {"_envelope_version": "1"}  # missing 'value', 'unit', etc.
+    state_data = {"GRC": {"bad_attr": bad_envelope}}
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+
+    with caplog.at_level(logging.WARNING, logger=_WSR_LOGGER):
+        state = await _reconstruct_state_from_snapshot(conn, "scen-1", "Test", state_data, ts)
+
+    sim_integrity_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "[SIM-INTEGRITY]" in r.getMessage()
+    ]
+    assert sim_integrity_warnings, (
+        f"Expected [SIM-INTEGRITY] WARNING but got: {[r.getMessage() for r in caplog.records]}"
+    )
+    warning_text = " ".join(r.getMessage() for r in sim_integrity_warnings)
+    assert "GRC" in warning_text, f"Warning must name entity_id 'GRC'. Got: {warning_text!r}"
+    assert "bad_attr" in warning_text, (
+        f"Warning must name attribute 'bad_attr'. Got: {warning_text!r}"
+    )
+    # Entity is still created despite the failed attribute
+    assert "GRC" in state.entities
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_snapshot_skips_bad_attr_preserves_good_attr(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #279: bad attr is skipped; valid attrs on the same entity are loaded."""
+    from app.simulation.repositories.quantity_serde import (
+        quantity_to_jsonb_envelope,  # noqa: PLC0415
+    )
+    from app.simulation.web_scenario_runner import _reconstruct_state_from_snapshot  # noqa: PLC0415
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {"entity_id": "GRC", "entity_type": "country", "metadata": "{}"},
+    ])
+
+    good_qty = _make_quantity(value="-0.054", unit="ratio_0_1", variable_type=VariableType.RATIO)
+    good_envelope = quantity_to_jsonb_envelope(good_qty)
+    bad_envelope = {"_envelope_version": "1"}  # missing required fields → InvalidOperation
+
+    state_data = {"GRC": {"good_attr": good_envelope, "bad_attr": bad_envelope}}
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+
+    with caplog.at_level(logging.WARNING, logger=_WSR_LOGGER):
+        state = await _reconstruct_state_from_snapshot(conn, "scen-1", "Test", state_data, ts)
+
+    grc = state.entities["GRC"]
+    assert "good_attr" in grc.attributes, "Valid attribute must be loaded"
+    assert "bad_attr" not in grc.attributes, "Malformed attribute must be skipped"
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_snapshot_no_warning_for_valid_envelopes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #279: no [SIM-INTEGRITY] warning when all envelopes deserialize cleanly."""
+    from app.simulation.repositories.quantity_serde import (
+        quantity_to_jsonb_envelope,  # noqa: PLC0415
+    )
+    from app.simulation.web_scenario_runner import _reconstruct_state_from_snapshot  # noqa: PLC0415
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[
+        {"entity_id": "GRC", "entity_type": "country", "metadata": "{}"},
+    ])
+
+    good_qty = _make_quantity(value="-0.054", unit="ratio_0_1", variable_type=VariableType.RATIO)
+    state_data = {"GRC": {"gdp_growth": quantity_to_jsonb_envelope(good_qty)}}
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+
+    with caplog.at_level(logging.WARNING, logger=_WSR_LOGGER):
+        await _reconstruct_state_from_snapshot(conn, "scen-1", "Test", state_data, ts)
+
+    sim_integrity_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "[SIM-INTEGRITY]" in r.getMessage()
+    ]
+    assert not sim_integrity_warnings, (
+        f"Unexpected [SIM-INTEGRITY] warnings: {[r.getMessage() for r in sim_integrity_warnings]}"
+    )


### PR DESCRIPTION
## Summary

- **Issue #279** — `_reconstruct_state_from_snapshot()`: replaces `contextlib.suppress(ValueError, KeyError)` with explicit `try/except` that emits a `[SIM-INTEGRITY]` WARNING naming `entity_id`, `attr_key`, envelope keys, and the exception. Entity is preserved; only the malformed attribute is skipped.
- **Issue #280** — `_accumulate()` docstring: corrects "minimum" to "maximum" in the confidence-tier lower-of-two description (higher tier number = lower quality; `max()` is the correct implementation). Adds a KNOWN LIMITATIONS block documenting STOCK conflict summing as interim behavior pending M8 fix.

Closes #279.
Closes #280.

## What changed

**`backend/app/simulation/web_scenario_runner.py`**
- Added `import logging` and `_log = logging.getLogger(__name__)`
- Added `InvalidOperation` to the `from decimal import` line (the real exception raised when `QuantitySchema.from_jsonb` fills missing fields with defaults and then `Decimal("")` fails — the original `contextlib.suppress(ValueError, KeyError)` would NOT have caught this)
- Replaced `contextlib.suppress` block with `try/except (ValueError, KeyError, InvalidOperation)` emitting `[SIM-INTEGRITY]` WARNING with full context

**`backend/app/simulation/engine/propagation.py`**
- Fixed `_accumulate()` docstring: "the accumulated tier is the minimum" → "the accumulated tier is the **maximum** of all contributing tier numbers"
- Added KNOWN LIMITATIONS block documenting that STOCK conflict summing is incorrect-but-intentional interim behavior; the WARNING exists because this state should not occur

**Tests** — 765/765 passing, lint clean
- `test_web_scenario_runner.py`: 3 new tests — warning fires with entity+attr context, bad attr skipped with good attr preserved, no warning on clean envelopes
- `test_propagation.py`: 1 new test — `test_confidence_tier_lower_of_two_uses_max_not_min` explicitly guards against a future min() regression

## Note on InvalidOperation

The original `contextlib.suppress(ValueError, KeyError)` was catching the wrong exceptions for the malformed-envelope case. `QuantitySchema.from_jsonb` uses Pydantic defaults for missing fields (value becomes `""`), so no `KeyError` is raised during schema construction — `decimal.InvalidOperation` is raised downstream when `Decimal("")` is evaluated. The original suppress block would have re-raised this, making the reconstruction crash. The new except tuple correctly covers all three failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)