### PR TITLE
chore(release): M8 formal close — CHANGELOG v0.8.0 + SESSION_STATE milestone advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,128 @@ closure ceremony defined in `docs/MILESTONE_RUNBOOK.md`.
 
 ---
 
+## v0.8.0 — Milestone 8: Ecological and Governance Frameworks (2026-05-19)
+
+### Summary
+
+Three live radar axes for the first time. Honest-null governance axis. Greece 2010–2015
+six-step scenario as the primary backtesting and demo fixture. Case B UX architecture
+verdict — rethink warranted before M9 implementation. Synthetic data framework
+consultation complete. CLAUDE.md structural refactor with satellite simulation-framework.md.
+
+### Delivered
+
+**EcologicalModule expansion (Issues #312, #313, #314 — PR #324)**
+- `_compute_composite_score()` three-branch strategy dispatch: ecological →
+  `_boundary_proximity_strategy` (boundary-normalized, absolute); financial/human_development
+  → validated percentile rank; unregistered → `[SIM-INTEGRITY]` WARNING + percentile rank fallback
+- Planetary boundary proximity indicators: `planetary_boundary_co2_proximity` (min(ppm/350, 2.0)),
+  `planetary_boundary_land_use_proximity` (min(index, 2.0) — no double-normalization per Decision M8-6)
+- `_SINGLE_ENTITY_GUARD_EXEMPT_FRAMEWORKS = frozenset({"ecological"})` — ecological exempt
+  because boundary proximity is physically meaningful for a single entity (Decision M8-2)
+- STOCK delta path contract: emit `current + elasticity_delta` (absolute level), not raw delta —
+  propagation engine replaces STOCK attributes; raw delta would corrupt all subsequent proximity
+  computations (PR #328 fix)
+- `simulation_reference_constants` table seeded: CO2 boundary 350 ppm (Rockström 2009),
+  land-use boundary 0.25 (Richardson 2023); temporal guards enforce effective_from dates
+- Migrations: `c1a4e7f2d9b3` (confidence_tier), `d2b5f8a3e6c4` (ecological MDA thresholds),
+  `b3c5d7e9f1a2` (reference constants seed)
+
+**ADR-005 Amendment 3 (Issue #218 — PR #309)**
+- Ecological Framework Completion: eight M8 decisions (M8-1 through M8-8)
+- Governs composite strategy dispatch, single-entity exemption, null axis rendering,
+  STOCK delta path contract, land-use double-normalization prevention
+
+**Greece fixture extension (Issues #284, #316 — PR #321)**
+- Steps 4–6 (2013–2015) actuals: capital controls, privatization, DIRECTION_ONLY thresholds
+- `ECOLOGICAL_COMPOSITE_DISCLOSURE` — honest disclosure of CO2-only composite for Greece
+  (land-use boundary constant effective 2023-09-13, post-dates scenario period)
+- CO2 seed: `co2_concentration_ppm = 388.0 ppm` (NOAA MLO 2010) in `initial_attributes`
+- `gdp_direction_step5_positive` moved to `deferred_thresholds` — mean-reversion channel
+  absent from MacroeconomicModule; deferred Issue #221 (M10)
+
+**Null governance axis (Issue #315 — PR #323)**
+- `RadarAxisDatum.composite_score: number | null` live on main
+- `GOVERNANCE_IN_VALIDATION_LABEL = "Governance — in validation"` (em dash — ADR-required constant)
+- `GOVERNANCE_IN_VALIDATION_TOOLTIP` — promotion criteria: 0 of 5 met at M8, target M9
+- `computeFinalScore(null, weight) → null` — honest null propagates to Recharts polygon gap
+- Null axis: dashed hollow SVG circle (`strokeDasharray="2 2"`, `fill="none"`); polygon vertex absent
+- Animation guard: `isAnimationActive = false` when any axis is null (undefined interpolation prevention)
+- DD-011 sentinel in `docs/frontend/design-decisions.md`
+- 10 Vitest tests
+
+**Frontend UX Areas 2–5 (Issues #317, #318, #319, #320 — PR #329)**
+- `INDICATOR_DISPLAY_NAMES` registry — human-readable labels for all M8 indicators
+- Zone 3A expandable ecological methodology note (`EcologicalNoteDrawer`)
+- PMM Zone 1C placeholder widget (`PolicyManoeuvreMeter`) — null at M8, live at M9
+- Radar 250ms CSS transition animation with `prefers-reduced-motion` guard
+
+**Demo scenario assembly (Issue #269 — PR #328)**
+- `build_greece_demo_scenario()` in `tests/fixtures/greece_2010_scenario.py`
+- Six steps, EcologicalModule enabled, eight scheduled programme inputs
+- 5 backtesting tests in `tests/backtesting/test_greece_m8_demo.py`
+- CLI demo: `backend/scripts/demo_greece_2010_2015.py`
+
+**Demo infrastructure (PRs #334, #338, #339, #340)**
+- `docs/process/demo-preparation-standard.md` — nine-step biennial demo cadence
+- `demo-narrated.spec.ts` — narrated Playwright spec, M8 rewrite; excluded from CI
+  via `@demo` tag and `grep: /^(?!.*@demo)/`; uses `playwright.demo.config.ts` for
+  `headless: false`, `slowMo: 800`, `--start-fullscreen` (screen-recording mode)
+- `__worldsim_selectEntity` / `__worldsim_setAttributeName` window globals — DEV-only
+  test seam in `App.tsx` (`import.meta.env.DEV` guard); bypasses WebGL canvas for
+  reliable entity selection in headless Chromium
+- Five screenshots captured: frames A–E per UX Agent brief (Issue #233)
+- TTS voice: macOS "Zoe (Enhanced)" at 175 WPM
+- Independent Review Agent: 9 findings (DEMO-001–009), 2 CRITICAL, 4 SIGNIFICANT, 3 MINOR;
+  issues #342–#350 filed; Root Cause B (drawer density) explains DEMO-002/003/005/006
+
+**UX Design Thinking work stream (PRs #354, #355, #356)**
+- UX Design Thinking Agent activated — first activation, persona added to `agents.md`
+- M8 critique: `docs/ux/design-thinking/m8-interaction-model-critique.md`
+  — core diagnosis: WorldSim is a spatial comparison tool applied to a temporal problem
+- Panel synthesis: three-agent panel (UX Designer, Development Economist, Chief Methodologist)
+  — nine cross-cutting concerns; three EL decisions required
+- First-principles derivation: `docs/ux/design-thinking/worldsim-ux-architecture-first-principles.md`
+  — **Case B verdict**: current UI inverts instrument/context relationship;
+  architecture rethink warranted before M9 implementation
+- Five M9 governing premises codified; control plane zone reserved in layout
+
+**CLAUDE.md structural refactor (Issue #359 — PR #372)**
+- `docs/architecture/simulation-framework.md` extracted (mandatory reading for all agents)
+- Platform Principle, Synthetic Data framework, UX Architectural Commitments added
+- Role-based mandatory reading table (UX, Data/Backend, Architecture, Standards/Compliance)
+- Three-mode architecture (Mode 1: Replay, Mode 2: Simulation, Mode 3: Active Control) formalised
+
+**Synthetic data framework (Issue #361 — PR #373)**
+- Chief Methodologist consultation: `docs/architecture/synthetic-data-consultation.md` (560 lines)
+- Five-method hierarchy: Bayesian > MICE > Bootstrap > structural extrapolation > structural absence
+- Three-condition meaninglessness threshold; MDA tier table (full/advisory/exploratory/none)
+- Anomaly detection: requires TSC sign-off, opt-in, Mode 3 excluded, governance indicators excluded
+- ADR-007 outline produced
+
+**M8 exit compliance (PR #380)**
+- SCAN-022: 0 violations across all M8 changes
+
+### Deferred to M9
+
+- GovernanceModule composite score — five promotion criteria not yet met (Decision M8-4);
+  null axis and validation label are the M8 resolution
+- PMM live computation — placeholder at M8; target M9
+- Mean-reversion channel — Issue #221; `gdp_direction_step5_positive` in `deferred_thresholds`
+- DEMO issues #342–#350 — re-milestoned to M9
+
+### Compliance Posture
+
+- SCAN-022 — Milestone 8 exit gate: **Clean** (0 violations)
+- ADR license status at milestone close: ADR-001 CURRENT, ADR-002 CURRENT, ADR-005 CURRENT
+  (Amendment 3 merged PR #309)
+- GovernanceModule deferred per Decision M8-4: exception recorded with single-principal
+  governance acknowledgement per CLAUDE.md §Governance
+- Known limitation: `gdp_direction_step5_positive` at step 5 — model produces −0.434 vs
+  historical +0.007; mean-reversion channel absent; deferred to M10 (Issue #221)
+
+---
+
 ## v0.3.0 — Milestone 3: Scenario Engine (2026-04-24)
 
 ### Delivered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,9 @@ This is what makes the democratization mission operationally real. A global
 south finance ministry with thin, delayed, or unreliable data can still use
 WorldSim — and the tool is honest about what it knows and what it inferred.
 
-Synthetic data framework ADR: forthcoming (Issue #361).
+Synthetic data framework: Chief Methodologist consultation complete (PR #373).
+Five-method hierarchy, three-condition meaninglessness threshold, MDA alert
+tier table. ADR-007 forthcoming.
 Confidence tier system: `docs/DATA_STANDARDS.md §Confidence Tier System`.
 
 ---
@@ -258,15 +260,17 @@ Detailed domain profiles: `docs/agents/domain-intelligence-council.md`
 
 ## What We Are Building First
 
-M0–M7 complete (v0.1.0–v0.7.0). ADRs 001–006 current. See GitHub Releases
-for full delivery history.
+M0–M8 complete (v0.1.0–v0.8.0). ADRs 001–006 current; ADR-007 forthcoming.
+See GitHub Releases for full delivery history.
 
-**Milestone 8 — Ecological and Governance Frameworks (Current)**
-- All four radar chart axes live with real data
-- Ecological Module complete; Governance Module complete
-- Coffin Corner / Policy Maneuver Margin Zone 1 indicator
-- MDA extended to ecological and governance indicators
-- End-of-milestone demo: all four radar axes simultaneously
+**Milestone 9 — Standards Foundation (Current)**
+- GovernanceModule promotion path (five criteria; target M9)
+- UX architecture rethink — Case B verdict executed; instrument cluster in
+  primary viewport; control plane zone reserved
+- User persona document (five personas, marquee acceptance cases)
+- Synthetic data framework ADR (ADR-007) — Chief Methodologist consultation
+  complete; formal ADR pending
+- Agent working agreements (15 agents; RACI chart)
 
 Each milestone is a vertical slice — working software at every stage,
 not infrastructure waiting for features.
@@ -280,30 +284,40 @@ Core deliverable: P0 technical debt resolved; compliance scan clean;
 defensive programming standards codified. See GitHub Releases for full
 delivery record.
 
-**Milestone 8 — Ecological and Governance Frameworks (Current)**
-Core deliverable: All four radar axes live; ecological and governance
-composite scores non-null for the first time.
+**Milestone 8 — Ecological and Governance Frameworks (Complete — v0.8.0)**
+Core deliverable: Three live radar axes for the first time; honest-null
+governance axis; Greece 2010–2015 six-step demo; Case B UX architecture verdict.
+
+Delivered:
+- EcologicalModule: CO2 boundary proximity (Rockström 2009 350 ppm); land-use
+  proximity; three-branch composite strategy dispatch; STOCK delta path contract
+- Governance: honest-null axis — dashed hollow dot, "Governance — in validation"
+  label, `computeFinalScore(null) → null` (GovernanceModule deferred to M9;
+  five promotion criteria not met at M8)
+- Greece 2010–2015: six-step fixture; step 5 (2014) thesis frame; CO2 seed
+  (NOAA MLO 388 ppm); ecological composite live from step 1
+- PMM Zone 1C placeholder widget (live computation deferred to M9)
+- MDA threshold system extended to ecological indicators
+- ADR-005 Amendment 3 (eight M8 decisions); SCAN-022 clean
+- Demo infrastructure: narrated Playwright spec; five thesis frames captured
+- UX Design Thinking: Case B verdict — instrument/context relationship inverted;
+  five M9 governing premises; three-mode architecture formalised
+- CLAUDE.md structural refactor; simulation-framework.md extracted
+- Synthetic data framework: Chief Methodologist consultation complete (PR #373)
+
+**Milestone 9 — Standards Foundation (Current)**
+Core deliverable: GovernanceModule promotion, UX architecture rethink executed,
+user personas, synthetic data framework ADR.
 
 Scope:
-- Ecological Module complete (planetary boundaries, natural capital depletion)
-- Governance Module complete (institutional quality, political freedom, rule of law)
-- All four radar chart axes live with real data
-- Coffin Corner indicator: Policy Maneuver Margin Zone 1 widget
-- MDA threshold system extended to ecological and governance indicators
-- ADR-005 reviewed and extended for Ecological/Governance framework coverage
-- End-of-milestone demo scenario (Greece 2010–2012 candidate)
-
-**Milestone 9 — Standards Foundation**
-Core deliverable: Canonical unit registry, field-level data certification,
-and legibility framework. STD-REVIEW-004 gaps resolved.
-
-Scope:
-- Canonical unit registry replacing `unit="dimensionless"` placeholders
-- Field-level certification chain and data admission tests
+- GovernanceModule promotion path (five criteria)
+- UX architecture rethink (Case B): instrument cluster in primary viewport;
+  control plane zone reserved; trajectory view as primary instrument
+- User persona document (five personas, marquee acceptance cases per use case)
+- Synthetic data framework ADR (ADR-007)
+- Agent working agreements and RACI chart (15 agents)
 - WGI territorial conventions documented
-- Legibility baseline audit and North Star legibility section
-- Domain Intelligence Council blind stakeholder interviews
-- M7 orphan issues triaged and closed
+- M8 DEMO issues #342–#350 re-triaged
 
 **Milestone 10 — Engine Integrity and Backtesting**
 Core deliverable: Mean-reversion channels, Ecuador backtesting case,
@@ -321,7 +335,7 @@ polished; branch protection and second governance account established.
 Core deliverable: Methodology publication and external validation;
 Technical Steering Committee formation; public launch.
 
-Full roadmap: `docs/roadmap/milestone-roadmap-m6-m8.md`
+Full roadmap: `docs/roadmap/milestone-roadmap-m6-m8.md` (M9+ roadmap pending update)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/PublicEnemage/worldsim/actions/workflows/ci.yml/badge.svg)](https://github.com/PublicEnemage/worldsim/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
-[![Release](https://img.shields.io/badge/release-v0.5.0%20M5%20complete-green)](https://github.com/PublicEnemage/worldsim/releases/tag/v0.5.0)
+[![Release](https://img.shields.io/badge/release-v0.8.0%20M8%20complete-green)](https://github.com/PublicEnemage/worldsim/releases/tag/v0.8.0)
 
 **An open-source geopolitical-economic simulation platform for governments and
 vulnerable actors navigating high-stakes decisions under uncertainty.**
@@ -47,20 +47,19 @@ not show.
 **The simulation is a structured reasoning tool, not a prediction engine.** It
 is designed to produce distributions, not point estimates — outputs carry
 confidence tiers, uncertainty bounds are quantified and displayed, and the
-model's blindspots are documented and visible. MacroeconomicModule with
-regime-dependent fiscal multipliers and a second backtesting case
-(Argentina 2001–2002) shipped in Milestone 5; full distribution propagation
-across all outputs is Milestone 6 scope.
+model's blindspots are documented and visible. Three of four measurement
+framework axes are live at Milestone 8 (financial, human development,
+ecological); governance renders as an honest-null axis pending module certification.
 
 **This tool is in active pre-release development.** The working software
-described below reflects Milestone 5. It is not yet usable for consequential
+described below reflects Milestone 8. It is not yet usable for consequential
 analysis.
 
 ---
 
 ## What's Built
 
-The working system at Milestone 5:
+The working system at Milestone 8:
 
 - **Simulation engine** — Event-driven graph in Python. The `Quantity` type
   system tracks `value: Decimal`, unit, variable type (STOCK/FLOW/RATIO/
@@ -72,48 +71,59 @@ The working system at Milestone 5:
   regime-dependent fiscal multipliers: standard multiplier (0.8) in healthy
   conditions; elevated multiplier (1.5) in depressed regimes (unemployment
   above 15%). Processes FiscalPolicyInput, MonetaryRateInput, and
-  EmergencyPolicyInput events. Validated against the Argentina 2001-2002
-  backtesting case.
+  EmergencyPolicyInput events.
+
+- **EcologicalModule** — Planetary boundary proximity scoring live at M8.
+  CO2 concentration tracked against the Rockström 2009 350 ppm boundary
+  (confidence tier 2). Land-use pressure index tracked against the Richardson
+  2023 boundary. Composite score: unweighted mean of boundary proximity scores.
+  STOCK delta path emits new absolute levels (not raw deltas) — the propagation
+  engine replaces STOCK attributes.
 
 - **Database** — PostgreSQL/PostGIS with 177 country entities loaded from
-  Natural Earth 110m boundary data, 10 attributes per entity. Five declared
-  territorial positions (Taiwan, Palestine, Kosovo, Western Sahara, Crimea)
-  are enforced by a hard-gate validator on every database INSERT.
-  `backtesting_thresholds` table holds DIRECTION_ONLY, MAGNITUDE, and
-  DISTRIBUTION_COMBINED fidelity thresholds for each historical case.
+  Natural Earth 110m boundary data. Five declared territorial positions
+  (Taiwan, Palestine, Kosovo, Western Sahara, Crimea) are enforced by a
+  hard-gate validator on every database INSERT. `backtesting_thresholds`,
+  `simulation_reference_constants` (planetary boundary values with temporal
+  guards), and `scenario_deleted_tombstones` tables.
 
-- **Backend API** — FastAPI with 16 endpoints. Float prohibition enforced
-  end-to-end: `Quantity.value` is always `Decimal` in Python and `str` at
-  the API boundary. Measurement-output endpoint surfaces a
-  `single_entity_warning` flag when composite score is not meaningful.
+- **Backend API** — FastAPI. Float prohibition enforced end-to-end:
+  `Quantity.value` is always `Decimal` in Python and `str` at the API
+  boundary. Composite score computation via framework-dispatched strategy:
+  ecological uses boundary proximity; financial and human development use
+  percentile rank. Ecological is exempt from the single-entity guard
+  (boundary proximity is physically meaningful for one country).
 
 - **Scenario engine** — Create scenarios, advance step by step, compare two
   scenarios via delta choropleth. Scenario deletion writes a tombstone record
   enabling reconstruction from first principles under the determinism guarantee.
 
 - **Backtesting fixtures** — Two validated historical cases:
-  - *Greece 2010–2012*: fiscal adjustment under the IMF/EU program;
-    DIRECTION_ONLY GDP contraction thresholds
+  - *Greece 2010–2015*: six-step fixture; fiscal adjustment under the IMF/EU
+    program; CO2 ecological trajectory live from step 1 (NOAA MLO 388 ppm
+    seed); step 5 (2014) is the thesis frame — financial partial recovery,
+    human development depressed; DIRECTION_ONLY thresholds
   - *Argentina 2001–2002*: Zero Deficit Plan spending cut and sovereign
     default; DIRECTION_ONLY GDP contraction thresholds at both steps
   Both run in CI as a build gate — a backtesting regression is a build failure.
-  DISTRIBUTION_COMBINED threshold infrastructure is in place for magnitude
-  calibration in Milestone 6.
 
 - **Human Cost Ledger** — Multi-framework measurement output across financial,
   human development, ecological, and governance dimensions simultaneously, with
   equal visual weight to financial indicators. MDA (Minimum Descent Altitude)
   threshold system fires WARNING/CRITICAL/TERMINAL alerts when indicators cross
   hard floors. Demographic cohort model produces indicators by income quintile,
-  age band, and employment sector. Note: ecological and governance composite
-  scores are null at M5 — modules are planned for M6–M7; these axes render
-  with a ⊘ indicator in the dashboard.
+  age band, and employment sector. Governance composite score is honest-null
+  at M8 — the GovernanceModule is implemented but has not yet met its five
+  promotion criteria; it renders as a dashed axis labeled "Governance — in
+  validation" rather than showing zero (which would imply governance failure).
 
 - **Frontend** — React + MapLibre GL choropleth map; scenario panel and step
   controls; EntityDetailDrawer with a four-axis radar chart, MDA alert panel,
-  and per-framework indicator tables with collapsible cohort breakdowns; delta
-  choropleth for side-by-side scenario comparison. Playwright integration test
-  suite (3/3) covers the full create→advance→drawer flow.
+  and per-framework indicator tables. Zone 3A expandable ecological methodology
+  note. PMM (Policy Maneuver Margin) Zone 1C placeholder widget. Radar 250ms
+  animation with `prefers-reduced-motion` and null-axis guards. Delta
+  choropleth for side-by-side scenario comparison. Playwright E2E suite covers
+  the full create→advance→drawer flow.
 
 ---
 
@@ -129,7 +139,10 @@ The working system at Milestone 5:
 | M3 — Scenario Engine | ✅ Complete | v0.3.0 | Scenario create/advance/compare, Greece 2010–2012 backtesting fixture, tombstones |
 | M4 — Human Cost Ledger | ✅ Complete | [v0.4.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.4.0) | DemographicModule, MDA threshold system, radar chart dashboard, schema registry |
 | M5 — Calibration and Uncertainty | ✅ Complete | [v0.5.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.5.0) | MacroeconomicModule, Argentina backtesting, DISTRIBUTION_COMBINED thresholds, Playwright suite |
-| M6 — Backtesting Coverage Expansion | 🔧 In progress | — | Five historical cases, Ecological Module initial, Governance Module initial |
+| M6 — Backtesting Coverage Expansion | ✅ Complete | v0.6.0 | EcologicalModule initial, HumanDevelopmentModule, Greece 2010–2015 fixture extension |
+| M7 — Technical Foundation | ✅ Complete | v0.7.0 | P0 technical debt resolved; compliance scan clean; defensive programming standards |
+| M8 — Ecological and Governance Frameworks | ✅ Complete | [v0.8.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.8.0) | Three live radar axes; honest-null governance; Greece 2010–2015 demo; Case B UX verdict |
+| M9 — Standards Foundation | 🔧 In progress | — | GovernanceModule promotion, UX architecture rethink, user personas, ADR-007 |
 
 Full milestone history: [`CHANGELOG.md`](CHANGELOG.md). Live issue tracker:
 [GitHub Milestones](https://github.com/PublicEnemage/worldsim/milestones).
@@ -151,13 +164,13 @@ as optional annotations on the real results.
 
 **Backtesting as epistemic discipline.** Every model relationship is validated
 against historical cases before being trusted for forward projection. Two cases
-are implemented: Greece 2010–2012 (fiscal multiplier estimation error — IMF
-assumed ~0.5, empirical ~1.5) and Argentina 2001–2002 (Zero Deficit Plan
-pro-cyclical austerity and sovereign default). Both run DIRECTION_ONLY fidelity
-thresholds in CI; DISTRIBUTION_COMBINED magnitude calibration is Milestone 6
-scope. The gap between model prediction and historical outcome is not a failure
-— it is the primary signal for improvement. Additional cases (Thailand 1997,
-Lebanon 2019–2020) are planned for Milestone 6.
+are implemented: Greece 2010–2015 (fiscal multiplier estimation error — IMF
+assumed ~0.5, empirical ~1.5; extended to six steps at M8 with ecological CO2
+trajectory live) and Argentina 2001–2002 (Zero Deficit Plan pro-cyclical
+austerity and sovereign default). Both run DIRECTION_ONLY fidelity thresholds
+in CI. The gap between model prediction and historical outcome is not a failure
+— it is the primary signal for improvement. Mean-reversion channels and
+additional backtesting cases are Milestone 10 scope.
 
 **No false precision.** Outputs are designed to be distributions over scenarios
 conditional on stated assumptions, not point forecasts about the future.
@@ -245,10 +258,10 @@ standards at every milestone exit.
 
 ## Contributing
 
-External contribution infrastructure — documentation written for non-agent
-contributors, public methodology review, and Technical Steering Committee
-formation — is a Milestone 8 deliverable. **The project is not yet ready for
-general open-source contribution.**
+External contribution infrastructure — documentation for non-agent contributors,
+public methodology review, and Technical Steering Committee formation — is
+roadmapped for M9–M13. **The project is not yet ready for general open-source
+contribution.**
 
 What is valuable now:
 

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,8 +5,8 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated:** 2026-05-19 (Issue #361 Chief Methodologist consultation complete — synthetic-data-consultation.md, five questions answered, ADR-007 outline produced)
-**Current milestone:** M8 → M9 transition — design foundation sequence in progress
+**Last updated:** 2026-05-19 (M8 formal close complete — v0.8.0 tagged and released; Issue #209 closed; CHANGELOG updated; demo recording attached)
+**Current milestone:** M9 — Standards Foundation
 
 ---
 
@@ -81,6 +81,7 @@ Twelve issues filed 2026-05-19. Must complete before M9 UX implementation begins
 
 | PR | Title | Date |
 |---|---|---|
+| v0.8.0 | GitHub Release — Milestone 8 formal close | 2026-05-19 |
 | #355 | docs(ux): M8 interaction model critique — UX Design Thinking Agent first activation (closes #353) | 2026-05-18 |
 | #354 | docs(process): add UX Design Thinking Agent to agents.md (closes #353) | 2026-05-18 |
 | #352 | chore(state): update SESSION_STATE.md — PR #351 open (IR issues #342–#350 + M8 walkthrough) | 2026-05-18 |
@@ -126,7 +127,7 @@ All Horizon:Immediate issues are now closed. M8 feature-complete.
 | Decision | Context | Status |
 |---|---|---|
 | GovernanceModule promotion path | Deferred from M8 demo — five criteria not yet met — target M9 | Decided: deferred |
-| M8 formal close / M9 kickoff | Issue #370 filed — gate: retrospective + compliance scan + Socratic Agent TEST + #209 exit checklist | Pending — see #370 |
+| M8 formal close / M9 kickoff | Issue #370 filed — gate: retrospective + compliance scan + Socratic Agent TEST + #209 exit checklist | Complete ✅ — v0.8.0 released, Issue #209 closed |
 | M9 UX architecture — EL Decision 1 (north-star formulation) | Five options incl. per-mode tasks (Mode 1: trajectory reconstruction; Mode 2: threshold-safe path construction; Mode 3: real-time steering). Load-bearing for all hierarchy changes. | Pending — see #364, gates after #363 |
 | M9 UX architecture — EL Decision 2 (viewport architecture) | Wrong question was Zone 1B vs 1C; correct question is primary viewport vs. drawer. Gates after #363 Gap 2. | Pending — see #364, gates after #363 |
 | M9 UX architecture — EL Decision 3 (comparison mode conditional) | Conditional (single→divergence timeline; multi→DeltaChoropleth) vs. supplemental. Mode 3 always temporal. | Pending — see #364, gates after #363 |
@@ -137,6 +138,7 @@ All Horizon:Immediate issues are now closed. M8 feature-complete.
 
 | Decision | Rationale | Date |
 |---|---|---|
+| M8 formal close complete | All six exit gates satisfied; v0.8.0 tagged and released; Issue #209 closed; CHANGELOG updated; demo recording attached to GitHub release | 2026-05-19 |
 | Issue #361 Chief Methodologist consultation — synthetic data framework | docs/architecture/synthetic-data-consultation.md (41.5k chars, 560 lines). Five questions answered. Method hierarchy: Bayesian > MICE > Bootstrap > structural extrapolation > structural absence. Three-condition meaninglessness threshold. MDA tier table (full/advisory/exploratory/none). Anomaly detection requires TSC sign-off, opt-in, Mode 3 excluded, governance indicators excluded. ADR-007 outline produced. PR #373. | 2026-05-19 |
 | Issue #359 implemented — CLAUDE.md structural refactor | docs/architecture/simulation-framework.md created (7.7k chars); CLAUDE.md reduced to 28,375 chars; role-based mandatory reading table added; three new principle sections (Platform Principle, Synthetic Data, UX Architectural Commitments); three-mode architecture referenced. PR #372. | 2026-05-19 |
 | Design foundation sequence filed — 12 issues #359–#370 | PM Agent: EXECUTE — all 12 design foundation issues filed in dependency order. Issues #359–#363 are Immediate horizon; #364–#369 are Near-Term; #370 (M8 formal close) is Immediate and runs in parallel. | 2026-05-19 |


### PR DESCRIPTION
## Summary

- Adds `v0.8.0` entry to `CHANGELOG.md` — eight work streams documented with full delivery detail, compliance posture, and known limitations
- Advances `SESSION_STATE.md` current milestone from `M8 → M9 transition` to `M9 — Standards Foundation`; marks M8 formal close `Complete ✅`; records M8 formal close in Key Decisions table
- Updates `README.md` to M8 state — release badge, body text, "What's Built" section (rewritten), milestone table (M6/M7/M8 added), Contributing section, backtesting paragraph
- Updates `CLAUDE.md` — synthetic data ADR note (Issue #361 closed); "What We Are Building First" to M9 current; Milestone Roadmap marks M8 Complete (v0.8.0) with accurate delivered scope and M9 as Current

## README changes

- Badge: `v0.5.0 M5 complete` → `v0.8.0 M8 complete`
- Body: M5 language → M8 state; ecological/governance status corrected
- "What's Built": full M8 rewrite — EcologicalModule, honest-null governance axis, Greece 2010–2015, Zone 3A, PMM placeholder, updated Playwright note
- Milestone table: adds M6 ✅ v0.6.0, M7 ✅ v0.7.0, M8 ✅ v0.8.0, M9 🔧 In progress
- Contributing: "Milestone 8 deliverable" → "roadmapped for M9–M13"
- Backtesting: Greece 2010–2012 → 2010–2015; "Milestone 6 scope" → "Milestone 10 scope"

## CLAUDE.md changes

- Synthetic data note: "forthcoming (Issue #361)" → consultation complete, ADR-007 forthcoming
- "What We Are Building First": M0–M7 → M0–M8 complete; M8 Current → M9 Current with accurate scope
- Milestone Roadmap: M8 "(Current)" → "(Complete — v0.8.0)" with accurate delivered/deferred scope; M9 updated with design-foundation-sequence scope

## Test plan

- [ ] README milestone table is internally consistent (all rows present, versions correct)
- [ ] CLAUDE.md Milestone Roadmap matches SESSION_STATE §Architectural State for M8 delivered items
- [ ] No stale M5/M6 references remain in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)