### PR TITLE
feat(backend): M8 ecological boundary normalization — dispatch refactor, indicator expansion, migrations

### DIFF
--- a/backend/alembic/versions/c1a4e7f2d9b3_sim_ref_constants_confidence_tier.py
+++ b/backend/alembic/versions/c1a4e7f2d9b3_sim_ref_constants_confidence_tier.py
@@ -1,0 +1,60 @@
+"""simulation_reference_constants — add confidence_tier column (ADR-005 Amendment 3 Decision M8-6)
+
+Revision ID: c1a4e7f2d9b3
+Revises: 5eec5d75c103
+Create Date: 2026-05-17
+
+Adds a confidence_tier INTEGER NOT NULL DEFAULT 2 column to
+simulation_reference_constants (Decision M8-6 Implementation obligation 4).
+
+The column carries the epistemic confidence tier of the boundary constant
+itself — distinct from the confidence tier of the indicator that uses it.
+Derived indicator tiers propagate via max(source_indicator_tier,
+boundary_constant_tier) per the lower-of-two rule (ADR-001 Amendment 1 §Quantity type).
+
+Tier assignments for existing rows:
+  ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM        → 2
+    Rockström 2009 peer-reviewed consensus; scientifically contested —
+    boundary represents a scientific judgment, not a physical constant.
+  ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO → 2
+    Richardson 2023 revision; higher uncertainty than CO2 boundary given
+    data availability constraints for global land-system assessment.
+
+These tiers are queried by _fetch_active_boundary_constants() in scenarios.py.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c1a4e7f2d9b3"
+down_revision = "5eec5d75c103"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "simulation_reference_constants",
+        sa.Column(
+            "confidence_tier",
+            sa.Integer(),
+            nullable=False,
+            server_default="2",
+        ),
+    )
+    op.execute(
+        """
+        UPDATE simulation_reference_constants
+        SET confidence_tier = 2
+        WHERE constant_id IN (
+            'ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM',
+            'ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("simulation_reference_constants", "confidence_tier")

--- a/backend/alembic/versions/d2b5f8a3e6c4_m8_ecological_mda_thresholds.py
+++ b/backend/alembic/versions/d2b5f8a3e6c4_m8_ecological_mda_thresholds.py
@@ -1,0 +1,87 @@
+# ruff: noqa: E501
+"""mda_thresholds — seed M8 ecological planetary boundary thresholds (ADR-005 Amendment 3 M8-1)
+
+Revision ID: d2b5f8a3e6c4
+Revises: c1a4e7f2d9b3
+Create Date: 2026-05-17
+
+Seeds two MDA thresholds for the M8 ecological indicator expansion:
+
+  MDA-ECO-CO2-BOUNDARY  — planetary_boundary_co2_proximity ≥ 1.0
+    Fires WARNING when the entity's CO2 concentration crosses the
+    Rockström 2009 boundary (350 ppm). Proximity score 1.0 = at boundary.
+    comparison_operator='gte': breach when proximity ≥ 1.0.
+
+  MDA-ECO-LAND-BOUNDARY — planetary_boundary_land_use_proximity ≥ 1.0
+    Fires WARNING when land-use pressure index crosses the Richardson 2023
+    revision boundary. Proximity score 1.0 = at boundary.
+    comparison_operator='gte': breach when proximity ≥ 1.0.
+
+Confidence Tier 2 for both thresholds (literature-calibrated; not yet
+validated by backtesting runs). Tier assignment consistent with confidence_tier
+column added by c1a4e7f2d9b3 for ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM (Tier 2)
+and ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO (Tier 2 by default).
+
+These thresholds activate the MDA breach detection path in alerts_from_events_snapshot
+for ecological indicators once EcologicalModule produces proximity attributes.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "d2b5f8a3e6c4"
+down_revision = "c1a4e7f2d9b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO mda_thresholds (
+            mda_id, indicator_key, entity_scope, measurement_framework,
+            floor_value, floor_unit, approach_pct, comparison_operator,
+            severity_at_breach, description, historical_basis,
+            recovery_horizon_years, irreversibility_note
+        ) VALUES
+        (
+            'MDA-ECO-CO2-BOUNDARY',
+            'planetary_boundary_co2_proximity',
+            'all',
+            'ecological',
+            1.0,
+            'ratio_0_1',
+            0.10,
+            'gte',
+            'WARNING',
+            'CO2 planetary boundary proximity ≥ 1.0 — Rockström 2009 boundary (350 ppm) met or exceeded.',
+            'Rockström et al. 2009 (Nature) — nine planetary boundaries; 350 ppm CO2 boundary.',
+            NULL,
+            'Atmospheric CO2 accumulation is irreversible on century timescales; exceedance commits future generations to warming trajectories.'
+        ),
+        (
+            'MDA-ECO-LAND-BOUNDARY',
+            'planetary_boundary_land_use_proximity',
+            'all',
+            'ecological',
+            1.0,
+            'ratio_0_1',
+            0.10,
+            'gte',
+            'WARNING',
+            'Land-use planetary boundary proximity ≥ 1.0 — Richardson 2023 land-system boundary met or exceeded.',
+            'Richardson et al. 2023 (Science Advances) — updated planetary boundaries; land-system revision.',
+            NULL,
+            'Biodiversity loss from land-system change can be irreversible at species and habitat level.'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM mda_thresholds
+        WHERE mda_id IN ('MDA-ECO-CO2-BOUNDARY', 'MDA-ECO-LAND-BOUNDARY')
+        """
+    )

--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -30,6 +30,8 @@ import json
 import logging
 import subprocess
 import uuid
+from collections.abc import Callable
+from datetime import datetime  # noqa: TCH003
 from decimal import Decimal
 from math import floor
 from typing import Annotated, Any
@@ -796,21 +798,44 @@ _UNIMPLEMENTED_FRAMEWORKS = {"governance"}
 _UNIMPLEMENTED_NOTES = {
     "governance": "Governance module not yet implemented — see module-capability-registry.md",
 }
