### PR TITLE
docs(process): Architecture Backlog — pre-ADR queue, RACI-grounded panel composition rule (closes #405)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,13 @@ Architecture Decision Records document what was decided, why, and what
 alternatives were considered. They are the institutional memory that
 survives leadership changes — both human and AI session boundaries.
 
+The Architecture Decision Record Backlog (`docs/architecture/backlog.md`) is the
+single source of ADR number assignment. Before drafting any ADR, the Architect
+Agent must: (1) check the backlog for the next available number, (2) mark the
+entry ASSIGNED, (3) derive the panel composition from `docs/process/agent-raci.md`,
+and (4) confirm the implementing agent is included in the panel. ADR numbers must
+not appear in issue titles or documents before they are assigned from the backlog.
+
 **Tests are not optional.**
 The backtesting infrastructure is the most important test suite.
 Unit and integration tests are table stakes. A feature is not done

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -297,6 +297,24 @@ suffices — no ADR required unless the fix reveals a design issue.
 
 ---
 
+## ADR Process
+
+All significant architectural decisions require an Architecture Decision Record
+before implementation begins. The process:
+
+1. File a GitHub issue describing the architectural question — no ADR number in the title
+2. The PM Agent HORIZON sweep reviews the Architecture Backlog for priority
+3. The Architect Agent claims the next available number from `docs/architecture/backlog.md`
+4. The Architect Agent consults `docs/process/agent-raci.md` to derive the panel
+5. The implementing agent must be in the panel — this is not optional
+6. The Architect Agent drafts the ADR; the panel reviews; the Engineering Lead signs off
+7. Status moves to ACCEPTED; the backlog entry is updated
+
+The Architecture Backlog (`docs/architecture/backlog.md`) is the authoritative
+source for ADR numbers and status. Do not assign ADR numbers informally.
+
+---
+
 ## Contribution Workflow
 
 ### Branch Naming

--- a/docs/architecture/backlog.md
+++ b/docs/architecture/backlog.md
@@ -1,0 +1,56 @@
+# Architecture Decision Record Backlog
+
+> This file is the single source of truth for ADR number assignment.
+> No ADR number may be used in any issue title, document, or code comment
+> before it appears in this table with status ASSIGNED.
+> Last updated: 2026-05-22
+
+## Process
+
+When an architectural question requiring an ADR is identified:
+1. File a GitHub issue describing the architectural question — no ADR number in the title
+2. Add the issue to this backlog with status PENDING_NUMBER
+3. At the next PM Agent HORIZON sweep, the backlog is reviewed for priority against all pending ADRs
+4. Before any ADR is drafted, the Architect Agent claims the next available number from this table, marks it ASSIGNED, and begins drafting
+5. Only then does the ADR number appear in the issue title and document
+
+## Panel Composition Rule
+
+Before naming the review panel for any ADR, the Architect Agent must consult
+`docs/process/agent-raci.md`. Any agent listed as R (Responsible) or C (Consulted)
+for the decision type in the RACI chart must either be included in the panel or have
+their exclusion explicitly documented with rationale.
+
+**The implementing agent is always required in the ADR panel regardless of panel size.**
+
+Minimum panel by ADR type:
+
+| ADR type | Required panel members |
+|---|---|
+| Frontend architecture | Architect Agent (author), Frontend Architect Agent, UX Designer Agent, Engineering Lead |
+| Simulation engine | Architect Agent (author), Chief Engineer, Chief Methodologist, Engineering Lead |
+| Data standards | Architect Agent (author), Chief Methodologist, Development Economist, Engineering Lead |
+| UX design | Architect Agent (author), UX Designer Agent, Frontend Architect Agent, Engineering Lead |
+| Cross-cutting | Architect Agent (author), relevant domain DIC members per RACI, Engineering Lead |
+
+The Architect Agent authors the ADR — they are not a reviewer. The Engineering Lead is
+accountable on all ADRs — their sign-off is always required.
+
+## Priority Review
+
+The PM Agent HORIZON sweep must include a backlog review before any ADR activation:
+- Are there PENDING_NUMBER entries that should be prioritized over newer requests?
+- Does any PENDING entry block another issue or milestone more urgently than the proposed ADR?
+- Is the proposed ADR's empirical evidence available, or should it remain PENDING until it is?
+
+Recency bias is explicitly countered by this review. A new architectural question raised in
+the current session does not automatically take priority over an older pending entry.
+
+## ADR Registry
+
+| Entry | GitHub Issue | Title | Filed | Status | ADR # | Milestone | Notes |
+|---|---|---|---|---|---|---|---|
+| ARCH-001 | — | Synthetic data framework | 2026-05-19 | ASSIGNED — ADR-007 | 7 | M9 | CM consultation complete PR #373; formal ADR pending |
+| ARCH-002 | #397 | UX architecture — instrument cluster, viewport, interaction model | 2026-05-21 | ASSIGNED — ADR-008 | 8 | M9 | Panel must include Frontend Architect per panel composition rule |
+| ARCH-003 | #217 | Simulation engine computation model — iterative vs. matrix | 2026-04-xx | ASSIGNED — ADR-009 | 9 | M11 | Do not author until M11 Phase 1 baseline benchmarks complete |
+| ARCH-004 | #366 | Trajectory view as primary instrument | 2026-05-21 | ASSIGNED — ADR-010 | 10 | M9 | Gates M9 Frontend Architect brief |

--- a/docs/process/agent-raci.md
+++ b/docs/process/agent-raci.md
@@ -424,3 +424,32 @@ notified in every case.
 
 *See also: `docs/process/disposition-review-standard.md` for the RACI applied to the specific
 case of standards gap dispositions.*
+
+---
+
+## ADR Panel Composition
+
+When an ADR is being drafted, the Architect Agent derives the panel from this RACI chart.
+Any agent with R or C assignment for the relevant decision type is either included or
+their exclusion is documented with rationale.
+
+The implementing agent — the agent responsible for building what the ADR commits to —
+is always required regardless of panel size. This rule was established after ADR-008's
+panel was initially drafted without the Frontend Architect, who is the primary
+implementer of all frontend architecture decisions. See Issue #397 comment
+2026-05-22 for the correction record.
+
+Minimum panels by ADR type (derived from the RACI matrix above):
+
+| ADR type | RACI row | Required panel members |
+|---|---|---|
+| Frontend architecture | Row 1 (Architectural decisions) | Architect Agent (author), Frontend Architect Agent (C), Engineering Lead (A) |
+| Simulation engine | Row 1 (Architectural decisions) | Architect Agent (author), Chief Engineer Agent (C), Chief Methodologist (via DI — C), Engineering Lead (A) |
+| Data standards | Row 4 (Data / schema decisions) | Architect Agent (C), Chief Methodologist (via DI — C), Development Economist (domain validation), Engineering Lead (A) |
+| UX design | Row 2/3 (UX frame / component decisions) | Architect Agent (C), UX Designer Agent (R), Frontend Architect Agent (C), Engineering Lead (A) |
+| Cross-cutting | All relevant rows | Relevant R/C agents per RACI, Engineering Lead (A) |
+
+The Architect Agent authors the ADR — they are not a reviewer. The Engineering Lead
+holds A on all ADR decisions — their sign-off is always required.
+
+Full backlog and panel composition process: `docs/architecture/backlog.md`


### PR DESCRIPTION
## Summary

Implements Issue #405. Establishes the Architecture Backlog as the single source of ADR number assignment and formalizes the RACI-grounded panel composition rule across four documents.

- **`docs/architecture/backlog.md`** (new): four initial ARCH entries (ADR-007 through ADR-010), process rules, RACI-derived panel composition table, PM Agent HORIZON priority review guidance
- **`CLAUDE.md`**: backlog reference and panel composition process appended to §No significant feature without an ADR
- **`docs/CONTRIBUTING.md`**: new §ADR Process section (seven-step process; backlog as authoritative ADR number source)
- **`docs/process/agent-raci.md`**: §ADR Panel Composition section added — RACI-derived minimum panels by ADR type, implementing-agent requirement documented, ADR-008 correction named as canonical incident

## Key rule established

The implementing agent is always required in the ADR panel. Panel is derived from `agent-raci.md` R/C assignments, not from prior panel compositions. Exclusions must be documented with rationale.

## Closes

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)