### PR TITLE
ci: auto-merge SESSION_STATE.md-only PRs

### DIFF
--- a/.github/workflows/auto-merge-session-state.yml
+++ b/.github/workflows/auto-merge-session-state.yml
@@ -1,0 +1,61 @@
+name: auto-merge SESSION_STATE.md
+
+# Automatically merges PRs that touch only SESSION_STATE.md.
+#
+# SESSION_STATE.md is machine-maintained session continuity state — it changes
+# every session and carries no code, architecture, or governance risk. Routing
+# it through the full PR review cycle produces friction with no safety benefit.
+#
+# Safety contract:
+#   - Only fires when SESSION_STATE.md appears in the changed files (paths filter).
+#   - Verifies via the GitHub API that SESSION_STATE.md is the *only* changed
+#     file before enabling auto-merge. PRs that include other files alongside
+#     SESSION_STATE.md are left alone and follow the normal review process.
+#   - Uses --auto so GitHub waits for required status checks to pass before
+#     merging. For SESSION_STATE.md-only PRs all CI jobs are skipped (root file,
+#     no backend/ or frontend/ changes), and GitHub counts skips as passing.
+#   - No approval step: required_approving_review_count is 0.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - SESSION_STATE.md
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check if PR only modifies SESSION_STATE.md
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGED=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --json files \
+            --jq '[.files[].path] | sort | join("\n")')
+          echo "Changed files:"
+          echo "$CHANGED"
+          if [ "$CHANGED" = "SESSION_STATE.md" ]; then
+            echo "session_state_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "session_state_only=false" >> "$GITHUB_OUTPUT"
+            echo "PR includes files beyond SESSION_STATE.md — skipping auto-merge."
+          fi
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.session_state_only == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --auto
+          echo "Auto-merge enabled. PR will merge once required checks pass."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-merge-session-state.yml`
- Enables `allow_auto_merge` on the repository (required for `gh pr merge --auto`)
- When a PR's only changed file is `SESSION_STATE.md`, the workflow calls `gh pr merge --squash --auto`, which merges once required CI checks resolve
- PRs that include other files alongside `SESSION_STATE.md` are left untouched

## How it works

`SESSION_STATE.md` lives at the repo root — not under `backend/` or `frontend/`. The `ci.yml` path filter produces `changes.outputs.backend == 'false'` and `changes.outputs.frontend == 'false'`, so `lint`, `test-backend`, and `playwright-e2e` are all skipped. GitHub counts skipped jobs as passing for branch protection. `required_approving_review_count` is 0, so no approval step is needed.

The `--auto` flag ensures GitHub handles the merge timing; the workflow doesn't race against CI.

## Test plan

- [ ] Merge this PR manually (one-time bootstrap)
- [ ] Open a SESSION_STATE.md-only PR and confirm it auto-merges without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)