### PR TITLE
docs(ux): UX document updates — EL Decisions 1/2/3 (north-star, information-hierarchy, user-journeys)

### DIFF
--- a/docs/ux/information-hierarchy.md
+++ b/docs/ux/information-hierarchy.md
@@ -6,26 +6,36 @@
 > and progressive disclosure. When a proposed component placement conflicts
 > with this hierarchy, this document governs — not implementation convenience.
 >
-> Last updated: 2026-05-11 (founding document; M8 scope; extends
-> `north-star.md` and `user-journeys.md`).
+> Last updated: 2026-05-21 (EL Decisions 1/2/3 — per-mode cognitive tasks,
+> instrument cluster as primary viewport, comparison mode conditional,
+> control plane reserved zone; closes Issue #365).
 
 ---
 
 ## Governing Principle
 
-The information hierarchy exists to serve one task: threshold alarm detection
-under cognitive load. This is the primary cognitive task established in
-`north-star.md §Primary Cognitive Task`.
+The information hierarchy exists to serve the primary cognitive task of the
+active mode: trajectory reconstruction and historical pattern recognition
+(Mode 1), threshold-safe path construction (Mode 2), or real-time steering
+within human cost constraints (Mode 3). Per-mode cognitive tasks are
+established in `north-star.md §Primary Cognitive Tasks by Mode`.
 
 Every hierarchy decision is evaluated against this question:
 
-> Does this placement help the specialist answer "has any indicator crossed a
-> floor?" in under 30 seconds with people in the room and a clock running?
+> Does this placement allow the user to complete the primary cognitive task
+> of the active mode within the time constraints of that mode — under
+> 30 seconds in Mode 3, under 5 minutes in Mode 2 preparation, without
+> navigating away from the primary viewport in any mode?
 
-Elements that serve this question directly occupy primary position. Elements
-that support it after the first question is answered occupy secondary position.
-Elements that require exploration occupy tertiary position — accessible, but
-not competing with the primary scan.
+Elements that serve the active mode's primary task directly occupy primary
+position. Elements that support it once the initial question is answered
+occupy secondary position. Elements that require exploration occupy tertiary
+position — accessible, but not competing with the primary scan.
+
+**Foundational rule (EL Decision 2):** The primary viewport is the instrument
+cluster. The choropleth is a navigable context surface. The EntityDetailDrawer
+is a detail and methodology surface. No primary instrument lives inside the
+drawer or requires choropleth interaction to reach.
 
 ---
 
@@ -59,95 +69,156 @@ it supports the argument-building phase but is never the first stop.
 
 ## Dashboard View Hierarchy (SCENARIO_VIEW / SCENARIO_COMPLETE)
 
+### Persistent Header — Entity Selector
+
+Above all zones, always visible regardless of mode, drawer state, or interaction
+state. This element does not belong to any zone — it is always present.
+
+In a single-entity scenario, shows the entity name. In a multi-entity scenario,
+shows a selector that allows the user to switch entity without navigating away
+from the instrument cluster. The entity selector is never inside a drawer, never
+behind a navigation action.
+
+Requirements:
+- Visible and functional in Mode 1, Mode 2, and Mode 3 without any scroll or
+  navigation action
+- In multi-entity scenarios, the selector must list all entities in the scenario
+  with their current-step composite score visible per entity
+- Entity switch must update all four Zone 1 instruments atomically — not one at
+  a time, not with separate loading states per instrument
+
+---
+
 ### Zone 1 — Primary
 
-**1A — MDA Alert Panel** *(highest weight)*
+**1A — Trajectory View** *(highest weight — primary instrument)*
 
-The alert panel is the first element the user's eye must reach. Positioned
-at the top of the entity detail surface (above all framework tabs) when the
-EntityDetailDrawer is open. Positioned as a persistent overlay or banner
-in the main view when the drawer is closed and alerts are active.
+Four composite score curves (financial, human development, ecological, governance)
+on a shared step axis. This is the primary Zone 1 instrument. It makes
+multi-framework trajectory comparison legible at a glance in all three modes.
+
+The trajectory view is positioned in the primary viewport — not inside the
+EntityDetailDrawer, not behind a tab or navigation action.
+
+Requirements:
+- Four framework curves visible simultaneously on a single shared step axis
+- Shared step axis with mode-specific annotation:
+  - Mode 1: step index + calendar date + event label for SIGNIFICANT steps
+    (mandatory fixture fields: `effective_from`, `step_event_label`,
+    `step_significance`; see Gap 1B, PR #390)
+  - Mode 2: step index + projected calendar date
+  - Mode 3: step index + projected calendar date; baseline ghost curves
+    (50% opacity, 1px stroke) appear automatically when the first control
+    input is applied
+- MDA floor lines overlaid as horizontal dashed threshold lines on each curve
+- Mode 3 live A/B: baseline curves (50% opacity, 1px) and active curves
+  (100% opacity, 2px) simultaneously; divergence fill region (5–10% opacity)
+  where they separate — automatic, no user action required to invoke
+- Policy inflection markers (blue) and shock event markers (orange vertical
+  line across all curves) per Gap 3 cross-layer visual system (PR #390)
+- Step transitions animated 200–300ms ease-in-out
+- Trajectory view occupies the primary viewport at all supported viewport
+  sizes (desktop 1280×800 minimum, tablet 1024×768 minimum) without requiring
+  any navigation
+
+**1B — MDA Alert Panel** *(co-primary)*
+
+Threshold crossing alerts from the trajectory computation. Positioned within
+the primary viewport (instrument cluster) — not inside the EntityDetailDrawer.
+In Mode 3, alerts fire in real time as control inputs propagate.
 
 Requirements:
 - Top 1–3 alerts visible without scrolling at all supported viewports
-- Each alert row must show: severity (color + label), indicator name,
-  step index, and top affected cohort — all readable without expanding
+- Each alert row: severity (color + label), indicator name, step index, top
+  affected cohort — all readable without expanding
 - Severity ordering: TERMINAL before CRITICAL before WARNING
 - Framework source visible per alert (financial / human_development /
-  ecological / governance) — this is new at M8 and must appear without
-  requiring the user to open a framework tab
+  ecological / governance) without requiring a framework tab to open
+- Mode 3 causal attribution per alert: "Caused by: [policy input description]"
+  or "Caused by: [shock type]" or "Caused by: Multiple inputs (see trajectory
+  view)" — this attribution is the negotiating instrument
+- Alert tense is mode-dependent: historical fact (Mode 1), projected warning
+  (Mode 2), live update (Mode 3)
 
-**1B — Radar Chart** *(secondary primary weight)*
+**1C — PMM Widget** *(co-primary)*
 
-Positioned immediately below the alert panel or alongside it on
-wide viewports. The radar chart is the visual argument that a country's
-situation cannot be understood through one lens. At M8, with all four
-axes live for the first time, this is the most visually significant
-element the tool has ever displayed.
-
-Requirements:
-- All four axes visible simultaneously — no tabs, no toggles, no "click to
-  see ecological"
-- Axis labels must be human-readable: "Financial", "Human Development",
-  "Ecological", "Governance" — not framework enum values
-- Each axis shows the composite score value as a number alongside the
-  visual position on the axis
-- Step-to-step transitions must be animated (200–300ms ease-in-out) so
-  the user sees the deformation happen, not just the result
-- When all four composite scores are non-null (M8 target state), the chart
-  fills visibly — a partially-filled chart (null axes showing as zero) is
-  not acceptable as the default; null axes must be visually distinct from
-  zero-value axes
-
-**1C — Coffin Corner / Policy Maneuver Margin Indicator** *(M8 addition)*
-
-New at M8. The Policy Maneuver Margin is the most conceptually powerful
-output WorldSim produces — it tells the specialist how much room remains
-before the corrective maneuver window closes. It must not appear as a row
-in a table or a footnote in an indicator list.
+The Policy Maneuver Margin: remaining degrees of policy freedom before the
+corrective maneuver window closes.
 
 Requirements:
 - Dedicated visual treatment: not a row in FrameworkPanel, not a subtitle
-  under the radar chart — a distinct widget with its own visual identity
-- Must show direction (is the margin growing or shrinking since last step?)
-  as a directional indicator (arrow or trend line), not just a current value
-- Positioned in Zone 1 — visible without scrolling when EntityDetailDrawer
-  is open at minimum supported viewport
-- Label must be legible to a non-specialist on first read: "Policy
-  Maneuver Margin" is acceptable; "coffin_corner_index" is not
+  under another element — a distinct widget with its own visual identity
+- Direction indicator (arrow or trend line) showing whether margin is growing
+  or shrinking since the last step
+- Mode-specific header label: "Policy Maneuver Margin — historical" (Mode 1),
+  "Policy Maneuver Margin — projected" (Mode 2), "Policy Maneuver Margin —
+  current" (Mode 3); in Mode 3, the trend arrow updates after each control
+  input computation
+- Visible without scrolling at minimum supported viewport
+- Label legible to a non-specialist: "Policy Maneuver Margin" acceptable;
+  "coffin_corner_index" is not
+
+**1D — Four-Framework Current Position** *(co-primary)*
+
+The four composite score values at the current step — a quick-read number
+readout serving as the flight instrument analog to an altimeter cluster.
+
+Requirements:
+- All four values visible simultaneously — no tabs, no toggles
+- Human-readable framework labels: "Financial", "Human Development",
+  "Ecological", "Governance"
+- Current step value shown as a number per framework
+- Null axes visually distinct from zero-value axes (distinct treatment, e.g.,
+  dashed border, "—" label) — a null governance score and a zero governance
+  score are categorically different
+- Updates atomically when a step advances or a control input is applied
 
 ---
 
 ### Zone 2 — Secondary
 
-**2A — Framework Panels** (financial, human_development, ecological, governance)
+**2A — Radar Chart**
 
-The four FrameworkPanel tabs contain the indicator detail behind each
-radar axis. The user reaches Zone 2 after Zone 1 has confirmed which
-framework is under stress — she then opens the relevant tab to examine
-specific indicators, confidence tiers, and cohort breakdowns.
+The four-dimensional deformation view: composite scores for all four frameworks
+plotted on a radar axis at the current step. Provides the visual argument that
+a country's situation cannot be understood through one lens. Moved from Zone 1
+to Zone 2 by EL Decision 2 — the four-framework current position readout (1D)
+provides the Zone 1 quick-read; the radar chart provides the Zone 2 visual depth.
 
-Requirements at M8:
-- Indicator display names must be human-readable (see Gap 1 from UX
-  Designer M8 recommendations): `rule_of_law_percentile` → "Rule of Law
-  (global percentile)", `co2_concentration_ppm` → "CO2 Contribution (ppm)"
-- Confidence tier must be visible per indicator row without expanding —
-  it is an argument quality signal the specialist needs to cite
+Requirements:
+- All four axes visible simultaneously — no tabs, no toggles, no "click to
+  see ecological"
+- Axis labels human-readable: "Financial", "Human Development", "Ecological",
+  "Governance"
+- Each axis shows the composite score value alongside the visual position
+- Step-to-step transitions animated 200–300ms ease-in-out so the user sees
+  the deformation happen, not just the result
+- Null axes visually distinct from zero-value axes — a partially-filled chart
+  with null axes showing as zero is not acceptable
+- Accessible via one scroll or one tab action from Zone 1; does not require
+  opening a separate drawer or navigating away from the instrument cluster
+
+**2B — Framework Panels** (financial, human_development, ecological, governance)
+
+The four FrameworkPanel tabs contain the indicator detail behind each radar
+axis. The user reaches 2B after Zone 1 has confirmed which framework is under
+stress — she then opens the relevant tab to examine specific indicators,
+confidence tiers, and cohort breakdowns.
+
+Requirements:
+- Indicator display names human-readable: `rule_of_law_percentile` → "Rule of
+  Law (global percentile)", `co2_concentration_ppm` → "CO2 Contribution (ppm)"
+- Confidence tier visible per indicator row without expanding — argument quality
+  signal the specialist needs to cite; in Mode 3, confidence tier badges are
+  interactive (tapping opens the methodology note for that indicator)
 - Cohort breakdown (income quintile, age band) visible within Zone 2 by
   expanding an indicator row — one click, not a separate navigation
 
-**2B — Step Timeline / Scenario Progress**
-
-Shows the step-by-step trajectory of key indicators. Accessed via scroll
-in the drawer or a dedicated trajectory tab. The specialist uses this to
-identify at which step a deterioration began — required for the
-argument ("this threshold is crossed in year 3 of the program").
-
 **2C — Distribution Bands** (M5 forward)
 
-Uncertainty bands on individual indicators. Visible in Zone 2 after
-the alert panel has confirmed which indicators to examine. The band
-width is the evidence behind the distribution-source alert.
+Uncertainty bands on individual indicators. Visible in Zone 2 after the alert
+panel has confirmed which indicators to examine. The band width is the evidence
+behind the distribution-source alert.
 
 ---
 
@@ -199,20 +270,83 @@ Zone 3: System status, data source registry, configuration.
 
 ---
 
-## COMPARE_VIEW Hierarchy (two scenarios active)
+## COMPARE_VIEW Hierarchy
+
+The comparison surface is context-dependent. EL Decision 3 (Issue #364)
+establishes a conditional rule across all three modes.
+
+**Mode 2 — Single-entity scenarios:**
+
+Zone 1: Divergence timeline — two scenario trajectory curves (proposed path
+and counter-proposal) on the shared step axis. The primary question is "at
+which step does path A diverge from path B, and which thresholds does path A
+cross that B avoids?" The delta alert panel shows which MDA alerts fire in
+the primary scenario but not the comparison scenario (or vice versa).
+
+Zone 2: Side-by-side indicator tables for the two scenarios, used in
+preparation mode to build the detailed counter-proposal argument.
+
+Zone 3: Methodology disclosures for both scenarios.
+
+The DeltaChoropleth is not the Zone 1 surface for single-entity Mode 2
+comparisons — geographic divergence is not the primary question when both
+scenarios model the same entity.
+
+**Mode 2 — Multi-entity scenarios:**
 
 Zone 1: DeltaChoropleth — geographic divergence between scenarios, color-coded
-by direction and magnitude. The primary question in compare mode is "where do
-these scenarios diverge?" and the answer must be visible immediately.
+by direction and magnitude. The primary question in multi-entity compare mode
+is "which entities diverge and in which direction?" and the answer must be
+visible immediately.
 
-Zone 2: EntityDetailDrawer for the primary scenario — MDA alerts for the
-entity of interest in the primary scenario, showing which alerts fire in the
-primary but not the comparison (or vice versa).
+Zone 2: Entity detail for the entity of interest in the primary scenario —
+MDA alerts showing which alerts fire in the primary but not the comparison.
 
-Zone 3: Side-by-side indicator tables for the two scenarios. Used in preparation
-mode to build the detailed counter-proposal argument.
+Zone 3: Side-by-side indicator tables for the entities of interest.
+
+**Mode 3 — Active Control:**
+
+The Mode 3 live A/B comparison is automatic — not invoked. No COMPARE_VIEW
+state is entered. The instrument cluster's trajectory view always shows
+baseline ghost curves (50% opacity) alongside active trajectory curves (100%
+opacity) from the moment the first control input is applied. See Zone 1 / 1A
+requirements for the visual specification.
+
+The DeltaChoropleth has no role in Mode 3 comparisons. The comparison in
+active control is always temporal (baseline trajectory vs. live modified
+trajectory), not geographic.
 
 ---
+
+## Control Plane Reserved Zone
+
+A dedicated screen zone is reserved in the primary viewport layout for the Mode 3
+control plane from M9 onward. This zone is reserved before Mode 3 is built —
+not retrofitted when Mode 3 arrives (CLAUDE.md Governing Premise 5).
+
+**Location:** A persistent zone adjacent to the trajectory view. In Mode 1 and
+Mode 2, this zone is empty — it holds no content and is not collapsed or hidden;
+it is reserved. In Mode 3, it is populated with the control plane.
+
+**Minimum Mode 3 zone content (established M9, sized from this requirement):**
+
+The reserved zone must be large enough to accommodate simultaneously:
+- Policy instruments form: control input type selector, parameter field(s),
+  step selector, "Apply policy input" button, applied inputs history list
+  (blue visual treatment throughout)
+- Scenario shocks form: step selector, shock type selector from taxonomy,
+  "Inject scenario shock" button, injected shocks history list (orange visual
+  treatment throughout)
+
+Both forms must be visible simultaneously in Mode 3 — the visual separation
+between policy inputs (blue) and exogenous shocks (orange) is an epistemic
+requirement, not a layout preference. The zone sizing must accommodate both
+without requiring scroll to see either form.
+
+**Sizing constraint:** The control plane zone must not reduce the trajectory view
+below a minimum legible width at the desktop minimum viewport (1280×800). The
+trajectory view is the primary instrument — the control plane is secondary. If
+the zone sizes conflict, the trajectory view wins.
 
 ## M8 Hierarchy Decisions
 
@@ -228,6 +362,24 @@ by implementation convenience.
 | Indicator display names are human-readable | Display name mapping layer in frontend | Demo and negotiation-room legibility; internal keys are implementation detail |
 | Radar chart step transitions are animated | 200–300ms ease-in-out | The deformation across steps is the visual argument; it must be observable, not just the result |
 | MDA alert framework source visible in Zone 1 | Shown per alert row without expanding | At M8, ecological and governance alerts fire for the first time; the specialist must know which framework without opening a tab |
+
+---
+
+## M9 Hierarchy Decisions
+
+These decisions supersede or extend M8 decisions where they conflict. EL Decision
+numbers refer to decisions recorded on Issue #364.
+
+| Decision | Ruling | Rationale |
+|---|---|---|
+| Trajectory view is Zone 1, not Zone 2 (EL Decision 2) | Trajectory view in primary viewport; not in drawer or behind tab | The primary cognitive task across all three modes requires multi-framework trajectory comparison as the first read — it cannot be behind a click |
+| Radar chart moves from Zone 1 to Zone 2 (EL Decision 2) | Accessible via one scroll or tab; not on initial view | Zone 1 four-framework current position (1D) provides the quick-read; the radar chart provides the spatial depth behind it — it is Zone 2 evidence, not a Zone 1 scan surface |
+| EntityDetailDrawer demoted to detail/methodology surface (EL Decision 2) | No primary instrument lives inside the drawer | Primary instruments are in the instrument cluster viewport. The drawer provides indicator detail, cohort breakdowns, and methodology notes — it is the Zone 2/3 expansion surface |
+| Entity selector is a persistent header element (EL Decision 2) | Always visible, never inside a drawer or behind navigation | In multi-entity scenarios, the user must be able to switch entity without leaving the primary viewport — a flight simulator cannot require navigating away to switch which aircraft is on instruments |
+| COMPARE_VIEW Zone 1 is mode-and-context-conditional (EL Decision 3) | Single-entity Mode 2 → divergence timeline; multi-entity Mode 2 → DeltaChoropleth; Mode 3 → automatic live A/B (no COMPARE_VIEW entered) | The primary comparison question differs: multi-entity asks "where do these entities diverge?"; single-entity asks "at which step does path A cross a threshold B avoids?"; Mode 3 comparison is always temporal, never geographic |
+| DeltaChoropleth deprecated for single-entity and Mode 3 (EL Decision 3) | DeltaChoropleth used only in multi-entity Mode 2 | Geographic divergence is not the primary question in single-entity comparison or in Mode 3 active control; using it in these contexts answers the wrong question |
+| Control plane zone reserved from M9 onward (Premise 5, PR #390) | Empty reserved zone in Mode 1 and Mode 2; populated in Mode 3 | A zone retrofitted at Mode 3 introduction will be undersized; a zone sized from M9 will accommodate both policy instrument and scenario shock forms simultaneously |
+| Mode 3 live A/B is automatic, not invoked (EL Decision 3, Gap 4) | Ghost baseline curves appear at first applied control input; no toggle required | In Mode 3, "baseline vs. active" is always the comparison frame — it is not an optional view; making it user-invoked would require an action at the moment when cognitive load is highest |
 
 ---
 

--- a/docs/ux/north-star.md
+++ b/docs/ux/north-star.md
@@ -3,8 +3,8 @@
 > Owned by the UX Designer Agent. This document is the authoritative source
 > for who we are building for, what they are trying to do, and what the
 > experience must make possible. All frontend decisions are evaluated against
-> it. Last updated: 2026-05-02 (open questions resolved; user journeys in
-> `docs/ux/user-journeys.md`).
+> it. Last updated: 2026-05-21 (EL Decisions 1/2/3 — per-mode cognitive tasks,
+> viewport architecture, comparison mode conditional; closes Issue #365).
 
 ---
 
@@ -24,6 +24,11 @@ signal in minutes, not hours.
 They are operating under cognitive load. There are people in the room,
 a document on the table, and a clock running. The tool must work for
 them in that context, not in a calm research environment.
+
+Five personas — from finance ministry specialist to academic economist to
+institutional decision-maker — provide concrete instantiations of this
+canonical user across roles, entry states, and scenarios:
+`docs/ux/personas.md`.
 
 ---
 
@@ -51,83 +56,134 @@ These questions were open at M4 close. The answers are binding UX
 constraints for all M5 distribution visualization work and for M6
 frontend decisions.
 
-### 1. Primary Cognitive Task
+### 1. Primary Cognitive Tasks by Mode
 
-**Question:** When the user scans a scenario output showing distributions
-across multiple indicators, what is her primary cognitive task — threshold
-alarm detection, trajectory tracking, or cross-scenario comparison?
+**Question:** What is the user's primary cognitive task at the tool — and
+does it vary across the three interaction modes (Replay, Simulation,
+Active Control)?
 
-**Answer: Threshold alarm detection.**
+**Answer: Yes — per-mode cognitive tasks, not a single universal formulation.**
 
-The canonical user's purpose at the tool is to determine whether a
-proposed fiscal adjustment path crosses human cost thresholds. This is
-a binary question: has any indicator crossed a floor, or is any
-indicator's distribution at material risk of crossing one?
+The M4-era answer ("threshold alarm detection") correctly identified a
+central user task but applied it uniformly across contexts where the
+cognitive task differs. EL Decision 1 (Issue #364) supersedes it. The
+three-mode per-task formulation was validated against all thirteen
+marquee acceptance cases across primary, secondary, and tertiary tiers.
 
-Trajectory tracking (where is this heading?) and cross-scenario
-comparison (how does A differ from B?) are both present in the
-workflow, but they are activated *after* the threshold scan. The user
-first asks: is anything in the danger zone? Only then does she ask:
-when does it get there, and would an alternative path avoid it?
+**Mode 1 (Replay) — Trajectory reconstruction AND historical pattern recognition**
 
-**Design implication for M5 distribution visualization:**
+Both tasks are valid primary cognitive tasks within Mode 1; both must be
+served by the instrument cluster. The academic economist (Persona 4) needs
+trajectory reconstruction: does the simulation reproduce what actually
+happened? The political advisor (Persona 3) needs historical pattern
+recognition: did the trajectory follow a recognizable pre-collapse pattern?
+These are distinct tasks with a shared instrument. The step axis annotation
+requirement — calendar dates and event labels on SIGNIFICANT steps — is the
+precondition for serving both tasks. Without it, the step axis serves the
+finance ministry specialist while remaining opaque to the political advisor
+and the institutional decision-maker.
 
-The MDA alert panel is the primary visual element. The radar chart is
-secondary (it shows which dimensions are under stress, supporting the
-threshold scan). The delta choropleth is tertiary (activated only after
-the user has identified what to compare).
+**Mode 2 (Simulation) — Threshold-safe path construction**
 
-Distribution bands on individual indicators must be legible as
-proximity-to-threshold information — not statistical detail. The
-ADR-006 composite alert rule (ci_lower < floor AND mean ≤ 1.5 × floor)
-directly operationalizes this task: it fires when the distribution
-places material probability mass below the floor, before the mean
-has crossed. The alert must be the first thing the user reads.
+The preparation task: which policy path achieves the required fiscal outcome
+while keeping all four framework indicators above their Minimum Descent
+Altitudes? The user is not passively scanning for alarms — she is
+constructing a defensible path. The comparison surface (divergence timeline
+for single-entity scenarios) shows which path crosses fewer thresholds, not
+just whether a specific path crosses one.
+
+**Mode 3 (Active Control) — Real-time steering within human cost constraints**
+
+Active negotiation: proposed terms applied as control inputs in real time,
+trajectory effects propagate and update the instrument cluster. The live A/B
+comparison — baseline ghost curves at 50% opacity versus active trajectory —
+makes the effect of each proposed term immediately legible. The MDA alert
+panel causal attribution ("caused by: −2% spending cut applied at step 3")
+is the negotiating instrument: it distinguishes threshold crossings caused by
+the proposed policy from those caused by the underlying scenario trajectory.
+
+**Design implication (EL Decisions 1 and 2):**
+
+The primary viewport is the instrument cluster. The trajectory view (four
+composite score curves on a shared step axis) is the primary Zone 1 instrument
+— the frame that makes all three per-mode cognitive tasks legible. The MDA
+alert panel and PMM widget are co-primary Zone 1 elements within the instrument
+cluster. The entity selector is a persistent header element, visible without
+navigation in all three modes.
+
+The choropleth is a navigable context surface, not a primary viewport element.
+The EntityDetailDrawer is demoted to detail and methodology surface — primary
+instruments are in the instrument cluster viewport, not inside the drawer.
+
+The M4-era design implication — "the MDA alert panel is the primary visual
+element; the radar chart is secondary" — correctly identified the alert panel's
+primacy but placed it inside the drawer. The alert panel occupies Zone 1 of the
+instrument cluster viewport directly. Distribution bands on individual indicators
+must remain legible as proximity-to-threshold information — the ADR-006 composite
+alert rule (ci_lower < floor AND mean ≤ 1.5 × floor) operationalizes this.
+
+Full hierarchy specification: `docs/ux/information-hierarchy.md`.
 
 ---
 
-### 2. Preparation Mode vs. Active Negotiation Mode
+### 2. Preparation, Active Negotiation, and Historical Analysis
 
-**Question:** Does the user's relationship to the tool differ between a
-preparation session (the night before) and an active negotiation session
-(tablet open on the table, 90 seconds to respond)?
+**Question:** Does the user's relationship to the tool differ across the three
+interaction modes — and how does this map to real-world usage contexts?
 
-**Answer: Yes — the information hierarchy differs; the underlying
-data requirement and primary cognitive task do not.**
+**Answer: Yes — the cognitive task and information hierarchy both differ
+across modes. The instrument architecture and underlying analytical standard
+do not.**
 
-**What changes:**
+**Three modes, three contexts:**
 
-In preparation mode, the specialist is building the argument. She has
-time to explore. She needs the full distribution, the cohort breakdown,
-the ability to advance step by step and observe where thresholds are
-crossed, and the ability to compare proposals. Every panel is relevant.
-The four-framework radar chart, MDA severity progression, and cohort-level
-indicator tables are all primary surfaces.
+*Mode 2 (Simulation) — Preparation: building the case*
 
-In active negotiation mode, the specialist is citing the argument
-she already built. She needs one thing in seconds: the threshold
-crossing she identified the night before — indicator, step, severity,
-cohort. She is not re-running the analysis. She is reading a conclusion
-that must be immediately visible.
+The specialist is at her desk the night before. She has time to explore.
+Primary cognitive task: threshold-safe path construction — which consolidation
+path keeps all four framework indicators above their MDAs? Every panel is
+relevant: full distribution bands, cohort breakdown, the comparison divergence
+timeline between the proposed path and the counter-proposal. The trajectory
+view shows where the proposed path fails; the divergence timeline confirms
+the counter-proposal avoids it.
 
-**What stays the same:**
+*Mode 3 (Active Control) — Active negotiation: steering in real time*
 
-The primary cognitive task is identical: threshold alarm detection.
-The MDA alert panel is the primary entry point in both modes — in
-preparation it is the scanning surface; in negotiation it is the
-recall surface. The underlying analytical standard — defensible
-argument, quantified uncertainty, pre-calibration disclosure — does
-not change between modes.
+The specialist is in the room, tablet open. The IMF proposes a modified
+term. She applies it as a control input. The trajectory updates: live A/B
+comparison shows the effect of the proposed term against the baseline she
+built the previous night. The MDA alert panel causal attribution confirms
+whether the proposed term is what causes the threshold crossing. She is not
+re-exploring — she is navigating the terrain she already mapped, with
+the proposed modification injected directly.
 
-**Design implication for M6:**
+*Mode 1 (Replay) — Historical analysis: trajectory reconstruction*
 
-Progressive disclosure achieves both modes without separate screens.
-The alert panel surfaces the headline finding (severity + indicator +
-step + top affected cohort) in the negotiation-mode scan. Clicking
-through opens the full preparation-mode detail. The M6 information
-hierarchy decision should ensure the top 1–3 MDA alerts are readable
-without scrolling in any viewport likely to be used at a negotiating
-table.
+The academic economist or political advisor examines how a trajectory actually
+unfolded. Primary cognitive tasks: trajectory reconstruction (does the model
+reproduce what happened?) and historical pattern recognition (did the
+trajectory follow a recognizable pre-crisis pattern?). The demonstrative
+entry state — Aicha Mbaye oriented in 60 seconds without driving the tool —
+is also a Mode 1 context: a pre-loaded, completed historical fixture navigated
+by someone other than the driver.
+
+**What stays the same across all three modes:**
+
+The instrument cluster is always the primary viewport. The step axis is always
+the shared coordinate system. The four-framework measurement is always
+simultaneous — no framework is hidden while another is examined. The underlying
+analytical standard — defensible argument, quantified uncertainty,
+pre-calibration disclosure — does not change between modes.
+
+**Design implication:**
+
+Progressive disclosure achieves all three modes without separate screens.
+The instrument cluster serves all three cognitive tasks when the correct mode
+is active. The mode indicator — always visible in the primary viewport header —
+tells both the user and any observer which cognitive task is active. The top
+1–3 MDA alerts must be readable without scrolling at all supported viewports.
+
+Journeys for each mode: `docs/ux/user-journeys.md`.
 
 ---
 

--- a/docs/ux/user-journeys.md
+++ b/docs/ux/user-journeys.md
@@ -5,7 +5,9 @@
 > the reference for information hierarchy decisions and for evaluating whether
 > a proposed UI change supports or obstructs the user's task.
 >
-> Last updated: 2026-05-02 (initial journeys; two primary flows documented).
+> Last updated: 2026-05-21 (EL Decisions 1/2/3 — Journey A Step 3 separated;
+> Journey B extended for Mode 3; Journey C Mode 3 active control added;
+> Journey D demonstrative entry state added; closes Issue #365).
 
 ---
 
@@ -54,19 +56,34 @@ modeled ("IMF Draft 2026-04") for recall during active negotiation.
 
 ---
 
-**Step 3 — Advance: run through the program horizon**
+**Step 3 — Advance and inspect: run through the program horizon**
 
-She advances the scenario step by step. At each step she can observe the
-choropleth update and see how the attribute distribution shifts across the
-country's regions or indicators.
+Step 3 has two distinct sub-actions that must not be conflated.
 
-*Information need:* The step counter ("Step N / M") must confirm each advance
-completed. The choropleth color shift gives a geographic first-pass signal
-before she drills into entity detail.
+*Sub-action 3a — Advance:* She clicks the advance control. The simulation
+computes the next step. The step counter increments ("Step N / M"). The
+instrument cluster updates atomically — trajectory view curves extend to the
+new step, the four-framework current position readout updates, any new MDA
+alerts appear in the alert panel. This sub-action is complete when the step
+counter confirms the advance.
+
+*Sub-action 3b — Inspect:* She reads the instrument cluster at the new step.
+The trajectory view shows whether any composite score is trending toward an
+MDA floor. The alert panel shows whether any threshold has been crossed at this
+step. She does not need to open the EntityDetailDrawer to complete the scan —
+the Zone 1 instruments provide the pass/fail read.
+
+The choropleth (geographic context) also updates at each step and is accessible
+for geographic distribution inspection, but it is not the primary scan surface.
+The trajectory view is.
+
+She repeats 3a → 3b for each step through the full program horizon before
+proceeding to Step 4.
 
 *Note (M5 context):* At M5, with pre-calibration epistemic bands, each step
-now produces a distribution. The choropleth continues to render the point
-estimate. The distribution detail is in the entity drawer.
+produces a distribution. The trajectory view renders point estimates. The
+distribution detail (band width, alert_source) is accessible via the alert panel
+and framework panels.
 
 ---
 
@@ -249,23 +266,30 @@ not as a caveat that invalidates the finding.
 
 ---
 
-**Step 5 (branching) — Real-time scenario advance**
+**Step 5 (branching) — Real-time control input via Mode 3**
 
 If the IMF proposes a specific modification that differs from what was
-prepared, and the specialist judges that 2–3 minutes is available to
-run a new scenario:
+prepared, and the specialist judges that 2–3 minutes are available:
 
-- She opens the panel, creates a scenario with the modified parameters,
-  selects it, advances 3 steps, and opens the entity drawer.
+She switches to Mode 3 (Active Control). She applies the proposed
+modification as a control input — not as a new scenario. The baseline
+ghost curves (her prepared scenario) remain visible at 50% opacity. The
+active trajectory updates immediately to reflect the proposed term. The
+MDA alert panel causal attribution confirms whether the proposed term is
+what causes the threshold crossing she identified the night before.
 
-*Information need:* The scenario creation and 3-step advance must be
-completable in under 3 minutes with the scenario panel open. Each advance
-button click must respond within 5–10 seconds (acceptable latency for a
-live simulation advance).
+*Information need:* The mode switch and first control input must be
+completable in under 60 seconds. Control input propagation must update
+the instrument cluster within 5–10 seconds. The live A/B comparison
+(baseline ghost vs. active) must be legible at tablet font sizes without
+additional interaction.
 
-*This is a stretch use case.* The primary negotiation journey assumes
-the scenario is already complete. Real-time advance is available but is
-not the designed flow for the active negotiation mode.
+*This is a stretch use case.* The primary negotiation journey (Steps 1–4)
+assumes the analysis is already complete and the specialist is citing it.
+Mode 3 active control is available for real-time modification but requires
+that a completed baseline scenario exists (Journey A must be complete first).
+
+Full Mode 3 journey: Journey C below.
 
 ---
 
@@ -286,13 +310,230 @@ step, severity, and cohort. One of three outcomes:
 
 ---
 
+## Journey C: Active Control — Real-Time Steering (Mode 3)
+
+**Context:** Eleni Papadimitriou, Deputy Director, Hellenic Ministry of Finance.
+February 2012. The Troika has circulated the second memorandum conditionality
+package overnight. She has spent the previous three hours in Mode 2 building her
+analysis and counter-proposal ("Counter_Feb2012_ModA"). At 9am she enters the
+negotiation session. The Troika is now proposing a modification to the minimum
+wage cut term.
+
+**Entry state:** Application open. The "Counter_Feb2012_ModA" scenario is loaded
+and complete (SCENARIO_COMPLETE, 6 steps computed). The instrument cluster is
+visible at step 6. She switches to Mode 3.
+
+*Precondition for Mode 3:* A completed baseline scenario must exist before the
+first control input is applied. Journey A is the prerequisite for Journey C.
+
+---
+
+### Steps
+
+**Step 1 — Switch to Mode 3**
+
+She taps "MODE 3 — ACTIVE CONTROL" in the mode indicator in the primary viewport
+header. The control plane zone (reserved in the primary viewport) populates with
+the policy instruments form and the scenario shocks form. The trajectory view
+remains visible — it now shows the "Counter_Feb2012_ModA" trajectory as the
+baseline (single trajectory set, no ghost curves yet — observation mode).
+
+*Information need:* The mode switch must not navigate away from the instrument
+cluster. The control plane zone must be visible alongside the trajectory view
+without scroll. The mode indicator must confirm she is in Mode 3.
+
+*Critical constraint:* Mode switch must complete in under 3 seconds.
+
+---
+
+**Step 2 — Apply the proposed modification as a control input**
+
+The Troika proposes: minimum wage cut applied at step 1 instead of step 2
+(the 12-month delay she had built into her counter-proposal is removed).
+
+She selects the policy input type, enters the modified parameter, selects
+step 1, and clicks "Apply policy input."
+
+The instrument cluster updates: the baseline curves are preserved as ghost
+curves (50% opacity). The active trajectory recalculates to reflect the
+earlier minimum wage cut. The divergence fill region appears between the
+ghost and active curves where they separate.
+
+*Information need:* The live A/B comparison must be legible immediately
+after the control input computes. She must see: (a) where the active
+trajectory diverges from her counter-proposal baseline; (b) whether the
+divergence crosses any MDA floor. The MDA alert panel causal attribution
+must show "Caused by: minimum wage cut applied at step 1."
+
+*Critical constraint:* Control input propagation must complete in under 10
+seconds. The divergence fill must appear immediately on computation complete.
+
+---
+
+**Step 3 — Read the causal attribution and cite the finding**
+
+The MDA alert panel fires:
+```
+CRITICAL — poverty_headcount — bottom_quintile — step 2
+Caused by: minimum wage cut applied at step 1
+```
+
+This is the finding. The earlier application of the minimum wage cut pushes
+poverty headcount across the CRITICAL threshold at step 2 — one step earlier
+than her counter-proposal baseline.
+
+She reads the alert text directly to the Troika: "Under the proposed timing,
+poverty headcount crosses the critical threshold in month 6 of the programme,
+specifically for the bottom income quintile. In our counter-proposal, with the
+12-month delay, the crossing does not occur."
+
+*Information need:* The alert text must be readable at tablet font sizes without
+expanding. The causal attribution must be specific enough to cite verbatim.
+The ghost baseline curves must confirm that the counter-proposal baseline does
+not cross the same threshold.
+
+---
+
+**Step 4 — Inject a scenario shock to test the Troika's rebuttal**
+
+The Troika argues: "Even without the delay, the GDP rebound in year 2 will
+protect the bottom quintile." She tests this claim by injecting a positive GDP
+shock at step 2.
+
+She uses the scenario shocks form: selects step 2, selects shock type, clicks
+"Inject scenario shock." The orange vertical marker appears across all curves
+at step 2. The active trajectory updates.
+
+*Information need:* The policy input marker (blue) at step 1 and the shock
+marker (orange) at step 2 must be visually distinct. The alert panel must update
+to show whether the GDP shock changes the threshold crossing result. If the
+crossing persists after the GDP shock, her argument is reinforced.
+
+---
+
+**Exit state:**
+
+The specialist has demonstrated in real time that:
+- The proposed timing change (minimum wage cut at step 1) causes a CRITICAL
+  threshold crossing at step 2
+- The GDP rebound assumption does not eliminate the crossing (if the alert
+  persists after the shock injection)
+- The causal attribution is traceable to the specific proposed term
+
+One of three outcomes, same as Journey B Step 4, but with live evidence rather
+than prepared evidence.
+
+---
+
+## Journey D: Demonstrative — Orientation for Aicha Mbaye
+
+**Context:** Aicha Mbaye, IMF Executive Board Member. She has been invited to
+observe a WorldSim session. She is not the driver — she will not advance steps,
+apply control inputs, or configure scenarios. She needs to understand what the
+instrument cluster shows, what the threshold system means, and why this tool
+represents a capability shift for vulnerable-country finance ministries.
+
+She has 60 seconds to orient before the driver begins the session. She has no
+prior exposure to WorldSim.
+
+**Entry state:** Application open, a pre-loaded historical fixture ("Greece
+2010–2015, six steps") visible on a large display. The instrument cluster shows
+step 1 (May 2010). Mode 1 (Replay).
+
+This is the same scenario the driver will advance step by step. Aicha is reading
+the instrument cluster, not controlling it.
+
+---
+
+### Steps
+
+**Step 1 — Read the instrument cluster in 20 seconds**
+
+The driver names each instrument once. Aicha can read the step axis annotation:
+"Step 1 — May 2010 — Troika memorandum signed." She can read the four composite
+score curves: financial deteriorating, human development stable, ecological
+stable, governance stable.
+
+*Orientation need:* Within 20 seconds, Aicha must be able to read: (a) what
+country and time period; (b) which frameworks are deteriorating; (c) that this
+is a historical replay, not a prediction.
+
+*Design requirement this imposes:* The step axis calendar date and event label
+must be readable at display-screen sizes without interaction. The entity name
+must be in the persistent header. The mode indicator must confirm "MODE 1 —
+REPLAY." These three elements must be legible to a cold reader with no tool
+knowledge.
+
+---
+
+**Step 2 — MDA alert panel as threshold orientation**
+
+The driver reads one alert: "CRITICAL — unemployment rate — working-age adults
+— step 3." Aicha asks what "CRITICAL" means.
+
+*Information need:* The severity label (CRITICAL) and the indicator and step
+are readable without expansion. The driver explains: "CRITICAL means the
+indicator has crossed the floor below which comparable historical cases produced
+social instability. Step 3 is 2012 — two years into the programme."
+
+Aicha does not need to interact with the panel to read the finding. She needs
+to understand the hierarchy: TERMINAL > CRITICAL > WARNING.
+
+---
+
+**Step 3 — PMM widget as capacity orientation**
+
+The driver points to the PMM widget: "Policy Maneuver Margin — historical: 0.23,
+declining." Aicha asks what this means.
+
+The driver explains: "This tells the minister how much policy room remains. At
+0.23 and declining, the country is approaching the point where no policy response
+avoids a binding constraint. In February 2012, this was already severely
+constrained."
+
+*Information need:* The PMM value and trend arrow must be legible at a glance.
+The label "Policy Maneuver Margin — historical" must make the framing clear without
+explanation beyond the driver's single sentence.
+
+---
+
+**Exit state:**
+
+Within 60 seconds, Aicha understands:
+- What the instrument cluster shows (four frameworks, shared step axis, historical
+  replay)
+- What threshold crossings mean and how severity is classified
+- What the PMM represents and why it matters in a negotiation context
+
+She is ready to follow the session without needing to drive the tool. The
+demonstrative entry state is not a simplified mode — it is the same instrument
+cluster, read by a cold observer rather than a trained driver.
+
+*Design requirement this imposes on the instrument cluster:* Every Zone 1 element
+must be self-describing enough that a cold reader can orient within one
+explanatory sentence per instrument. Labels, values, and severity systems must
+not require prior training to parse. This is the audience-size test: if it works
+for Aicha in 60 seconds, it works for any finance ministry official who encounters
+WorldSim for the first time.
+
+---
+
 ## Journey Dependency Map
 
-| Journey | Primary WorldSim state | Primary UI surface | ADR-006 dependency |
-|---|---|---|---|
-| Preparation — Step 4 | SCENARIO_RUNNING / COMPLETE | MDA alert panel | Decision 5 composite alert |
-| Preparation — Step 5 | DRAWER_DATA | FrameworkPanel + cohort breakdown | Decision 4 sibling fields |
-| Preparation — Step 6 | COMPARE_VIEW | DeltaChoropleth + EntityDetailDrawer | None (M4 feature) |
-| Negotiation — Step 2 | SCENARIO_PRELOADED | EntityDetailDrawer (instant open) | currentStep ?? fallback |
-| Negotiation — Step 3 | DRAWER_DATA | MDA alert panel | Decision 5 alert_source field |
-| Negotiation — Step 4 | DRAWER_DATA | ia1_disclosure text | Decision 13 canonical phrase |
+| Journey | Mode | Primary WorldSim state | Primary UI surface | Dependency |
+|---|---|---|---|---|
+| A — Preparation Step 3a | Mode 2 | SCENARIO_RUNNING | Trajectory view (advance confirmation) | Step counter |
+| A — Preparation Step 3b | Mode 2 | SCENARIO_RUNNING | Trajectory view + MDA alert panel | EL Decision 2 viewport |
+| A — Preparation Step 4 | Mode 2 | SCENARIO_RUNNING / COMPLETE | MDA alert panel | ADR-006 Decision 5 composite alert |
+| A — Preparation Step 5 | Mode 2 | DRAWER_DATA | FrameworkPanel + cohort breakdown | ADR-006 Decision 4 sibling fields |
+| A — Preparation Step 6 | Mode 2 | COMPARE_VIEW (single-entity) | Divergence timeline | EL Decision 3 |
+| B — Negotiation Step 2 | Mode 3 | SCENARIO_PRELOADED | Instrument cluster (instant load) | currentStep ?? fallback |
+| B — Negotiation Step 3 | Mode 3 | DRAWER_DATA | MDA alert panel | ADR-006 Decision 5 alert_source |
+| B — Negotiation Step 4 | Mode 3 | DRAWER_DATA | ia1_disclosure text | ADR-006 Decision 13 canonical phrase |
+| B — Negotiation Step 5 | Mode 3 | MODE_3_ACTIVE | Control plane + live A/B trajectory | EL Decision 3 Gap 4 |
+| C — Active Control Step 2 | Mode 3 | MODE_3_ACTIVE | Trajectory view live A/B | EL Decision 3 Gap 4 |
+| C — Active Control Step 3 | Mode 3 | MODE_3_ACTIVE | MDA alert panel (causal attribution) | Gap 3 blue/orange system |
+| C — Active Control Step 4 | Mode 3 | MODE_3_ACTIVE | Shock marker on trajectory view | Gap 3 orange vertical marker |
+| D — Demonstrative Step 1 | Mode 1 | SCENARIO_PRELOADED | Trajectory view + step axis annotation | Gap 1B fixture fields |
+| D — Demonstrative Step 2 | Mode 1 | SCENARIO_PRELOADED | MDA alert panel | ADR-006 Decision 5 alert_source |
+| D — Demonstrative Step 3 | Mode 1 | SCENARIO_PRELOADED | PMM widget (historical label) | Gap 5 mode-specific labels |


### PR DESCRIPTION
## Summary

Implements Issue #365. Updates three UX documents to reflect the three Engineering Lead architecture decisions recorded on Issue #364.

### EL Decision 1 — Per-mode cognitive tasks (north-star.md)

- `§Primary Cognitive Task` superseded by `§Primary Cognitive Tasks by Mode`
- Three per-mode formulations: Mode 1 trajectory reconstruction + historical pattern recognition; Mode 2 threshold-safe path construction; Mode 3 real-time steering within human cost constraints
- `§Preparation Mode vs. Active Negotiation Mode` extended to three modes and renamed; 'what stays the same' corrected (primary cognitive task is NOT identical across modes)
- `docs/ux/personas.md` reference added to Canonical User section
- M4-era design implication ("MDA alert panel is the primary visual element") updated to reflect instrument cluster as primary viewport

### EL Decision 2 — Instrument cluster as primary viewport (information-hierarchy.md)

- Governing Principle updated to per-mode cognitive task framing + foundational rule: no primary instrument inside the drawer
- Zone 1 restructured: entity selector as persistent header; trajectory view as 1A (new primary instrument); MDA alert panel as 1B; PMM as 1C; four-framework current position as 1D
- Radar chart moved from Zone 1 to Zone 2 (2A) — Zone 1 four-framework current position (1D) is the quick-read; radar chart is the Zone 2 visual depth behind it
- EntityDetailDrawer demoted from primary instrument surface to detail/methodology surface
- Control Plane Reserved Zone section added (zone sized to accommodate both policy instrument and scenario shock forms simultaneously; constraint: must not reduce trajectory view below legible minimum)
- M9 Hierarchy Decisions table added (8 decisions)

### EL Decision 3 — Comparison mode conditional (information-hierarchy.md + user-journeys.md)

- COMPARE_VIEW replaced with full three-mode conditional specification
- Single-entity Mode 2: divergence timeline; multi-entity Mode 2: DeltaChoropleth; Mode 3: automatic live A/B in instrument cluster (no COMPARE_VIEW entered)
- DeltaChoropleth explicitly deprecated for single-entity and Mode 3 contexts

### User journeys (user-journeys.md)

- Journey A Step 3 separated into advance (3a) and inspect (3b) sub-actions; choropleth demoted to secondary context; trajectory view as primary scan surface
- Journey B Step 5 reframed as Mode 3 control input (not new scenario creation)
- Journey C added: Mode 3 active control for Eleni Papadimitriou, February 2012 — 4 steps from mode switch through live A/B comparison and shock injection
- Journey D added: Demonstrative entry state for Aicha Mbaye — cold-reader orientation in 60 seconds, Mode 1 pre-loaded fixture; derives cold-reader design requirements for all Zone 1 instrument labels
- Journey Dependency Map extended to cover all four journeys across all three modes (15 rows)

## Test plan

- [ ] Read all three updated documents end-to-end; confirm no surviving references to single-task 'threshold alarm detection' framing
- [ ] Confirm information-hierarchy.md Zone 1 no longer lists radar chart as Zone 1 element
- [ ] Confirm COMPARE_VIEW section covers all three modes explicitly
- [ ] Confirm user-journeys.md Journey C and Journey D match the depth document (PR #390) requirements at journey level
- [ ] Confirm Journey Dependency Map covers Journeys A–D
- [ ] Confirm north-star.md §1 heading is 'Primary Cognitive Tasks by Mode'

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)