### PR TITLE
docs: SESSION_STATE.md — machine-maintained session state for continuity across Claude Code sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,20 @@ exists, but whose government may make better decisions because it does.
 
 ---
 
+## Session Continuity
+
+Before beginning any task, read `SESSION_STATE.md` in the project root.
+It contains: current active work streams and their gates, recently merged
+PRs, pending Engineering Lead decisions, and key architectural facts for
+session continuity. It is updated at the end of every session.
+`CLAUDE.md` is the permanent constitution. `SESSION_STATE.md` is the
+current situation report. Both are required reading at session start.
+
+At the end of every session, updating `SESSION_STATE.md` is the last
+action before closing — not optional.
+
+---
+
 ## Guiding Principles
 
 These principles are not constraints imposed from outside. They are values

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -1,0 +1,131 @@
+# WorldSim Session State
+
+> This file is maintained by Claude Code. It is updated at the end of
+> every session as the last action before closing. Do not edit manually.
+> Engineering Lead decisions and context are recorded here for session
+> continuity. For permanent rules and architecture, see CLAUDE.md.
+
+**Last updated:** 2026-05-16
+**Current milestone:** M8 — Ecological and Governance Frameworks
+
+---
+
+## Active Work Streams
+
+| Stream | Issues | Status | Gate |
+|---|---|---|---|
+| ADR-005 M8 amendment | #218 | Not started — Architect Agent ready to activate | **Critical path — blocks everything below** |
+| Intent block retrofit | #287 | Unblocked | None |
+| Greece fixture extension | #284 | Not started | ADR-005 (ecological axis) |
+| EcologicalModule expansion | — | Not started | ADR-005 |
+| UI/UX issues | #265–268 | Not started | ADR-005 dispatch architecture |
+| Demo scenario assembly | #269 | Not started | #284 + EcologicalModule |
+| SESSION_STATE.md | — | In flight | — |
+
+---
+
+## Recently Merged PRs (last 5)
+
+| PR | Title | Date |
+|---|---|---|
+| #289 | fix(legibility): contextlib.suppress → [SIM-INTEGRITY] warning (#279); _accumulate() docstring (#280) | 2026-05-16 |
+| #288 | docs(standards): ratify intent block format — §Intent Blocks in CODING_STANDARDS.md | 2026-05-16 |
+| #283 | docs(process): disposition-review-standard — generative agent consultation before dispositions | 2026-05-16 |
+| #282 | docs(standards): STD-REVIEW-004 EL dispositions — all six gaps, three-agent panel informed | 2026-05-16 |
+| #281 | docs: M8 pre-implementation gates — legibility baseline, North Star standard, blind audit | 2026-05-11 |
+
+---
+
+## Open Issues — M8 Horizon:Immediate
+
+| Issue | Title | Blocked by |
+|---|---|---|
+| #218 | ADR-005 M8 amendment (causal meta-map) | Nothing — activate Architect Agent |
+| #284 | Greece fixture extension to 2015 | ADR-005 |
+| #265 | Indicator display name mapping layer | ADR-005 |
+| #266 | Mandatory ecological note → Zone 3 expandable | ADR-005 |
+| #267 | Radar chart transition animation | ADR-005 |
+| #268 | Coffin Corner / PMM Zone 1 widget | ADR-005 |
+| #269 | Demo scenario — Greece 2010–2015 | #284 + EcologicalModule |
+
+---
+
+## Open Issues — M8 Horizon:Near-Term
+
+| Issue | Title | Blocked by |
+|---|---|---|
+| #258 | Mandatory intent blocks | #285 (merged ✅) |
+| #286 | Spec-to-test gap check script | #285 (merged ✅) |
+| #287 | Intent block retrofit — five M7 audit functions | #285 (merged ✅) |
+| #233 | Screenshot artifact bundle | Demo scenario #269 |
+| #221 | Mean-reversion channel (Greece MAGNITUDE) | ADR-005 |
+| #222 | Contemporaneous processing path | ADR-005 |
+
+---
+
+## Pending Engineering Lead Decisions
+
+| Decision | Context | Status |
+|---|---|---|
+| ADR-005 M8 amendment disposition | After five-agent panel review (Data Architect, QA Lead, Ecological Economist, Chief Methodologist) | Awaiting Architect Agent draft |
+| GovernanceModule promotion path | Deferred from M8 demo — five criteria not yet met — target M9 | Decided: deferred |
+| SESSION_STATE.md adoption | This file — approve and merge | In flight |
+
+---
+
+## Key Decisions Made — Recent Sessions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| UX Agent ruling: Option B — three-axis demo, governance null, Greece 2015 | Three-axis + honest null axis is stronger for methodology reviewers than waiting for governance; 2015 extension required to show financial/human development divergence | 2026-05-16 |
+| GovernanceModule deferred from M8 demo | Five promotion criteria not met; null axis with "in validation" label is methodologically correct per information-hierarchy.md Zone 1B | 2026-05-16 |
+| STD-REVIEW-004 all six gaps: ACCEPT | Three-agent panel (Data Architect, QA Lead, Architect) informed all dispositions; 10 substantive improvements over draft | 2026-05-16 |
+| simulation_reference_constants: dedicated DB table | Data Architect recommendation — different access pattern from time-series data; fixture file escape hatch closed | 2026-05-16 |
+| runner.py [SIM-INTEGRITY] prefix was absent | Architect confirmed by code inspection; fixed in PR #282 | 2026-05-16 |
+| Disposition review standard: generative before confirmatory | Agent consultation must precede dispositions, not follow them; reference case STD-REVIEW-004 produced 10 improvements | 2026-05-16 |
+| M9–M13 milestone sequence approved | M9 Standards Foundation → M10 Engine Integrity → M11 Political Economy → M12 Analyst Tooling → M13 Methodology Publication | 2026-05-11 |
+
+---
+
+## Architectural State — Key Facts for Session Continuity
+
+**ADR-005 M8 amendment scope (not yet drafted):**
+- Decision 1: Boundary normalization formula `min(current_value / boundary_value, 2.0)` using `simulation_reference_constants`
+- Decision 2: `is_single_entity` guard exempt for ecological (boundary scores meaningful for single entity)
+- Decision 3: `_compute_composite_score()` strategy dispatch — routes ecological to boundary proximity, financial/human_development to percentile rank, governance registration point TBD
+- Decision 4: GovernanceModule promotion deferred to M9 (five criteria not met)
+- Decision 5: Null governance axis renders as dashed outline, "—" score, "Governance — in validation" label (binding UX ruling)
+- Decision 6: EcologicalModule M8 expansion adds `planetary_boundary_co2_proximity` and `planetary_boundary_land_use_proximity`
+
+**Standards state:**
+- Canonical unit registry: in DATA_STANDARDS.md §Canonical Unit Registry (PR #282)
+- Field-level certification standard: in DATA_STANDARDS.md §Field-Level Data Certification (PR #282)
+- simulation_reference_constants table: migrations a2b4c6d8e0f1 + b3c5d7e9f1a2 (PR #282)
+- Intent block format: ratified in CODING_STANDARDS.md §Intent Blocks (PR #288)
+- Framework promotion protocol: in CODING_STANDARDS.md §Framework Promotion Protocol (PR #282)
+- [SIM-INTEGRITY] monitoring contract: in CODING_STANDARDS.md §Simulation Integrity Monitoring (PR #282)
+- Disposition review standard: docs/process/disposition-review-standard.md (PR #283)
+
+**Legibility baseline:**
+- M7 baseline mean audit score: 6.8/10
+- Lowest scoring function: `_reconstruct_state_from_snapshot` — 5/10 (fixed in PR #289)
+- Baseline document: docs/standards/legibility-baseline-m7.md
+- Blind audit prompt: docs/process/blind-code-audit-prompt.md
+
+**M8 gate status (all clear):**
+- #235 DIC blind interviews ✅
+- #255 Legibility metrics baseline ✅
+- #256 North Star CODING_STANDARDS ✅
+- #257 Blind code audit ✅
+
+---
+
+## Session Update Instructions
+
+At the end of every Claude Code session, update this file:
+1. Update "Last updated" date
+2. Move completed streams to Recently Merged PRs
+3. Add any new open issues to the appropriate horizon section
+4. Record any Engineering Lead decisions made
+5. Update ADR-005 amendment scope if decisions were made
+6. This update is the **last action** of every session before closing


### PR DESCRIPTION
## Summary

- Introduces `SESSION_STATE.md` in the project root — a machine-maintained file updated as the **last action of every session** before closing
- Adds `## Session Continuity` section to `CLAUDE.md` (immediately after `## What This Project Is:`), making `SESSION_STATE.md` required reading at every session start

## What SESSION_STATE.md contains

- **Active work streams** with blocking gates (ADR-005 is the current critical path)
- **Recently merged PRs** (last 5) for orientation
- **Open M8 issues** by horizon (immediate / near-term)
- **Pending Engineering Lead decisions** with status
- **Key decisions** from recent sessions with rationale and dates
- **Architectural state** — key facts needed for session continuity without re-deriving from git history
- **Session update instructions** — the six steps agents follow at session close

## Why this exists

Claude Code sessions start cold. The auto-memory system captures user preferences and project state, but it cannot capture the granular situational awareness needed to know what's blocking what, which EL decisions were made this session, and what the exact ADR amendment scope is. SESSION_STATE.md bridges that gap — it is the situation report that CLAUDE.md (the permanent constitution) is not designed to carry.

## CLAUDE.md change

The new `## Session Continuity` section is placed immediately after `## What This Project Is:` — the first content an agent reads. It declares the required reading contract: both files at session start, SESSION_STATE.md update at session close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)