### PR TITLE
chore(demo): switch TTS voice to Zoe (Enhanced)

### DIFF
--- a/frontend/tests/e2e/demo-narrated-m6.spec.ts
+++ b/frontend/tests/e2e/demo-narrated-m6.spec.ts
@@ -1,0 +1,435 @@
+/**
+ * WorldSim Stakeholder Demo — Screen-Recorded Narrated Walkthrough
+ *
+ * This is the screen-recording variant of demo.spec.ts. Every page.pause()
+ * has been replaced with a synchronous TTS call via scripts/speak.sh so the
+ * demo runs end-to-end without human input, suitable for recording.
+ *
+ * ── RECORDING MODE ───────────────────────────────────────────────────────────
+ *
+ * Before recording:
+ *   1. Start the full stack: docker compose up (or ./scripts/demo.sh --up)
+ *   2. Ensure Natural Earth seed data is loaded.
+ *   3. Pre-create the Greece 2010-2012 backtesting scenario via the API so
+ *      the "create" step is demonstrating the UI, not waiting on a write.
+ *   4. Open a screen recorder pointing at the browser window.
+ *   5. Run: cd frontend && npx playwright test tests/e2e/demo-narrated.spec.ts \
+ *              --config playwright.demo.config.ts --headed
+ *   6. The browser opens, TTS narrates each step, and closes when complete.
+ *      Stop the screen recorder after the browser closes.
+ *
+ * TTS voice: macOS "Samantha" at 175 WPM (scripts/speak.sh).
+ * On non-macOS, narration is printed to stdout instead of spoken — the test
+ * still completes so Linux CI runners do not error on this file.
+ *
+ * DO NOT include in CI test runs — requires a live stack. See demo.spec.ts
+ * for the @demo tag used to filter this file from CI greps.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { spawn } from "child_process";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { test, expect } from "@playwright/test";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SPEAK_SCRIPT = path.resolve(__dirname, "../../../scripts/speak.sh");
+
+// Async so the Node.js event loop stays live during TTS — Playwright's CDP
+// keepalive must not be blocked or the browser disconnects mid-narration.
+function speak(text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("bash", [SPEAK_SCRIPT, text], { stdio: "inherit" });
+    proc.on("close", (code) => {
+      code === 0 || code === null ? resolve() : reject(new Error(`speak.sh exited ${code}`));
+    });
+    proc.on("error", reject);
+  });
+}
+
+const RUN_ID = Math.random().toString(36).slice(2, 8);
+const DEMO_SCENARIO_NAME = `Greece 2010-2012 Demo — ${new Date().toISOString().slice(0, 10)}-${RUN_ID}`;
+const COMPARE_SCENARIO_NAME = `Greece Alternative — ${new Date().toISOString().slice(0, 10)}-${RUN_ID}`;
+
+// ── Pre-demo cleanup ─────────────────────────────────────────────────────────
+// Delete scenarios from previous demo runs so the panel opens clean.
+// Matches any scenario whose name starts with the demo prefixes but belongs
+// to a different RUN_ID. Uses Node's built-in fetch (Node 18+).
+test.beforeAll(async () => {
+  const API = "http://localhost:8000/api/v1";
+  let scenarios: Array<{ scenario_id: string; name: string }> = [];
+  try {
+    const res = await fetch(`${API}/scenarios`);
+    if (res.ok) scenarios = await res.json() as typeof scenarios;
+  } catch {
+    // Stack not running — test will fail later with a clearer error.
+    return;
+  }
+
+  const stale = scenarios.filter(
+    (s) =>
+      (s.name.startsWith("Greece 2010-2012 Demo") ||
+        s.name.startsWith("Greece Alternative")) &&
+      s.name !== DEMO_SCENARIO_NAME &&
+      s.name !== COMPARE_SCENARIO_NAME,
+  );
+
+  await Promise.all(
+    stale.map((s) =>
+      fetch(`${API}/scenarios/${encodeURIComponent(s.scenario_id)}`, {
+        method: "DELETE",
+      }),
+    ),
+  );
+});
+
+test(
+  "Stakeholder demo walkthrough — narrated screen recording",
+  { tag: ["@demo"] },
+  async ({ page }) => {
+    // TTS narration adds ~4 minutes of blocking speech on top of interactions.
+    // Override the 60 s config timeout for this test only.
+    test.setTimeout(15 * 60 * 1000);
+
+    // ── STEP 1: Map loads ────────────────────────────────────────────────────
+
+    await page.goto("/");
+
+    await page.waitForFunction(
+      () =>
+        typeof (window as Record<string, unknown>).__worldsim_selectEntity ===
+        "function" &&
+        typeof (window as Record<string, unknown>).__worldsim_setAttributeName ===
+        "function",
+      { timeout: 15_000 },
+    );
+
+    // Switch to gdp_growth before the first narration so the choropleth shows a
+    // continuous GDP attribute rather than the categorical economy_tier default.
+    // gdp_growth is a scenario attribute — not in the static /attributes/available
+    // list — so we use the test seam instead of page.selectOption().
+    await page.evaluate(() => {
+      (window as Record<string, (key: string) => void>).__worldsim_setAttributeName(
+        "gdp_growth",
+      );
+    });
+
+    // Create the Greece scenario via API with the backtesting fixture inputs before
+    // opening the scenarios panel — the panel fetches on mount, so it will already
+    // include this scenario when it opens in Step 2.
+    const createRes = await page.request.post("http://localhost:8000/api/v1/scenarios", {
+      data: {
+        name: DEMO_SCENARIO_NAME,
+        description: "Greece 2010-2012 IMF Program — stakeholder demo run",
+        configuration: {
+          entities: ["GRC"],
+          n_steps: 3,
+          timestep_label: "annual",
+          start_date: "2010-01-01",
+          initial_attributes: {
+            GRC: {
+              gdp_growth: {
+                value: "-0.054", unit: "ratio", variable_type: "ratio",
+                confidence_tier: 3, observation_date: "2010-04-01",
+                source_registry_id: "IMF_WEO_APR2010", measurement_framework: "financial",
+              },
+              unemployment_rate: {
+                value: "0.127", unit: "ratio", variable_type: "ratio",
+                confidence_tier: 2, observation_date: "2010-07-01",
+                source_registry_id: "EUROSTAT_LFS_2010", measurement_framework: "human_development",
+              },
+              health_expenditure_pct_gdp: {
+                value: "0.095", unit: "ratio", variable_type: "ratio",
+                confidence_tier: 2, observation_date: "2011-12-01",
+                source_registry_id: "WDI_2010", measurement_framework: "human_development",
+              },
+              net_enrollment_secondary: {
+                value: "0.991", unit: "ratio", variable_type: "ratio",
+                confidence_tier: 2, observation_date: "2011-12-01",
+                source_registry_id: "WDI_2010", measurement_framework: "human_development",
+              },
+              // IMF CR10/110 — ~2.0 months coverage at programme entry, below MDA-FIN-RESERVES floor (2.5)
+              reserve_coverage_months: {
+                value: "2.0", unit: "months", variable_type: "ratio",
+                confidence_tier: 2, observation_date: "2010-05-01",
+                source_registry_id: "IMF_CR10_110", measurement_framework: "financial",
+              },
+            },
+          },
+        },
+        scheduled_inputs: [
+          // Step 1 (2010): IMF program acceptance — €110bn ESM/IMF program, May 2010
+          {
+            step: 1, input_type: "EmergencyPolicyInput",
+            input_data: { instrument: "imf_program_acceptance", target_entity: "GRC", expected_duration: 3, program_size_gdp_ratio: "0.48" },
+          },
+          // Step 1 (2010): Fiscal spending cuts — 2010 Memorandum primary cuts
+          {
+            step: 1, input_type: "FiscalPolicyInput",
+            input_data: { instrument: "spending_change", target_entity: "GRC", sector: "government", value: "-0.08", duration_years: 1 },
+          },
+          // Step 2 (2011): Second austerity package — June 2011 Medium-Term Fiscal Strategy
+          {
+            step: 2, input_type: "FiscalPolicyInput",
+            input_data: { instrument: "spending_change", target_entity: "GRC", sector: "government", value: "-0.05", duration_years: 1 },
+          },
+          // Step 2 (2011): Deficit target — Medium-Term Fiscal Strategy 2011–2015
+          {
+            step: 2, input_type: "FiscalPolicyInput",
+            input_data: { instrument: "deficit_target", target_entity: "GRC", sector: "", value: "-0.03", duration_years: 4 },
+          },
+        ],
+      },
+    });
+    if (!createRes.ok()) {
+      throw new Error(`Greece scenario creation failed: ${createRes.status()} — ${await createRes.text()}`);
+    }
+
+    await speak(
+      "This is the application's baseline view. The choropleth shows a simulation " +
+      "attribute across entities — in this case, GDP growth rate from the most recent " +
+      "completed scenario step. Each country is colored by its simulated value. " +
+      "Click any country to open its analysis panel. " +
+      "What makes this different from a data visualization tool will become clear in a moment.",
+    );
+
+    // ── STEP 2: Open scenario panel ──────────────────────────────────────────
+
+    await page.getByRole("button", { name: /Scenarios/ }).click();
+    await page.waitForTimeout(800);
+
+    await speak(
+      "We're going to model Greece's 2010 to 2012 fiscal adjustment programme. " +
+      "This is a historical case — we know what happened. In the simulation, we " +
+      "inject the IMF programme conditions as scheduled inputs: the fiscal tightening, " +
+      "the emergency declarations, the structural conditionality. Then we advance the " +
+      "scenario step by step and observe what the model produces. " +
+      "The reason we're starting with a historical case rather than a hypothetical " +
+      "is important. It's the point of the backtesting discipline, which we'll come back to.",
+    );
+
+    // ── STEP 3: Select the pre-created Greece scenario ───────────────────────
+    // Scenario was created via API in Step 1 with fixture scheduled inputs.
+    // The panel fetched the list on mount, so the row is already visible.
+
+    const scenarioRow = page
+      .locator(".scenario-row")
+      .filter({ hasText: DEMO_SCENARIO_NAME });
+    await expect(scenarioRow).toBeVisible({ timeout: 10_000 });
+
+    await scenarioRow.getByTitle("Select as primary scenario").click();
+    // Audience needs to read the ✓ Primary checkmark before the panel closes.
+    await page.waitForTimeout(1500);
+
+    await page.getByRole("button", { name: /Scenarios/ }).click();
+    await page.waitForTimeout(600);
+
+    const nextStepBtn = page.getByRole("button", { name: /Next Step/ });
+    await expect(nextStepBtn).toBeVisible({ timeout: 10_000 });
+
+    await speak(
+      "The scenario is now the active primary scenario. The step counter shows " +
+      "zero of three steps completed. Each step corresponds to one programme year: " +
+      "2010, 2011, 2012.",
+    );
+
+    // ── STEP 4: Advance to Step 1 ────────────────────────────────────────────
+
+    await nextStepBtn.click();
+    await expect(page.getByText("Step 1 / 3")).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(1_200);
+
+    await speak(
+      "Step 1. Year 2010. The simulation applies the first year of fiscal tightening. " +
+      "Watch the choropleth — Greece shifts as the contraction propagates through the " +
+      "model's relationship graph.",
+    );
+
+    // ── STEP 5: Advance to Step 2 ────────────────────────────────────────────
+
+    await nextStepBtn.click();
+    await expect(page.getByText("Step 2 / 3")).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(1_200);
+
+    await speak(
+      "Step 2. Year 2011. The fiscal contraction compounds. In the historical case, " +
+      "Greece's GDP contracted negative 9.1 percent this year — deeper than 2010.",
+    );
+
+    // ── STEP 6: Advance to Step 3 ────────────────────────────────────────────
+
+    await nextStepBtn.click();
+    await expect(page.getByText("Step 3 / 3")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(/Complete/)).toBeVisible({ timeout: 10_000 });
+    await expect(nextStepBtn).toBeDisabled();
+    await page.waitForTimeout(1_200);
+
+    await speak(
+      "Step 3. Year 2012. Programme complete. Three years of fiscal adjustment, " +
+      "modeled across the full programme horizon. Now let's look inside.",
+    );
+
+    // ── STEP 7: Open entity drawer for Greece ────────────────────────────────
+
+    await page.evaluate(() => {
+      (window as Record<string, (id: string) => void>).__worldsim_selectEntity(
+        "GRC",
+      );
+    });
+
+    await expect(page.getByLabel("Close drawer")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("Greece", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByText("Advance the scenario at least one step to view measurement output."),
+    ).not.toBeVisible();
+
+    await expect(page.getByText("Multi-Framework Overview")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.waitForTimeout(1_500);
+
+    await speak(
+      "This panel is the primary analytical surface. What I want to draw your attention " +
+      "to first is the top of the panel. These are the Minimum Descent Altitude alerts. " +
+      "The terminology comes from aviation: an MDA is the altitude below which an aircraft " +
+      "cannot safely descend given the terrain. In this simulation, MDAs are human cost " +
+      "floors — levels below which consequences become irreversible, or where standard " +
+      "policy frameworks no longer provide protection. " +
+      "The alert fires when the simulation determines that an indicator has crossed one of " +
+      "those floors. What you are reading is not a warning about the model's own uncertainty. " +
+      "It is a finding about where the proposed path takes the population.",
+    );
+
+    // ── STEP 8: MDA alert panel called out ───────────────────────────────────
+
+    const mdaSection = page.getByRole("heading", { name: "MDA Threshold Breaches" });
+    await expect(mdaSection).toBeVisible({ timeout: 10_000 });
+
+    await page.waitForTimeout(2_000);
+
+    await speak(
+      "Read this alert as a piece of evidence: Under this fiscal adjustment path, " +
+      "this indicator crosses the critical threshold at programme year 3. " +
+      "That sentence is specific enough to cite in a negotiation. It names an indicator, " +
+      "a step, a severity level, and a population cohort. " +
+      "The finance ministry specialist is not being alarmed by the simulation. " +
+      "She is being handed a finding she can use.",
+    );
+
+    // ── STEP 9: Radar chart called out ───────────────────────────────────────
+
+    await expect(page.getByText("Multi-Framework Overview")).toBeVisible();
+
+    await page.evaluate(() => {
+      const drawer = document.querySelector('[aria-label="Close drawer"]')
+        ?.closest('div[style*="position: absolute"]');
+      if (drawer) drawer.scrollTop = 0;
+    });
+
+    await page.waitForTimeout(1_500);
+
+    await speak(
+      "Below the alert panel is the radar chart — four axes, one for each measurement " +
+      "framework the simulation tracks. Financial indicators: fiscal balance, GDP trajectory. " +
+      "Human development: poverty headcount, health system capacity. " +
+      "Ecological: currently null — that module ships in Milestone 8. " +
+      "Governance: institutional quality indicators, now live as of this milestone. " +
+      "The radar chart tells you which dimensions are under stress, supporting the " +
+      "threshold scan the alert panel just completed. " +
+      "I will be honest about what is not on the screen yet: the ecological and governance " +
+      "axes are showing preliminary values. They will show composite scores in Milestone 8.",
+    );
+
+    // ── STEP 10: Enter compare mode ──────────────────────────────────────────
+    // Create and fully advance the comparison scenario via API before opening
+    // the panel — the panel fetches on mount so it will include the scenario.
+    // Using a lighter austerity path (-4% spending, no deficit target) to
+    // produce a visible delta on the choropleth.
+
+    await page.getByLabel("Close drawer").click();
+    await page.waitForTimeout(600);
+
+    const compareCreateRes = await page.request.post("http://localhost:8000/api/v1/scenarios", {
+      data: {
+        name: COMPARE_SCENARIO_NAME,
+        description: "Greece Alternative — lighter austerity path, stakeholder demo",
+        configuration: {
+          entities: ["GRC"],
+          n_steps: 3,
+          timestep_label: "annual",
+          start_date: "2010-01-01",
+          initial_attributes: {
+            GRC: {
+              gdp_growth: {
+                value: "-0.054", unit: "ratio", variable_type: "ratio",
+                confidence_tier: 3, observation_date: "2010-04-01",
+                source_registry_id: "IMF_WEO_APR2010", measurement_framework: "financial",
+              },
+              reserve_coverage_months: {
+                value: "2.0", unit: "months", variable_type: "ratio",
+                confidence_tier: 2, observation_date: "2010-05-01",
+                source_registry_id: "IMF_CR10_110", measurement_framework: "financial",
+              },
+            },
+          },
+        },
+        scheduled_inputs: [
+          // Alternative path: lighter first-year cut (-4% vs -8%) to demonstrate
+          // delta against the primary scenario on the choropleth.
+          {
+            step: 1, input_type: "FiscalPolicyInput",
+            input_data: { instrument: "spending_change", target_entity: "GRC", sector: "government", value: "-0.04", duration_years: 1 },
+          },
+        ],
+      },
+    });
+    if (!compareCreateRes.ok()) {
+      throw new Error(`Compare scenario creation failed: ${compareCreateRes.status()} — ${await compareCreateRes.text()}`);
+    }
+    const { id: compareScenarioId } = await compareCreateRes.json() as { id: string };
+
+    // Advance the comparison scenario 3 steps via API so delta data exists.
+    for (let s = 1; s <= 3; s++) {
+      const advRes = await page.request.post(
+        `http://localhost:8000/api/v1/scenarios/${encodeURIComponent(compareScenarioId)}/advance`,
+      );
+      if (!advRes.ok()) {
+        throw new Error(`Comparison advance step ${s} failed: ${advRes.status()} — ${await advRes.text()}`);
+      }
+    }
+
+    await page.getByRole("button", { name: /Scenarios/ }).click();
+    await page.waitForTimeout(600);
+
+    const compareRow = page
+      .locator(".scenario-row")
+      .filter({ hasText: COMPARE_SCENARIO_NAME });
+    await expect(compareRow).toBeVisible({ timeout: 10_000 });
+
+    await compareRow.getByTitle("Select as comparison scenario").click();
+    await page.waitForTimeout(600);
+
+    await page.getByRole("button", { name: /Scenarios/ }).click();
+    await page.waitForTimeout(600);
+
+    await page.getByText("Compare scenarios").click();
+    await page.waitForTimeout(800);
+
+    await page.waitForTimeout(1_500);
+
+    await speak(
+      "This is the counter-proposal function. Once you have identified which terms produce " +
+      "threshold crossings, you model an alternative — the same fiscal outcome, achieved " +
+      "differently. The DeltaChoropleth shows you, geographically, where the two scenarios " +
+      "diverge. The argument becomes: This path crosses the threshold. This alternative " +
+      "achieves the same primary fiscal objective and does not. Here is the evidence for both.",
+    );
+
+    // ── Demo complete ────────────────────────────────────────────────────────
+    // Section 3 (backtesting), Section 4 (roadmap), and Section 5 (North Star)
+    // are delivered verbally or via slides. See docs/demo/stakeholder-walkthrough.md.
+  },
+);

--- a/scripts/speak.sh
+++ b/scripts/speak.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-VOICE="Samantha"
+VOICE="Zoe (Enhanced)"
 RATE=175
 
 if [[ "${1:-}" == "--list-voices" ]]; then


### PR DESCRIPTION
Switch the narrated demo TTS voice from Samantha to Zoe (Enhanced) in `scripts/speak.sh`.

Verified `say -v "Zoe (Enhanced)"` returns exit 0 on the build machine before making the change.

Also carries `frontend/tests/e2e/demo-narrated-m6.spec.ts` (the M6 spec archive, staged on the prior branch and included in the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)