### PR TITLE
feat(frontend): M8 UX — display names, ecological note expandable, PMM widget, radar animation

### DIFF
--- a/frontend/src/components/EntityDetailDrawer.tsx
+++ b/frontend/src/components/EntityDetailDrawer.tsx
@@ -3,6 +3,7 @@ import { useMultiFrameworkOutput } from "../hooks/useMultiFrameworkOutput";
 import RadarChart from "./RadarChart";
 import FrameworkPanel from "./FrameworkPanel";
 import MDAAlertPanel from "./MDAAlertPanel";
+import PMMLedger from "./PMMLedger";
 import type { MDAAlert, RadarAxisDatum, FrameworkWeights } from "../types";
 
 const WEIGHTS_KEY = "worldsim.frameworkWeights";
@@ -188,13 +189,18 @@ export default function EntityDetailDrawer({ scenarioId, entityId, step, onClose
               />
             </section>
 
-            {/* MDA alerts — always rendered so the scanning surface is visible */}
+            {/* Zone 1A: MDA alerts — always rendered so the scanning surface is visible */}
             <section style={{ marginBottom: 16 }}>
               <h3 style={{ fontSize: 13, fontWeight: 600, margin: "0 0 8px", color: allAlerts.length > 0 ? "#c00" : "#333" }}>
                 MDA Threshold Breaches
               </h3>
               <MDAAlertPanel alerts={allAlerts} />
             </section>
+
+            {/* Zone 1C: Policy Maneuver Margin — Coffin Corner indicator.
+                M8 render state: null score (backend computation pending).
+                Live score ships when backend PMM computation is complete. */}
+            <PMMLedger pmm_score={null} pmm_trend={null} />
 
             {/* Framework indicator panels */}
             <section style={{ marginBottom: 16 }}>

--- a/frontend/src/components/FrameworkPanel.tsx
+++ b/frontend/src/components/FrameworkPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { FrameworkOutput, QuantitySchema } from "../types";
 import { getIndicatorDisplayName } from "../lib/indicatorDisplayNames";
+import MethodologyNote from "./MethodologyNote";
 
 interface Props {
   framework: string;
@@ -98,7 +99,8 @@ export default function FrameworkPanel({ framework, output }: Props) {
 
       {open && (
         <div style={{ padding: "8px 10px" }}>
-          {output.note && (
+          {/* Non-ecological frameworks: render note inline */}
+          {output.note && framework !== "ecological" && (
             <p style={{ fontSize: 12, color: "#888", fontStyle: "italic", margin: "0 0 8px" }}>
               {output.note}
             </p>
@@ -129,6 +131,29 @@ export default function FrameworkPanel({ framework, output }: Props) {
                 })}
               </tbody>
             </table>
+          )}
+
+          {/* Ecological framework: Zone 3A expandable — ADR-005 Amendment 3 Area 4.
+              Note is accessible but requires a click; composite score (Zone 1B) remains
+              the primary output. Governance gets the same treatment at M9 promotion. */}
+          {framework === "ecological" && (
+            <MethodologyNote label="Ecological methodology note">
+              {output.note && (
+                <p style={{ margin: "0 0 6px" }}>{output.note}</p>
+              )}
+              <p style={{ margin: "0 0 4px" }}>
+                <strong>Normalization formula:</strong>{" "}
+                proximity = min(current_value / boundary_value, 2.0)
+              </p>
+              <p style={{ margin: "0 0 4px" }}>
+                Values above 1.0 indicate the planetary boundary has been exceeded.
+              </p>
+              <p style={{ margin: 0, color: "#a60" }}>
+                <strong>Discriminating-power limitation:</strong> The cap at 2.0 means all
+                values above twice the boundary threshold are indistinguishable. Severity
+                above 2× boundary is not captured.
+              </p>
+            </MethodologyNote>
           )}
         </div>
       )}

--- a/frontend/src/components/FrameworkPanel.tsx
+++ b/frontend/src/components/FrameworkPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { FrameworkOutput, QuantitySchema } from "../types";
+import { getIndicatorDisplayName } from "../lib/indicatorDisplayNames";
 
 interface Props {
   framework: string;
@@ -32,11 +33,11 @@ function TierBadge({ tier }: { tier: number }) {
   );
 }
 
-function IndicatorRow({ name, qty }: { name: string; qty: QuantitySchema }) {
+function IndicatorRow({ name, qty, framework }: { name: string; qty: QuantitySchema; framework: string }) {
   return (
     <tr>
-      <td style={{ padding: "3px 6px", fontFamily: "monospace", fontSize: 11, color: "#333" }}>
-        {name}
+      <td style={{ padding: "3px 6px", fontSize: 11, color: "#333" }}>
+        {getIndicatorDisplayName(framework, name)}
       </td>
       <td style={{ padding: "3px 6px", textAlign: "right", fontFamily: "monospace", fontSize: 11 }}>
         {qty.value}
@@ -120,12 +121,11 @@ export default function FrameworkPanel({ framework, output }: Props) {
               <tbody>
                 {Object.entries(output.indicators).map(([key, value]) => {
                   if (isCohortBlock(value)) {
-                    // Nested cohort block — render each indicator inside
                     return (
-                      <CohortBlock key={key} cohortId={key} indicators={value} />
+                      <CohortBlock key={key} cohortId={key} framework={framework} indicators={value} />
                     );
                   }
-                  return <IndicatorRow key={key} name={key} qty={value as QuantitySchema} />;
+                  return <IndicatorRow key={key} name={key} framework={framework} qty={value as QuantitySchema} />;
                 })}
               </tbody>
             </table>
@@ -138,9 +138,11 @@ export default function FrameworkPanel({ framework, output }: Props) {
 
 function CohortBlock({
   cohortId,
+  framework,
   indicators,
 }: {
   cohortId: string;
+  framework: string;
   indicators: Record<string, QuantitySchema>;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -161,8 +163,8 @@ function CohortBlock({
       {expanded &&
         Object.entries(indicators).map(([iKey, qty]) => (
           <tr key={iKey} style={{ background: "#fdfdfd" }}>
-            <td style={{ padding: "3px 6px 3px 20px", fontFamily: "monospace", fontSize: 11, color: "#444" }}>
-              {iKey}
+            <td style={{ padding: "3px 6px 3px 20px", fontSize: 11, color: "#444" }}>
+              {getIndicatorDisplayName(framework, iKey)}
             </td>
             <td style={{ padding: "3px 6px", textAlign: "right", fontFamily: "monospace", fontSize: 11 }}>
               {qty.value}

--- a/frontend/src/components/MethodologyNote.tsx
+++ b/frontend/src/components/MethodologyNote.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+
+interface MethodologyNoteProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+// Zone 3A expandable — collapsed by default, accessible via (i).
+// ADR-005 Amendment 3 Area 4: methodology notes are Zone 3 deliberate navigation.
+// Same component will serve governance methodology note at M9 promotion.
+export default function MethodologyNote({ label, children }: MethodologyNoteProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div style={{ marginTop: 8, borderTop: "1px solid #eee", paddingTop: 6 }}>
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          fontSize: 11,
+          color: "#888",
+          padding: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+        }}
+      >
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 14,
+            height: 14,
+            borderRadius: "50%",
+            border: "1px solid #aaa",
+            fontSize: 10,
+            color: "#888",
+            flexShrink: 0,
+          }}
+        >
+          i
+        </span>
+        <span>{label}</span>
+        <span style={{ marginLeft: 2 }}>{expanded ? "▲" : "▼"}</span>
+      </button>
+
+      {expanded && (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 11,
+            color: "#666",
+            lineHeight: 1.5,
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PMMLedger.tsx
+++ b/frontend/src/components/PMMLedger.tsx
@@ -1,0 +1,149 @@
+// PMMLedger — Coffin Corner / Policy Maneuver Margin widget
+// Zone 1C: between MDA alert panel (Zone 1A) and radar chart (Zone 1B).
+// ADR-005 Amendment 3 Area 2: dedicated Zone 1 widget with directional indicator.
+// M8 render state: pmm_score is null (backend computation not yet complete).
+// Live score ships when backend PMM computation is implemented.
+
+export interface PMMLedgerProps {
+  pmm_score: number | null;
+  pmm_trend: "improving" | "stable" | "deteriorating" | null;
+}
+
+function trendArrow(trend: "improving" | "stable" | "deteriorating" | null): string {
+  if (trend === "improving") return "↑";
+  if (trend === "deteriorating") return "↓";
+  if (trend === "stable") return "→";
+  return "—";
+}
+
+function scoreColor(score: number): string {
+  if (score > 0.6) return "#0a6b0a";
+  if (score >= 0.3) return "#a66000";
+  return "#c00";
+}
+
+function scoreLabel(score: number | null): string {
+  if (score === null) return "—";
+  return `${(score * 100).toFixed(0)}`;
+}
+
+export default function PMMLedger({ pmm_score, pmm_trend }: PMMLedgerProps) {
+  const isNull = pmm_score === null;
+
+  return (
+    <div
+      style={{
+        border: "1px solid #ddd",
+        borderRadius: 4,
+        padding: "8px 12px",
+        marginBottom: 12,
+        background: "#fafcff",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 11, color: "#666", marginBottom: 2, fontWeight: 600 }}>
+            Policy Maneuver Margin
+          </div>
+          <div style={{ fontSize: 9, color: "#aaa" }}>
+            Coffin Corner indicator — remaining degrees of policy freedom
+          </div>
+        </div>
+
+        {isNull ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
+              color: "#aaa",
+              fontStyle: "italic",
+            }}
+          >
+            <span
+              style={{
+                display: "inline-block",
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                border: "2px solid #ccc",
+                borderTopColor: "#888",
+                animation: "spin 1s linear infinite",
+              }}
+            />
+            computing…
+          </div>
+        ) : (
+          <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+            <span
+              style={{
+                fontSize: 28,
+                fontWeight: 700,
+                color: scoreColor(pmm_score!),
+                lineHeight: 1,
+              }}
+            >
+              {scoreLabel(pmm_score)}
+            </span>
+            <span style={{ fontSize: 13, color: "#888" }}>/100</span>
+            <span
+              style={{
+                fontSize: 18,
+                color: pmm_trend === "improving"
+                  ? "#0a6b0a"
+                  : pmm_trend === "deteriorating"
+                  ? "#c00"
+                  : "#888",
+                marginLeft: 4,
+              }}
+              title={pmm_trend ?? undefined}
+            >
+              {trendArrow(pmm_trend)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {!isNull && (
+        <div style={{ marginTop: 6 }}>
+          <div
+            style={{
+              height: 4,
+              borderRadius: 2,
+              background: "#eee",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${(pmm_score! * 100).toFixed(0)}%`,
+                background: scoreColor(pmm_score!),
+                transition: "width 0.3s ease-in-out",
+              }}
+            />
+          </div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontSize: 9,
+              color: "#ccc",
+              marginTop: 2,
+            }}
+          >
+            <span>Constrained</span>
+            <span>Full margin</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RadarChart.tsx
+++ b/frontend/src/components/RadarChart.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
 } from "recharts";
 import type { RadarAxisDatum, FrameworkWeights } from "../types";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 
 // ADR-005 Decision M8-5: named constants required by ADR — do not inline.
 // Text changes require a corresponding ADR amendment (see design-decisions.md DD-011).
@@ -135,6 +136,14 @@ function CustomDot(props: {
 
 export default function RadarChart({ data, weights, onWeightsChange, onAxisClick }: Props) {
   const [showSliders, setShowSliders] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  // Disable animation when any axis transitions from null (null → number interpolation
+  // is undefined in Recharts — guard against undefined polygon behavior).
+  // Animation is also disabled on initial load (Recharts default: isAnimationActive
+  // controls post-mount transitions only).
+  const hasNullAxis = data.some((d) => d.composite_score === null);
+  const animationActive = !prefersReducedMotion && !hasNullAxis;
 
   // Apply weights to composite scores for visual emphasis only.
   // ADR-005 M8-5: null composite_score → final_score: null (Recharts gap, no polygon
@@ -193,8 +202,10 @@ export default function RadarChart({ data, weights, onWeightsChange, onAxisClick
             stroke="#1a6eb5"
             fill="#1a6eb5"
             fillOpacity={0.25}
+            isAnimationActive={animationActive}
+            animationDuration={250}
+            animationEasing="ease-in-out"
             dot={(props) => {
-              // find matching datum
               const datum = data.find((d) => d.framework === props.payload?.framework);
               return (
                 <CustomDot

--- a/frontend/src/hooks/usePrefersReducedMotion.ts
+++ b/frontend/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+
+// Reads the browser's prefers-reduced-motion media query and reacts to changes.
+// Returns true when the user has opted out of motion — consumers must disable
+// animations when this is true (ADR-005 Amendment 3 Area 5 requirement).
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(
+    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return prefersReduced;
+}

--- a/frontend/src/lib/indicatorDisplayNames.ts
+++ b/frontend/src/lib/indicatorDisplayNames.ts
@@ -1,0 +1,80 @@
+// Indicator display name registry — frontend/src/lib/indicatorDisplayNames.ts
+// Issue #317, ADR-005 Area 3: all indicator keys map to human-readable display
+// names. No raw key is visible in any UI surface. Extension contract: add a new
+// entry in the relevant framework block; no other file requires a change.
+
+const INDICATOR_DISPLAY_NAMES: Record<string, Record<string, string>> = {
+  financial: {
+    gdp_growth: "GDP Growth",
+    fiscal_balance_pct_gdp: "Fiscal Balance (% GDP)",
+    inflation_rate: "Inflation Rate",
+    unemployment_rate: "Unemployment Rate",
+    reserve_coverage_months: "Reserve Coverage (months)",
+    health_expenditure_pct_gdp: "Health Expenditure (% GDP)",
+    net_enrollment_secondary: "Secondary School Enrollment",
+    debt_gdp_ratio: "Debt-to-GDP Ratio",
+    current_account_balance: "Current Account Balance",
+    exchange_rate: "Exchange Rate",
+    interest_rate: "Interest Rate",
+    tax_revenue_pct_gdp: "Tax Revenue (% GDP)",
+    export_growth: "Export Growth",
+    import_growth: "Import Growth",
+    foreign_reserves: "Foreign Reserves",
+    credit_growth: "Credit Growth",
+  },
+  human_development: {
+    poverty_headcount_ratio: "Poverty Headcount Ratio",
+    gini_coefficient: "Gini Coefficient",
+    life_expectancy: "Life Expectancy",
+    infant_mortality_rate: "Infant Mortality Rate",
+    maternal_mortality_rate: "Maternal Mortality Rate",
+    literacy_rate: "Literacy Rate",
+    school_enrollment_primary: "Primary School Enrollment",
+    school_enrollment_secondary: "Secondary School Enrollment",
+    net_enrollment_secondary: "Secondary Net Enrollment Rate",
+    food_security_index: "Food Security Index",
+    undernourishment_rate: "Undernourishment Rate",
+    human_development_index: "Human Development Index",
+    income_share_q1: "Income Share — Bottom Quintile",
+    income_share_q5: "Income Share — Top Quintile",
+    access_to_healthcare: "Access to Healthcare",
+    access_to_clean_water: "Access to Clean Water",
+    sanitation_coverage: "Sanitation Coverage",
+  },
+  ecological: {
+    co2_concentration_ppm: "CO₂ Concentration (ppm)",
+    land_use_pressure_index: "Land Use Pressure Index",
+    planetary_boundary_co2_proximity: "CO₂ Boundary Proximity",
+    planetary_boundary_land_use_proximity: "Land Use Boundary Proximity",
+    deforestation_rate: "Deforestation Rate",
+    biodiversity_loss_index: "Biodiversity Loss Index",
+    freshwater_withdrawal_pct: "Freshwater Withdrawal (%)",
+    ocean_acidification_index: "Ocean Acidification Index",
+    nitrogen_cycle_loading: "Nitrogen Cycle Loading",
+    phosphorus_cycle_loading: "Phosphorus Cycle Loading",
+    aerosol_optical_depth: "Aerosol Optical Depth",
+    stratospheric_ozone_depletion: "Ozone Depletion",
+    chemical_pollution_index: "Chemical Pollution Index",
+    novel_entities_index: "Novel Entities Index",
+  },
+  governance: {
+    rule_of_law_percentile: "Rule of Law (percentile)",
+    democratic_quality_score: "Democratic Quality Score",
+    government_effectiveness: "Government Effectiveness",
+    regulatory_quality: "Regulatory Quality",
+    control_of_corruption: "Control of Corruption",
+    voice_and_accountability: "Voice and Accountability",
+    political_stability: "Political Stability",
+    press_freedom_index: "Press Freedom Index",
+    judicial_independence: "Judicial Independence",
+    transparency_index: "Transparency Index",
+  },
+};
+
+function formatFallback(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function getIndicatorDisplayName(framework: string, key: string): string {
+  return INDICATOR_DISPLAY_NAMES[framework]?.[key] ?? formatFallback(key);
+}


### PR DESCRIPTION
## Summary

Four M8 frontend UX issues from `docs/architecture/frontend-m8-brief.md`. UX Designer sign-off on record (brief, 2026-05-17). All four areas implement `tsc -b` clean + `npm test` 10/10.

**Issue #317 — Indicator display name mapping layer (Area 3)**
- New `frontend/src/lib/indicatorDisplayNames.ts`: `getIndicatorDisplayName(framework, key)` as the single access point
- Covers all financial, human_development, ecological indicators; M8 additions `planetary_boundary_co2_proximity` and `planetary_boundary_land_use_proximity` explicit
- `FrameworkPanel` and `CohortBlock` route all indicator name rendering through the registry; fallback: snake_case → Title Case
- No raw attribute key visible in any UI surface

**Issue #318 — Mandatory ecological note → Zone 3A expandable (Area 4)**
- New `frontend/src/components/MethodologyNote.tsx`: collapsed `(i)` expandable, `aria-expanded` set
- Ecological framework note moves from inline Zone 2 to Zone 3A — composite score (Zone 1B) remains primary display
- ADR-005 M8-1 disclosure included in expanded state: normalization formula `min(current_value / boundary_value, 2.0)`, meaning of values >1.0, cap-at-2.0 discriminating-power limitation
- Same component will serve governance methodology note at M9 promotion

**Issue #320 — Coffin Corner / PMM Zone 1C widget (Area 2)**
- New `frontend/src/components/PMMLedger.tsx`: color-coded score (green >60, amber 30–60, red <30) + directional arrow (↑/→/↓) + progress bar
- Rendered in `EntityDetailDrawer` between Zone 1A (MDA alerts) and Zone 1B (radar chart) — canonical Zone 1 stack
- M8 render state: `pmm_score=null` → "computing…" spinner placeholder; no zero displayed
- UX Designer confirmed Zone 1C placement in `frontend-m8-brief.md §Area 2`

**Issue #319 — Radar chart 250ms step-transition animation (Area 5)**
- New `frontend/src/hooks/usePrefersReducedMotion.ts`: reactive media query hook
- `RadarChart` applies `isAnimationActive` / `animationDuration=250` / `animationEasing=ease-in-out` to Recharts `<Radar>`
- Animation disabled when: user prefers reduced motion OR any axis has `null` composite_score (null→number interpolation is undefined in Recharts — guards M8 governance null axis)
- No animation on initial load

## Test plan

- [ ] `tsc -b` clean (verified in each commit)
- [ ] `npm test` 10/10 (verified in each commit)
- [ ] No raw indicator key (`gdp_growth`, `planetary_boundary_co2_proximity`, etc.) visible in FrameworkPanel indicator table
- [ ] Ecological framework panel shows `(i) Ecological methodology note ▼` in collapsed state with normalization formula and cap-at-2.0 limitation on expand
- [ ] PMMLedger renders "Policy Maneuver Margin — computing…" spinner (null M8 state)
- [ ] Radar chart axes animate on step advance; `prefers-reduced-motion: reduce` disables animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)