-# ADR-005 Amendment B mandatory note — must appear on every ecological FrameworkOutput
-# regardless of whether composite_score is null or non-null. Non-compliance is an
-# ADR violation. Planetary boundary absolute normalization is the methodologically
-# correct approach; percentile rank is the M6 scoped exception pending M8 full
-# indicator set.
-_ECOLOGICAL_MANDATORY_NOTE = (
-    "Ecological composite score uses cross-entity percentile rank at M6 scope. "
-    "Planetary boundary absolute normalization is methodologically preferred and "
-    "is deferred to M8 when the full indicator set is defined."
+# ADR-005 Amendment 3 Decision M8-1 mandatory note template — must appear on every
+# ecological FrameworkOutput. {n_indicators} is the count of active *_proximity
+# indicators at query time. Non-compliance is an ADR violation.
+_ECOLOGICAL_MANDATORY_NOTE_TEMPLATE = (
+    "Ecological composite score: unweighted mean of {n_indicators} boundary "
+    "proximity score(s) active at simulation time (formula: "
+    "min(current_value / boundary_value, 2.0) for absolute-scale indicators; "
+    "min(indicator_value, 2.0) for pre-normalized boundary-relative indicators). "
+    "Score 1.0 = boundary exactly met; >1.0 = boundary exceeded; "
+    "cap 2.0 = display ceiling only — entities with score 2.0 may be operating "
+    "at any exceedance level ≥2× the safe boundary; simulation snapshots preserve "
+    "uncapped values for analytical use. "
+    "Composite range: [0.0, 2.0]. "
+    "Equal weighting applied across contributing indicators — valid at current "
+    "indicator count; must be re-evaluated when count exceeds five. "
+    "Source: simulation_reference_constants table (effective-at-simulation-time)."
 )
 _ALL_FRAMEWORKS = ["financial", "human_development", "ecological", "governance"]
 _SINGLE_ENTITY_NOTE = (
     "Composite score not meaningful in single-entity scenarios — "
     "percentile rank requires at least two entities for comparison."
 )
+# ADR-005 Amendment 3 Decision M8-2: ecological is exempt from is_single_entity guard
+# because boundary proximity is physically meaningful for a single entity.
+_SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS: frozenset[str] = frozenset({"ecological"})
+# ADR-005 Amendment 3 Decision M8-3: frameworks validated for percentile-rank composite.
+# Governance is absent (M9 deferred — Decision M8-4). Unregistered frameworks fall
+# through to percentile rank with a [SIM-INTEGRITY] WARNING.
+_PERCENTILE_RANK_VALIDATED_FRAMEWORKS: frozenset[str] = frozenset(
+    {"financial", "human_development"}
+)
+# Maps ecological proximity indicator keys → (boundary_constant_id, is_pre_normalized).
+# Proximity indicators are produced by EcologicalModule and accumulated in entity.attributes.
+# is_pre_normalized=True: formula is min(v, 2.0) — module already applied the boundary ratio.
+_ECOLOGICAL_INDICATOR_BOUNDARY_CONFIG: dict[str, tuple[str, bool]] = {
+    "planetary_boundary_co2_proximity": ("ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM", True),
+    "planetary_boundary_land_use_proximity": ("ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO", True),
+}
 
 
 def _parse_entity_attrs(
@@ -834,40 +859,48 @@ def _parse_entity_attrs(
     return result
 
 
-def _compute_composite_score(
+# ---------------------------------------------------------------------------
+# Composite score strategy dispatch — ADR-005 Amendment 3 Decision M8-3
+# ---------------------------------------------------------------------------
+
+# Callable signature: (entity_indicators, all_entity_attrs, framework, context) → Decimal | None
+type CompositeStrategy = Callable[
+    [dict[str, QuantitySchema], dict[str, dict[str, QuantitySchema]], str, dict[str, Any]],
+    Decimal | None,
+]
+
+
+async def _fetch_active_boundary_constants(
+    db_connection: asyncpg.Connection,
+    scenario_timestep: datetime | str,
+) -> dict[str, Decimal]:
+    """Return active boundary constants at simulation time from simulation_reference_constants.
+
+    Effective-at-simulation-time query per ADR-005 Amendment 3 Decision M8-6.
+    Returns constant_id → Decimal value for constants active at scenario_timestep.
+    """
+    rows = await db_connection.fetch(
+        """
+        SELECT constant_id, value
+        FROM simulation_reference_constants
+        WHERE effective_from <= $1
+          AND (effective_through IS NULL OR effective_through >= $1)
+        """,
+        scenario_timestep,
+    )
+    return {row["constant_id"]: Decimal(str(row["value"])) for row in rows}
+
+
+def _percentile_rank_strategy(
     entity_indicators: dict[str, QuantitySchema],
     all_entity_attrs: dict[str, dict[str, QuantitySchema]],
     framework: str,
-) -> str | None:
-    """Mean percentile rank of entity indicators across all entities at this step.
+    context: dict[str, Any],
+) -> Decimal | None:
+    """Mean percentile rank across all entities for each framework indicator.
 
-    For each indicator, ranks the entity's value among all entities carrying
-    that indicator in this framework. Returns str(Decimal) rounded to 4 decimal
-    places, or None if no numeric indicators exist for this framework.
-    ADR-005 Decision 2 §Composite score normalization.
-
-    DISPATCH DESIGN NOTE (STD-REVIEW-004 Gap 4 + Gap 5, Architect panel finding):
-    This function currently applies the same percentile-rank calculation to all
-    frameworks, ignoring the `framework` parameter. Gaps 4 and 5 both require this
-    function to branch on framework:
-      - ecological: boundary proximity normalization (value / planetary_boundary,
-        capped at 2.0) — DATA_STANDARDS.md §Simulation Reference Constants
-      - governance: normalization methodology TBD in ADR-005 M8 amendment
-
-    The implementation must use a strategy dispatch pattern so that governance
-    can extend it without requiring a refactor. Design before implementing either:
-    define a Protocol or callable map keyed by framework string, with the
-    percentile-rank strategy as the default/fallback. Both ecological and governance
-    normalization strategies must be added in the same ADR-005 M8 amendment commit
-    — do not implement ecological strategy alone.
-
-    is_single_entity guard interaction (QA Lead panel finding, Gap 4):
-    The is_single_entity guard below suppresses composite_score for single-entity
-    scenarios uniformly. Boundary-normalized ecological scores are physically
-    meaningful for a single entity (CO2 vs. 350 ppm boundary), unlike percentile
-    rank. The ADR-005 M8 amendment must specify which frameworks are exempt from
-    the guard. TODO: update the guard to check framework exemption list before
-    suppressing composite_score.
+    ADR-005 Decision 2 §Composite score normalization. Returns [0.0, 1.0] Decimal
+    or None when no numeric indicators are present.
     """
     if not entity_indicators:
         return None
@@ -896,7 +929,116 @@ def _compute_composite_score(
         return None
 
     score = sum(percentile_ranks) / Decimal(len(percentile_ranks))
-    return str(score.quantize(Decimal("0.0001")))
+    return score.quantize(Decimal("0.0001"))
+
+
+def _boundary_proximity_strategy(
+    entity_indicators: dict[str, QuantitySchema],
+    all_entity_attrs: dict[str, dict[str, QuantitySchema]],
+    framework: str,
+    context: dict[str, Any],
+) -> Decimal | None:
+    """Unweighted mean of boundary proximity scores for ecological indicators.
+
+    Reads context["boundary_constants"] (populated by _fetch_active_boundary_constants)
+    to verify temporal validity. Indicators not in _ECOLOGICAL_INDICATOR_BOUNDARY_CONFIG
+    are skipped. Missing or inactive boundary constants trigger [SIM-INTEGRITY] WARNING
+    and exclude that indicator from the composite. ADR-005 Amendment 3 Decision M8-3.
+    """
+    boundary_constants: dict[str, Decimal] = context.get("boundary_constants", {})
+    proximity_scores: list[Decimal] = []
+
+    for indicator_key, qty in entity_indicators.items():
+        config = _ECOLOGICAL_INDICATOR_BOUNDARY_CONFIG.get(indicator_key)
+        if config is None:
+            continue
+
+        boundary_constant_id, is_pre_normalized = config
+
+        if boundary_constant_id not in boundary_constants:
+            _log.warning(
+                "[SIM-INTEGRITY] Ecological boundary constant '%s' not active at simulation "
+                "time — indicator '%s' excluded from composite score. Verify that migration "
+                "c1a4e7f2d9b3 has run and simulation_reference_constants is seeded.",
+                boundary_constant_id,
+                indicator_key,
+            )
+            continue
+
+        try:
+            raw_val = Decimal(qty.value)
+        except Exception:  # noqa: BLE001, S112
+            continue
+
+        if is_pre_normalized:
+            score = min(raw_val, Decimal("2.0"))
+        else:
+            boundary_val = boundary_constants[boundary_constant_id]
+            if boundary_val == Decimal("0"):
+                _log.warning(
+                    "[SIM-INTEGRITY] Boundary constant '%s' has zero value — "
+                    "cannot compute proximity for '%s'. Skipping.",
+                    boundary_constant_id,
+                    indicator_key,
+                )
+                continue
+            score = min(raw_val / boundary_val, Decimal("2.0"))
+
+        proximity_scores.append(score)
+
+    if not proximity_scores:
+        return None
+
+    composite = sum(proximity_scores) / Decimal(len(proximity_scores))
+    return composite.quantize(Decimal("0.0001"))
+
+
+# Registered strategies keyed by framework string. M9 governance strategy is added
+# in ADR-005 Amendment 4 when GovernanceModule promotion criteria are met (Decision M8-4).
+_COMPOSITE_STRATEGIES: dict[str, CompositeStrategy] = {
+    "ecological": _boundary_proximity_strategy,
+}
+_DEFAULT_COMPOSITE_STRATEGY: CompositeStrategy = _percentile_rank_strategy
+
+
+async def _compute_composite_score(
+    entity_indicators: dict[str, QuantitySchema],
+    all_entity_attrs: dict[str, dict[str, QuantitySchema]],
+    framework: str,
+    db_connection: asyncpg.Connection,
+    scenario_timestep: datetime | str,
+) -> str | None:
+    """Framework-dispatched composite score. Returns str(Decimal) or None.
+
+    Three-branch dispatch per ADR-005 Amendment 3 Decision M8-3:
+      1. Registered strategy (_COMPOSITE_STRATEGIES) — e.g. ecological boundary proximity
+      2. Validated percentile-rank framework (_PERCENTILE_RANK_VALIDATED_FRAMEWORKS)
+      3. Unknown framework — [SIM-INTEGRITY] WARNING, falls back to percentile rank
+    """
+    context: dict[str, Any] = {}
+
+    if framework in _COMPOSITE_STRATEGIES:
+        if framework == "ecological":
+            context["boundary_constants"] = await _fetch_active_boundary_constants(
+                db_connection, scenario_timestep
+            )
+        strategy = _COMPOSITE_STRATEGIES[framework]
+    elif framework in _PERCENTILE_RANK_VALIDATED_FRAMEWORKS:
+        strategy = _DEFAULT_COMPOSITE_STRATEGY
+    else:
+        _log.warning(
+            "[SIM-INTEGRITY] Framework '%s' has no registered composite strategy "
+            "and is not in _PERCENTILE_RANK_VALIDATED_FRAMEWORKS — "
+            "falling back to percentile rank. Register a strategy or add to "
+            "_PERCENTILE_RANK_VALIDATED_FRAMEWORKS.",
+            framework,
+        )
+        strategy = _DEFAULT_COMPOSITE_STRATEGY
+
+    result = strategy(entity_indicators, all_entity_attrs, framework, context)
+    if result is None:
+        return None
+    return str(result)
 
 
 def _alert_matches_framework(
@@ -929,10 +1071,12 @@ async def get_measurement_output(
 
     Groups the entity's attributes by measurement_framework tag. Attributes
     with no tag are classified as FINANCIAL (M1–M3 backward-compatibility rule,
-    CODING_STANDARDS.md §measurement_framework Tagging). Composite scores are
-    percentile-based across all entities present in the snapshot. ECOLOGICAL and
-    GOVERNANCE return composite_score=null with a note until those modules are
-    implemented. ia1_disclosure is always IA1_CANONICAL_PHRASE. ADR-005 Decision 2.
+    CODING_STANDARDS.md §measurement_framework Tagging). Composite score dispatch
+    is framework-specific: ecological uses boundary proximity normalization [0.0, 2.0]
+    (ADR-005 Amendment 3 Decision M8-3); financial and human_development use mean
+    percentile rank [0.0, 1.0]; governance returns null (deferred to M9, Decision M8-4).
+    Ecological is exempt from the single-entity composite suppression guard (Decision M8-2).
+    ia1_disclosure is always IA1_CANONICAL_PHRASE. ADR-005 Decision 2, Amendment 3.
 
     Query params:
         step      — snapshot step index (required)
@@ -1023,13 +1167,20 @@ async def get_measurement_output(
             for k, v in target_attrs.items()
             if (v.measurement_framework or "financial") == fw
         }
-        if is_single_entity:
+        # ADR-005 Amendment 3 Decision M8-2: ecological exempt from single-entity guard.
+        if is_single_entity and fw not in _SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS:
             composite = None
         else:
-            composite = _compute_composite_score(indicators, all_entity_attrs, fw)
-        # ADR-005 Amendment B: ecological note is mandatory regardless of composite_score.
+            composite = await _compute_composite_score(
+                indicators, all_entity_attrs, fw, conn, timestep
+            )
+        # ADR-005 Amendment 3 Decision M8-1: ecological note is mandatory regardless of
+        # composite_score; {n_indicators} counts active *_proximity attributes.
         if fw == "ecological":
-            note: str | None = _ECOLOGICAL_MANDATORY_NOTE
+            n_indicators = sum(1 for k in indicators if k.endswith("_proximity"))
+            note: str | None = _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE.format(
+                n_indicators=n_indicators
+            )
         elif is_single_entity:
             note = _SINGLE_ENTITY_NOTE
         else:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -357,12 +357,14 @@ class MDAAlert(BaseModel):
 class FrameworkOutput(BaseModel):
     """One measurement framework's indicators and composite score for an entity.
 
-    composite_score is a Decimal-as-string (0.0–1.0 percentile rank) or None
-    when the module producing this framework's indicators is not yet implemented,
-    or when the scenario has only one entity (percentile rank is meaningless with
-    a population of one). note is populated when composite_score is None.
-    mda_alerts is empty pending ADR-005 Decision 3 (MDAChecker) implementation.
-    ADR-005 Decision 2. Issue #193.
+    composite_score is a Decimal-as-string or None. Range and computation are
+    framework-dependent: [0.0, 1.0] percentile rank for financial and human_development;
+    [0.0, 2.0] boundary proximity for ecological (1.0 = at boundary, cap 2.0 for display).
+    None for governance (deferred to M9) and for financial/human_development in
+    single-entity scenarios (percentile rank is meaningless with a population of one).
+    Ecological is exempt from the single-entity suppression — boundary proximity is
+    physically meaningful for a single entity. note is always populated for ecological.
+    ADR-005 Decision 2, Amendment 3 Decisions M8-1/M8-2/M8-3. Issue #193.
     """
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/simulation/modules/ecological/module.py
+++ b/backend/app/simulation/modules/ecological/module.py
@@ -1,4 +1,4 @@
-"""EcologicalModule — ADR-005 Amendment 1.
+"""EcologicalModule — ADR-005 Amendment 1, expanded at M8 (Amendment 3 Decision M8-6).
 
 Subscribes to macro, fiscal, and emergency events on country entities and
 applies the ecological elasticity matrix to produce ecological indicator
@@ -18,11 +18,20 @@ Indicators produced at M6 minimum viable scope:
     of the safe land-system boundary consumed by the entity's land-use change
     trajectory.
 
-ADR-005 Amendment B mandatory note: the ecological composite score in
-MultiFrameworkOutput uses cross-entity percentile rank at M6 scope.
-Planetary boundary absolute normalization is methodologically preferred and
-is deferred to M8. This note appears on every ecological FrameworkOutput
-via scenarios.py — it is not this module's responsibility to set it.
+M8 expansion (ADR-005 Amendment 3 Decision M8-6) — stock-path proximity indicators:
+  planetary_boundary_co2_proximity — min(co2_concentration_ppm / 350, 2.0)
+    Confidence tier 2: max(source_tier=1, boundary_tier=2). Boundary effective
+    from 2009-09-24 (Rockström 2009, Nature). Temporal guard: not computed if
+    simulation timestep precedes effective_from.
+  planetary_boundary_land_use_proximity — min(land_use_pressure_index, 2.0)
+    No division by 0.25 — land_use_pressure_index is already boundary-relative
+    (double-normalization prevention, ADR-005 Amendment 3 Decision M8-6).
+    Confidence tier 3: max(source_tier=3, boundary_tier=2). Boundary effective
+    from 2023-09-13 (Richardson 2023, Science Advances).
+
+Proximity computation reads entity.attributes (accumulated stock values), not
+state.events (deltas). Delta computation continues to read state.events. Both
+paths run independently and are merged into a single event per step.
 
 Implicit dependency: subscribes to gdp_growth_change which only fires when
 MacroeconomicModule is active. If MacroeconomicModule is absent, GDP-mediated
@@ -31,8 +40,8 @@ ecological effects are silently absent. Enforcement tracked in Issue #211 (M7).
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 from app.simulation.engine.models import (
     Event,
@@ -43,9 +52,6 @@ from app.simulation.engine.models import (
 )
 from app.simulation.engine.quantity import Quantity, VariableType
 from app.simulation.modules.ecological.elasticities import ECOLOGICAL_ELASTICITY_REGISTRY
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 _log = logging.getLogger(__name__)
 
@@ -73,6 +79,106 @@ _INDICATOR_UNITS: dict[str, str] = {
 }
 _DEFAULT_ECOLOGICAL_UNIT = "ratio_0_1"
 
+# ---------------------------------------------------------------------------
+# M8 boundary proximity constants — ADR-005 Amendment 3 Decision M8-6
+# ---------------------------------------------------------------------------
+
+# Hardcoded boundary values matching simulation_reference_constants seed (migration b3c5d7e9f1a2).
+# Used for proximity computation in the simulation engine (sync context).
+# The DB query in scenarios.py validates temporal availability at read time.
+_BOUNDARY_CONSTANT_VALUES: dict[str, Decimal] = {
+    "ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM": Decimal("350"),
+    "ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO": Decimal("0.25"),
+}
+
+# effective_from dates matching the simulation_reference_constants table rows.
+_BOUNDARY_CONSTANT_EFFECTIVE_FROM: dict[str, datetime] = {
+    "ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM": datetime(2009, 9, 24, tzinfo=UTC),
+    "ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO": datetime(2023, 9, 13, tzinfo=UTC),
+}
+
+# Maps base indicator key → (constant_id, is_pre_normalized, output_key, confidence_tier)
+# is_pre_normalized=True: formula is min(v, 2.0) — indicator already boundary-relative.
+# is_pre_normalized=False: formula is min(v / boundary_value, 2.0).
+# confidence_tier = max(source_indicator_tier, boundary_constant_tier=2) per ADR-001 Amendment 1.
+_PROXIMITY_INDICATOR_CONFIG: dict[str, tuple[str, bool, str, int]] = {
+    "co2_concentration_ppm": (
+        "ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM",
+        False,  # absolute-scale ppm — divide by 350
+        "planetary_boundary_co2_proximity",
+        2,  # max(source=1, boundary=2) = 2
+    ),
+    "land_use_pressure_index": (
+        "ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO",
+        True,  # already boundary-relative ratio — no division (ADR M8-6: no double-normalization)
+        "planetary_boundary_land_use_proximity",
+        3,  # max(source=3, boundary=2) = 3
+    ),
+}
+
+
+def _compute_proximity_indicators(
+    entity: SimulationEntity,
+    timestep: datetime,
+) -> dict[str, Quantity]:
+    """Compute planetary boundary proximity scores from entity stock attributes.
+
+    Reads entity.attributes (accumulated STOCK values), not state.events (deltas).
+    Only computes proximity for boundary constants active at simulation timestep.
+    Emits [SIM-INTEGRITY] WARNING when base attribute is absent or boundary constant
+    is not yet temporally active. ADR-005 Amendment 3 Decision M8-6.
+    """
+    result: dict[str, Quantity] = {}
+
+    for base_key, (constant_id, is_pre_normalized, output_key, confidence_tier) in \
+            _PROXIMITY_INDICATOR_CONFIG.items():
+        effective_from = _BOUNDARY_CONSTANT_EFFECTIVE_FROM.get(constant_id)
+        if effective_from is not None and timestep < effective_from:
+            _log.warning(
+                "[SIM-INTEGRITY] Boundary constant '%s' not active at timestep=%r "
+                "(effective_from=%r) — skipping proximity for '%s'.",
+                constant_id,
+                timestep,
+                effective_from,
+                output_key,
+            )
+            continue
+
+        stock_qty = entity.attributes.get(base_key)
+        if stock_qty is None:
+            _log.warning(
+                "[SIM-INTEGRITY] Base attribute '%s' absent from entity '%s' attributes "
+                "— cannot compute '%s'. Proximity requires at least one prior step "
+                "with EcologicalModule active.",
+                base_key,
+                entity.id,
+                output_key,
+            )
+            continue
+
+        try:
+            stock_val = Decimal(str(stock_qty.value))
+        except Exception:  # noqa: BLE001, S112
+            continue
+
+        if is_pre_normalized:
+            proximity = min(stock_val, Decimal("2.0"))
+        else:
+            boundary_val = _BOUNDARY_CONSTANT_VALUES.get(constant_id, Decimal("1"))
+            if boundary_val == Decimal("0"):
+                continue
+            proximity = min(stock_val / boundary_val, Decimal("2.0"))
+
+        result[output_key] = Quantity(
+            value=proximity.quantize(Decimal("0.000001")),
+            unit="ratio_0_1",
+            variable_type=VariableType.STOCK,
+            measurement_framework=MeasurementFramework.ECOLOGICAL,
+            confidence_tier=confidence_tier,
+        )
+
+    return result
+
 
 class EcologicalModule(SimulationModule):
     """Translates country-level events into ecological indicator deltas.
@@ -83,27 +189,30 @@ class EcologicalModule(SimulationModule):
     composite score methodology (ADR-005 Amendment 1 §Amendment B M8 obligation).
     """
 
-    # INTENT: Translate prior-step events for one country entity into ecological
-    #         indicator Quantity-delta Events using the elasticity registry.
+    # INTENT: Produce ecological indicator events for one country entity per step.
+    #         Two independent computation paths merged into a single event:
+    #         (1) Stock path — planetary boundary proximity from entity.attributes
+    #             accumulated stock values (ADR-005 Amendment 3 Decision M8-6).
+    #         (2) Delta path — indicator deltas from prior-step events via the
+    #             elasticity registry (one-step lag design, M6 scope).
     # PRECONDITIONS: entity is a SimulationEntity with entity_type; state.events
-    #                contains the prior timestep's events (one-step lag design —
-    #                ecological effects of GDP and fiscal changes appear with a
-    #                structural delay); timestep is the current simulation step.
+    #                contains the prior timestep's events (one-step lag design);
+    #                timestep is the current simulation step.
     # POSTCONDITIONS: Returns a list of Events with framework=ECOLOGICAL and
     #                 event_type='ecological_indicator_update'; returns [] for
-    #                 non-country entities or when no subscribed events are found
-    #                 in state.events for this entity. All Quantity values use
-    #                 Decimal arithmetic. A DEBUG log is emitted when prior_events
-    #                 is empty.
+    #                 non-country entities or when both paths produce no attributes.
+    #                 All Quantity values use Decimal arithmetic. A DEBUG log is
+    #                 emitted when prior_events is empty.
     # ERROR CASES: Subscribed events with no matching elasticity registry entry
-    #              produce no output (silently ignored); magnitude extraction
-    #              failure for an event causes that event to be skipped.
+    #              produce no delta output (silently ignored). Missing stock
+    #              attributes or temporally inactive boundary constants produce
+    #              [SIM-INTEGRITY] WARNING and skip that proximity indicator.
     # KNOWN LIMITATIONS: Ecological effects are computed via a linear elasticity
     #                    approximation — non-linear threshold effects and
-    #                    irreversibility are not modelled. Only co2_concentration_ppm
-    #                    and land_use_pressure_index are produced at M6 scope;
-    #                    planetary boundary absolute normalization is deferred
-    #                    to M8 (ADR-005 Amendment B obligation).
+    #                    irreversibility are not modelled. Proximity computation
+    #                    requires entity.attributes to be populated from prior steps;
+    #                    on the first step with no prior ecological events, proximity
+    #                    attributes will be absent.
     def compute(
         self,
         entity: SimulationEntity,
@@ -113,6 +222,12 @@ class EcologicalModule(SimulationModule):
         if entity.entity_type != "country":
             return []
 
+        affected_attributes: dict[str, Quantity] = {}
+
+        # Stock path: compute proximity indicators from accumulated entity attributes.
+        affected_attributes.update(_compute_proximity_indicators(entity, timestep))
+
+        # Delta path: compute indicator deltas from prior-step subscribed events.
         prior_events = [
             e for e in state.events
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
@@ -124,41 +239,37 @@ class EcologicalModule(SimulationModule):
                 entity.id,
                 timestep,
             )
-            return []
+        else:
+            indicator_deltas: dict[str, Decimal] = {}
+            indicator_tiers: dict[str, int] = {}
 
-        # Accumulate deltas per indicator across all prior events.
-        indicator_deltas: dict[str, Decimal] = {}
-        indicator_tiers: dict[str, int] = {}
-
-        for event in prior_events:
-            magnitude = _extract_magnitude(event)
-            if magnitude is None:
-                continue
-            event_tier = _event_confidence_tier(event)
-            for row in ECOLOGICAL_ELASTICITY_REGISTRY:
-                if row.event_type != event.event_type:
+            for event in prior_events:
+                magnitude = _extract_magnitude(event)
+                if magnitude is None:
                     continue
-                delta = (magnitude * row.elasticity).quantize(Decimal("0.000001"))
-                key = row.indicator_key
-                indicator_deltas[key] = indicator_deltas.get(key, Decimal("0")) + delta
-                indicator_tiers[key] = max(
-                    indicator_tiers.get(key, row.confidence_tier),
-                    event_tier,
+                event_tier = _event_confidence_tier(event)
+                for row in ECOLOGICAL_ELASTICITY_REGISTRY:
+                    if row.event_type != event.event_type:
+                        continue
+                    delta = (magnitude * row.elasticity).quantize(Decimal("0.000001"))
+                    key = row.indicator_key
+                    indicator_deltas[key] = indicator_deltas.get(key, Decimal("0")) + delta
+                    indicator_tiers[key] = max(
+                        indicator_tiers.get(key, row.confidence_tier),
+                        event_tier,
+                    )
+
+            for key, delta in indicator_deltas.items():
+                affected_attributes[key] = Quantity(
+                    value=delta,
+                    unit=_INDICATOR_UNITS.get(key, _DEFAULT_ECOLOGICAL_UNIT),
+                    variable_type=_INDICATOR_VARIABLE_TYPES.get(key, VariableType.RATIO),
+                    measurement_framework=MeasurementFramework.ECOLOGICAL,
+                    confidence_tier=indicator_tiers[key],
                 )
 
-        if not indicator_deltas:
+        if not affected_attributes:
             return []
-
-        affected_attributes = {
-            key: Quantity(
-                value=delta,
-                unit=_INDICATOR_UNITS.get(key, _DEFAULT_ECOLOGICAL_UNIT),
-                variable_type=_INDICATOR_VARIABLE_TYPES.get(key, VariableType.RATIO),
-                measurement_framework=MeasurementFramework.ECOLOGICAL,
-                confidence_tier=indicator_tiers[key],
-            )
-            for key, delta in indicator_deltas.items()
-        }
 
         return [Event(
             event_id=f"eco-{entity.id}-{timestep.isoformat()}",

--- a/backend/tests/unit/test_ecological_module.py
+++ b/backend/tests/unit/test_ecological_module.py
@@ -16,8 +16,12 @@ Covers:
   - Registry event types are all in _SUBSCRIBED_EVENTS
   - co2_concentration_ppm uses VariableType.STOCK
   - land_use_pressure_index uses VariableType.RATIO
-  - mandatory ecological note present in scenarios._ECOLOGICAL_MANDATORY_NOTE
-  - mandatory note text matches ADR-005 Amendment B verbatim requirement
+  - mandatory note template present in scenarios._ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+  - mandatory note template text matches ADR-005 Amendment 3 Decision M8-1 requirements
+  - M8 proximity path: planetary_boundary_co2_proximity computed from stock attribute
+  - M8 proximity path: planetary_boundary_land_use_proximity (no division, pre-normalized)
+  - M8 proximity path: temporal guard (timestep before effective_from skips indicator)
+  - M8 proximity path: absent base attribute skips with [SIM-INTEGRITY] WARNING
 
 All tests run without a database connection.
 """
@@ -513,36 +517,38 @@ def test_registry_land_use_entry_uses_tier_3() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ecological_mandatory_note_is_defined() -> None:
-    """_ECOLOGICAL_MANDATORY_NOTE must be defined in scenarios.py."""
-    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE
-    assert _ECOLOGICAL_MANDATORY_NOTE
-    assert len(_ECOLOGICAL_MANDATORY_NOTE) > 50
+def test_ecological_mandatory_note_template_is_defined() -> None:
+    """_ECOLOGICAL_MANDATORY_NOTE_TEMPLATE must be defined in scenarios.py."""
+    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert len(_ECOLOGICAL_MANDATORY_NOTE_TEMPLATE) > 50
 
 
-def test_ecological_mandatory_note_references_percentile_rank() -> None:
-    """Mandatory note must reference 'percentile rank' per ADR-005 Amendment B."""
-    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE
-    assert "percentile rank" in _ECOLOGICAL_MANDATORY_NOTE
+def test_ecological_mandatory_note_template_has_n_indicators_slot() -> None:
+    """Template must contain the {n_indicators} slot per ADR-005 Amendment 3 Decision M8-1."""
+    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert "{n_indicators}" in _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
 
 
-def test_ecological_mandatory_note_references_m6_scope() -> None:
-    """Mandatory note must reference 'M6 scope' per ADR-005 Amendment B."""
-    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE
-    assert "M6 scope" in _ECOLOGICAL_MANDATORY_NOTE
+def test_ecological_mandatory_note_template_references_boundary_proximity() -> None:
+    """Template must reference boundary proximity formula per ADR-005 Amendment 3 Decision M8-1."""
+    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert "boundary" in _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert "proximity" in _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
 
 
-def test_ecological_mandatory_note_references_m8_deferral() -> None:
-    """Mandatory note must reference M8 deferral per ADR-005 Amendment B."""
-    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE
-    assert "M8" in _ECOLOGICAL_MANDATORY_NOTE
+def test_ecological_mandatory_note_template_references_composite_range() -> None:
+    """Template must state the [0.0, 2.0] composite range per ADR-005 Amendment 3 Decision M8-1."""
+    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    assert "[0.0, 2.0]" in _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
 
 
-def test_ecological_mandatory_note_references_planetary_boundary() -> None:
-    """Mandatory note must reference planetary boundary normalization."""
-    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE
-    assert "Planetary boundary" in _ECOLOGICAL_MANDATORY_NOTE or \
-           "planetary boundary" in _ECOLOGICAL_MANDATORY_NOTE
+def test_ecological_mandatory_note_template_formats_with_n_indicators() -> None:
+    """Template must format cleanly with an integer n_indicators value."""
+    from app.api.scenarios import _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE
+    formatted = _ECOLOGICAL_MANDATORY_NOTE_TEMPLATE.format(n_indicators=2)
+    assert "2 boundary" in formatted
+    assert "{n_indicators}" not in formatted
 
 
 def test_ecological_not_in_unimplemented_frameworks() -> None:
@@ -594,3 +600,188 @@ def test_ecological_module_logs_debug_on_no_prior_events(caplog: pytest.LogCaptu
         for r in caplog.records
         if r.levelno == logging.DEBUG
     ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# M8 expansion — planetary boundary proximity computation (ADR-005 Amendment 3 Decision M8-6)
+# ---------------------------------------------------------------------------
+
+
+def _make_entity_with_attrs(**attrs: tuple[Decimal, str]) -> SimulationEntity:
+    """Build a country SimulationEntity with the given attribute stock values.
+
+    attrs: keyword args where key is attribute name, value is (stock_value, unit).
+    """
+    attributes = {
+        key: Quantity(
+            value=val,
+            unit=unit,
+            variable_type=VariableType.STOCK,
+            measurement_framework=MeasurementFramework.ECOLOGICAL,
+            confidence_tier=1,
+        )
+        for key, (val, unit) in attrs.items()
+    }
+    return SimulationEntity(id="GRC", entity_type="country", attributes=attributes, metadata={})
+
+
+def _make_state_no_events() -> SimulationState:
+    from app.simulation.engine.models import ResolutionConfig, ScenarioConfig, SimulationState
+    return SimulationState(
+        timestep=datetime(2010, 1, 1, tzinfo=UTC),
+        resolution=ResolutionConfig(),
+        entities={},
+        relationships=[],
+        events=[],
+        scenario_config=ScenarioConfig(
+            scenario_id="test",
+            name="Test",
+            description="",
+            start_date=datetime(2010, 1, 1, tzinfo=UTC),
+            end_date=datetime(2013, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def test_co2_proximity_below_boundary() -> None:
+    """CO2 concentration below boundary → proximity < 1.0."""
+    entity = _make_entity_with_attrs(co2_concentration_ppm=(Decimal("280"), "ppm"))
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_co2_proximity"]
+    # 280 / 350 = 0.8
+    assert proximity.value == Decimal("0.8").quantize(Decimal("0.000001"))
+
+
+def test_co2_proximity_at_boundary() -> None:
+    """CO2 concentration exactly at boundary → proximity = 1.0."""
+    entity = _make_entity_with_attrs(co2_concentration_ppm=(Decimal("350"), "ppm"))
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_co2_proximity"]
+    assert proximity.value == Decimal("1.000000")
+
+
+def test_co2_proximity_above_boundary() -> None:
+    """CO2 concentration above boundary → proximity > 1.0."""
+    entity = _make_entity_with_attrs(co2_concentration_ppm=(Decimal("420"), "ppm"))
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_co2_proximity"]
+    # 420 / 350 = 1.2
+    assert proximity.value == Decimal("1.2").quantize(Decimal("0.000001"))
+
+
+def test_co2_proximity_capped_at_two() -> None:
+    """CO2 concentration far above boundary → proximity capped at 2.0."""
+    entity = _make_entity_with_attrs(co2_concentration_ppm=(Decimal("1400"), "ppm"))
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_co2_proximity"]
+    # 1400 / 350 = 4.0 → capped at 2.0
+    assert proximity.value == Decimal("2.000000")
+
+
+def test_land_use_proximity_no_division_by_boundary_value() -> None:
+    """land_use_pressure_index proximity uses min(v, 2.0) — no division by 0.25.
+
+    ADR-005 Amendment 3 Decision M8-6 explicit constraint: land_use_pressure_index
+    is already boundary-relative (pre-normalized). Dividing by 0.25 would produce
+    a double-normalization error. value=0.5 → proximity=0.5, NOT 0.5/0.25=2.0.
+    """
+    entity = _make_entity_with_attrs(
+        land_use_pressure_index=(Decimal("0.5"), "ratio_0_1")
+    )
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2023, 9, 14, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_land_use_proximity"]
+    assert proximity.value == Decimal("0.500000"), (
+        f"Expected 0.5 (no division), got {proximity.value}. "
+        "Double-normalization error: dividing by 0.25 boundary would give 2.0."
+    )
+
+
+def test_land_use_proximity_confidence_tier() -> None:
+    """land_use_proximity confidence_tier = max(source=3, boundary=2) = 3."""
+    entity = _make_entity_with_attrs(
+        land_use_pressure_index=(Decimal("0.5"), "ratio_0_1")
+    )
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2023, 9, 14, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_land_use_proximity"]
+    assert proximity.confidence_tier == 3
+
+
+def test_co2_proximity_confidence_tier() -> None:
+    """co2_proximity confidence_tier = max(source=1, boundary=2) = 2."""
+    entity = _make_entity_with_attrs(co2_concentration_ppm=(Decimal("350"), "ppm"))
+    state = _make_state_no_events()
+    module = EcologicalModule()
+    events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+    assert len(events) == 1
+    proximity = events[0].affected_attributes["planetary_boundary_co2_proximity"]
+    assert proximity.confidence_tier == 2
+
+
+def test_land_use_proximity_not_computed_before_effective_from(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """land_use_pressure_index proximity is not computed before 2023-09-13.
+
+    Richardson 2023 boundary effective_from 2023-09-13. Timestep 2010-01-01
+    precedes this date — boundary temporally inactive, [SIM-INTEGRITY] WARNING emitted.
+    """
+    entity = _make_entity_with_attrs(
+        land_use_pressure_index=(Decimal("0.5"), "ratio_0_1")
+    )
+    state = _make_state_no_events()
+    module = EcologicalModule()
+
+    with caplog.at_level(logging.WARNING, logger="app.simulation.modules.ecological.module"):
+        events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+
+    # land_use proximity is skipped; no other attributes → returns []
+    assert events == []
+    assert any(
+        "[SIM-INTEGRITY]" in r.message
+        and "ECOLOGICAL_LAND_USE_PLANETARY_BOUNDARY_RATIO" in r.message
+        for r in caplog.records
+    ), f"Expected [SIM-INTEGRITY] warning. Got: {[r.message for r in caplog.records]}"
+
+
+def test_co2_proximity_absent_attribute_emits_sim_integrity_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Absent co2_concentration_ppm attribute emits [SIM-INTEGRITY] WARNING."""
+    entity = SimulationEntity(
+        id="GRC",
+        entity_type="country",
+        attributes={},  # no stock attributes
+        metadata={},
+    )
+    state = _make_state_no_events()
+    module = EcologicalModule()
+
+    with caplog.at_level(logging.WARNING, logger="app.simulation.modules.ecological.module"):
+        events = module.compute(entity, state, datetime(2010, 1, 1, tzinfo=UTC))
+
+    assert events == []
+    assert any(
+        "[SIM-INTEGRITY]" in r.message and "co2_concentration_ppm" in r.message
+        for r in caplog.records
+    ), (
+        f"Expected [SIM-INTEGRITY] for co2_concentration_ppm. "
+        f"Got: {[r.message for r in caplog.records]}"
+    )

--- a/backend/tests/unit/test_measurement_output.py
+++ b/backend/tests/unit/test_measurement_output.py
@@ -95,6 +95,9 @@ def _entity_row(name: str = "Greece") -> dict:
 def _make_conn(*side_effects: dict[str, object] | None) -> AsyncMock:
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=list(side_effects))
+    # conn.fetch is used by _fetch_active_boundary_constants for ecological composite score.
+    # Default empty list = no active boundary constants = ecological composite_score None.
+    conn.fetch = AsyncMock(return_value=[])
     return conn
 
 
@@ -214,11 +217,12 @@ async def test_ecological_returns_null_composite_score_with_note() -> None:
         scenario_id="scen-1", entity_id="GRC", step=1, conn=conn
     )
     ecological = result.outputs["ecological"]
+    # No proximity indicators in _STATE, no active boundary constants → composite None.
     assert ecological.composite_score is None
     assert ecological.note is not None
-    # ADR-005 Amendment B: ecological note is the mandatory percentile-rank disclosure,
-    # not the "not yet implemented" note — ecological module shipped at M6.
-    assert "percentile rank" in ecological.note
+    # ADR-005 Amendment 3 Decision M8-1: mandatory note references boundary proximity formula.
+    assert "boundary" in ecological.note
+    assert "Composite range: [0.0, 2.0]" in ecological.note
 
 
 @pytest.mark.asyncio
@@ -341,7 +345,11 @@ _SINGLE_ENTITY_STATE = {
 
 @pytest.mark.asyncio
 async def test_single_entity_composite_score_is_null() -> None:
-    """Single-entity snapshot: composite_score must be None for all implemented frameworks."""
+    """Single-entity: financial and human_development composite_score must be None.
+
+    Ecological is exempt from the single-entity guard (ADR-005 Amendment 3 Decision M8-2)
+    and is tested separately in test_ecological_exempt_from_single_entity_guard.
+    """
     conn = _make_conn(
         {"scenario_id": "scen-1"},
         _snap_row(state=_SINGLE_ENTITY_STATE),
@@ -397,9 +405,10 @@ async def test_single_entity_unimplemented_frameworks_keep_their_note() -> None:
     result = await get_measurement_output(
         scenario_id="scen-1", entity_id="GRC", step=1, conn=conn
     )
-    # Ecological module shipped at M6: mandatory percentile-rank disclosure (ADR-005 Amendment B).
-    assert "percentile rank" in result.outputs["ecological"].note
-    # Governance module still unimplemented at M6.
+    # ADR-005 Amendment 3 Decision M8-1: ecological always gets the mandatory boundary note.
+    assert "boundary" in result.outputs["ecological"].note
+    assert "Composite range: [0.0, 2.0]" in result.outputs["ecological"].note
+    # Governance module still unimplemented (deferred to M9 — Decision M8-4).
     assert "not yet implemented" in result.outputs["governance"].note
 
 
@@ -480,6 +489,117 @@ async def test_multi_entity_composite_score_is_not_null() -> None:
     )
     assert result.outputs["financial"].composite_score is not None
     assert isinstance(result.outputs["financial"].composite_score, str)
+
+
+# ---------------------------------------------------------------------------
+# ADR-005 Amendment 3 — strategy dispatch and ecological exemption
+# ---------------------------------------------------------------------------
+
+_ECOLOGICAL_ATTR = {
+    "_envelope_version": "1",
+    "value": "1.2",
+    "unit": "ratio_0_1",
+    "variable_type": "stock",
+    "confidence_tier": 2,
+    "observation_date": None,
+    "source_registry_id": "ECO_TEST",
+    "measurement_framework": "ecological",
+}
+
+_SINGLE_ENTITY_ECO_STATE = {
+    "_envelope_version": "2",
+    "_modules_active": [],
+    "GRC": {
+        "planetary_boundary_co2_proximity": _ECOLOGICAL_ATTR,
+    },
+}
+
+
+def test_ecological_exempt_frameworks_constant_exists() -> None:
+    """_SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS must exist and include ecological."""
+    from app.api.scenarios import _SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS
+    assert "ecological" in _SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS
+
+
+@pytest.mark.asyncio
+async def test_ecological_exempt_from_single_entity_guard() -> None:
+    """Single-entity snapshot: ecological composite_score is computed (not suppressed).
+
+    ADR-005 Amendment 3 Decision M8-2 — boundary proximity is physically meaningful
+    for a single entity. With active boundary constants (mocked), composite is non-null.
+    """
+    boundary_row = {"constant_id": "ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM", "value": "350"}
+    conn = _make_conn(
+        {"scenario_id": "scen-1"},
+        _snap_row(state=_SINGLE_ENTITY_ECO_STATE),
+        _entity_row(),
+    )
+    # Override fetch to return an active boundary constant.
+    conn.fetch = AsyncMock(return_value=[boundary_row])
+
+    result = await get_measurement_output(
+        scenario_id="scen-1", entity_id="GRC", step=1, conn=conn
+    )
+    assert result.single_entity_warning is True
+    # Financial and human_development are still suppressed.
+    assert result.outputs["financial"].composite_score is None
+    assert result.outputs["human_development"].composite_score is None
+    # Ecological is exempt — composite_score computed from proximity value 1.2 → min(1.2, 2.0).
+    eco = result.outputs["ecological"]
+    assert eco.composite_score is not None
+    from decimal import Decimal
+    score = Decimal(eco.composite_score)
+    assert score == Decimal("1.2000")
+
+
+@pytest.mark.asyncio
+async def test_three_branch_dispatch_ecological_uses_boundary_strategy(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ecological framework must use the boundary proximity strategy, not percentile rank."""
+    import logging
+    boundary_row = {"constant_id": "ECOLOGICAL_CO2_PLANETARY_BOUNDARY_PPM", "value": "350"}
+    conn = _make_conn(
+        {"scenario_id": "scen-1"},
+        _snap_row(state=_SINGLE_ENTITY_ECO_STATE),
+        _entity_row(),
+    )
+    conn.fetch = AsyncMock(return_value=[boundary_row])
+
+    with caplog.at_level(logging.WARNING, logger="app.api.scenarios"):
+        result = await get_measurement_output(
+            scenario_id="scen-1", entity_id="GRC", step=1, conn=conn
+        )
+
+    # No [SIM-INTEGRITY] warning for ecological — it has a registered strategy.
+    sim_warnings = [r for r in caplog.records if "[SIM-INTEGRITY]" in r.message]
+    assert not any("ecological" in w.message for w in sim_warnings)
+    assert result.outputs["ecological"].composite_score is not None
+
+
+@pytest.mark.asyncio
+async def test_ecological_composite_null_when_no_active_boundary_constants(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ecological composite_score is None when no boundary constants are active.
+
+    conn.fetch returns [] (no constants seeded) — _boundary_proximity_strategy
+    cannot validate temporal availability and emits [SIM-INTEGRITY] WARNING per indicator.
+    """
+    import logging
+    conn = _make_conn(
+        {"scenario_id": "scen-1"},
+        _snap_row(state=_SINGLE_ENTITY_ECO_STATE),
+        _entity_row(),
+    )
+    conn.fetch = AsyncMock(return_value=[])  # no active constants
+
+    with caplog.at_level(logging.WARNING, logger="app.api.scenarios"):
+        result = await get_measurement_output(
+            scenario_id="scen-1", entity_id="GRC", step=1, conn=conn
+        )
+
+    assert result.outputs["ecological"].composite_score is None
 
 
 def test_multiframework_output_default_single_entity_warning_is_false() -> None:

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -414,9 +414,10 @@ endpoints:
     path: "/scenarios/{scenario_id}/measurement-output"
     summary: >
       Multi-framework measurement output for one entity at one step.
-      ADR-005 Decision 2. Groups entity attributes by measurement_framework tag.
-      Untagged attributes default to "financial". ECOLOGICAL and GOVERNANCE
-      return composite_score=null with a note until those modules are implemented.
+      ADR-005 Decision 2, Amendment 3. Groups entity attributes by measurement_framework tag.
+      Untagged attributes default to "financial". ECOLOGICAL uses boundary proximity
+      normalization [0.0, 2.0] (Decision M8-3). GOVERNANCE returns null (deferred M9,
+      Decision M8-4).
     auth: none
     path_params:
       scenario_id: {type: string}
@@ -449,8 +450,10 @@ endpoints:
             composite_score:
               type: "string|null"
               description: >
-                Decimal as string. Mean percentile rank across entities at this step.
-                null for unimplemented frameworks (ecological, governance at M4).
+                Decimal as string. Framework-dependent: [0.0, 1.0] percentile rank for
+                financial and human_development; [0.0, 2.0] boundary proximity for ecological
+                (1.0 = at boundary, cap 2.0 for display). null for governance (deferred M9)
+                and for financial/human_development in single-entity scenarios.
             indicators:
               type: object
               description: "dict[attribute_key, QuantitySchema] — attributes tagged to this framework"
@@ -477,15 +480,18 @@ endpoints:
           type: boolean
           default: false
           description: >
-            True when the snapshot contains exactly one entity. In that case,
-            composite_score is null for all implemented frameworks because
-            percentile rank is meaningless with a population of one.
-            composite_score being 1.0 for a single entity conveys no information
-            — this flag prevents silent misinterpretation. Issue #193.
+            True when the snapshot contains exactly one entity. composite_score is
+            null for financial and human_development (percentile rank is meaningless
+            with a population of one). Ecological is exempt — boundary proximity is
+            physically meaningful for a single entity (ADR-005 Amendment 3 Decision M8-2).
+            Issue #193.
       status_404: "Scenario not found; or no snapshot at step; or entity not in snapshot"
-    db_reads: [scenarios, scenario_state_snapshots, simulation_entities, mda_thresholds]
+    db_reads: [scenarios, scenario_state_snapshots, simulation_entities, mda_thresholds, simulation_reference_constants]
     notes:
-      - "composite_score computation: mean percentile rank across all entities in the snapshot for each indicator"
+      - "composite_score dispatch: ecological uses boundary proximity normalization (min(v/b,2.0) or min(v,2.0), capped at 2.0); financial and human_development use mean percentile rank. ADR-005 Amendment 3 Decision M8-3."
+      - "ecological composite_score range [0.0, 2.0]: 1.0 = at boundary; >1.0 = boundary exceeded; 2.0 = display cap only"
+      - "governance returns composite_score=null — GovernanceModule deferred to M9 (ADR-005 Amendment 3 Decision M8-4)"
+      - "ecological is exempt from single_entity_warning suppression — boundary proximity meaningful for single entity (Decision M8-2)"
       - "financial framework includes all untagged attributes (backward-compat rule)"
-      - "ecological and governance always return composite_score=null at M4"
-      - "composite_score is also null when single_entity_warning=true — percentile rank requires ≥2 entities"
+      - "composite_score is null when single_entity_warning=true for financial and human_development — percentile rank requires ≥2 entities"
+      - "db_reads includes simulation_reference_constants for ecological effective-at-simulation-time boundary constant query"


### PR DESCRIPTION
## Summary

- **Issue #312 — Alembic migrations:** `c1a4e7f2d9b3` adds `confidence_tier` column to `simulation_reference_constants`; `d2b5f8a3e6c4` seeds MDA thresholds for `planetary_boundary_co2_proximity` and `planetary_boundary_land_use_proximity` (floor 1.0, `gte`, WARNING severity)
- **Issue #313 — Strategy dispatch refactor:** `_compute_composite_score` is now `async` with `db_connection` + `scenario_timestep` params; three-branch dispatch (`_COMPOSITE_STRATEGIES` → `_PERCENTILE_RANK_VALIDATED_FRAMEWORKS` → `[SIM-INTEGRITY]` WARNING fallback); `_boundary_proximity_strategy` averages proximity scores capped at 2.0; `_ECOLOGICAL_MANDATORY_NOTE` → `_ECOLOGICAL_MANDATORY_NOTE_TEMPLATE` with `{n_indicators}` slot; ecological exempt from single-entity composite suppression (Decision M8-2)
- **Issue #314 — EcologicalModule expansion:** stock-path proximity computation from `entity.attributes`; `planetary_boundary_co2_proximity = min(co2_ppm/350, 2.0)` (tier 2, effective 2009-09-24); `planetary_boundary_land_use_proximity = min(index, 2.0)` (tier 3, effective 2023-09-13, **no division by 0.25** — double-normalization prevention per Decision M8-6); temporal guard emits `[SIM-INTEGRITY]` WARNING when timestep precedes `effective_from`

Implements ADR-005 Amendment 3 Decisions M8-1, M8-2, M8-3, M8-6. Closes #312, #313, #314.

## Test plan

- [x] 795 unit tests pass (`python -m pytest tests/unit/ -q`)
- [x] `ruff check` clean on all modified files
- [x] New tests in `test_ecological_module.py`: four-case CO2 proximity (below/at/above/cap), land-use no-division assertion, temporal guard test, absent-attribute WARNING test
- [x] New tests in `test_measurement_output.py`: ecological exempt from single-entity guard, boundary strategy routing, composite None when no active constants
- [x] Existing note tests updated: `_ECOLOGICAL_MANDATORY_NOTE_TEMPLATE` replaces `_ECOLOGICAL_MANDATORY_NOTE`; five old Amendment B tests replaced with five Amendment 3 template tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)