### PR TITLE
fix(dev): Python 3.12 Docker image rebuild — startup version guard, CONTRIBUTING docs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 12):
+if sys.version_info < (3, 12):  # noqa: UP036 — operational guard for stale Docker images
     raise RuntimeError(
         f"Python 3.12+ required; running {sys.version}. "
         "Rebuild the Docker image: docker compose build api"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,14 @@ deferred until authentication is introduced in Milestone 3.
 """
 from __future__ import annotations
 
+import sys
+
+if sys.version_info < (3, 12):
+    raise RuntimeError(
+        f"Python 3.12+ required; running {sys.version}. "
+        "Rebuild the Docker image: docker compose build api"
+    )
+
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -115,6 +115,11 @@ PostGIS is not required for Milestone 1 (simulation engine only). Skip this
 step if working on simulation logic, skip to Step 4.
 
 ```bash
+# Build the API image first — required after a fresh clone or any Dockerfile change.
+# The codebase uses Python 3.12 syntax (PEP 695 type aliases); a stale image
+# built on an earlier Python version will fail to start with SyntaxError.
+docker compose build api
+
 # Start local services with Docker
 docker compose up -d db redis
 


### PR DESCRIPTION
## Problem

Closes #332.

The `worldsim-api` container image was stale — built when the Dockerfile specified `python:3.11-slim`. The Dockerfile and CI already target `python:3.12-slim`. The `type CompositeStrategy = Callable[...]` PEP 695 type alias in `app/api/scenarios.py` requires Python 3.12+ and produced a `SyntaxError` on the stale 3.11 image, silently killing all uvicorn workers and returning 404 for every request.

## Changes

- **`backend/app/main.py`**: startup version guard — if Python < 3.12, raises `RuntimeError` with a clear message (`Rebuild the Docker image: docker compose build api`) rather than a cryptic 404
- **`docs/CONTRIBUTING.md`**: documents `docker compose build api` as the required first Docker step after a fresh clone or any Dockerfile change (Step 3 setup)

No change to `app/api/scenarios.py` — the PEP 695 syntax was always correct in the committed version; the workaround only lived in the working tree.

## Verification

- `docker compose build api` → rebuilt on `python:3.12-slim`
- `docker exec worldsim-api-1 python --version` → `Python 3.12.13` ✓
- `docker compose up -d` → all containers up
- `curl http://localhost:8000/api/v1/health/` → `{"status":"ok","version":"0.2.0","db":"connected"}` ✓
- `python -m pytest tests/unit/ -q` → **795 passed** ✓

## Test plan

- [ ] Verify `docker exec worldsim-api-1 python --version` returns `Python 3.12.x`
- [ ] Verify `/api/v1/health/` returns `{"status":"ok",...}`
- [ ] Verify `app/main.py` contains `sys.version_info < (3, 12)` guard
- [ ] Verify `docs/CONTRIBUTING.md` Step 3 includes `docker compose build api`
- [ ] 795 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)