### PR TITLE
docs(process): PM Agent ARCH command, HORIZON sweep sequence, backlog PENDING entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,45 @@ All agents reference the relevant ADR before implementing any significant
 feature. All agents treat the human cost ledger as a primary output,
 never an afterthought.
 
+### PM Agent — Session Commands
+
+**PM Agent: HORIZON**
+Open-issue audit against current and upcoming Milestone definitions — surfaces
+scope creep, orphaned issues, and committed work at risk. Sweep sequence:
+1. **Open-issue audit** — review all open issues against current milestone definitions; surface scope creep, orphaned issues, and committed work at risk.
+2. **Board health** — confirm zero open issues without milestone assignment, zero without a `horizon:` label.
+3. **ARCH** — Architecture Backlog priority review (see PM Agent: ARCH definition below).
+4. **TRIAGE** — one verdict per new finding surfaced during the sweep.
+
+End with a recommended next action. Full persona: `docs/process/agents.md §PM Agent`.
+
+**PM Agent: ARCH**
+Architecture Backlog priority review. Read `docs/architecture/backlog.md`,
+`docs/roadmap/worldsim-roadmap.md`, and `docs/process/agent-raci.md`. Then:
+1. For each ASSIGNED entry: confirm empirical evidence is available. If not, state
+   what evidence is required. If yes, confirm panel composition per `agent-raci.md`
+   and verify the implementing agent is named.
+2. For each ASSIGNED entry: list what is blocked until that ADR is accepted. Rank
+   by downstream impact on the current milestone.
+3. Scan open issues for architectural candidates missing from the backlog:
+   ```
+   gh issue list --repo PublicEnemage/worldsim --state open \
+     --json number,title,labels,milestone --limit 200 | python3 -c "
+   import json,sys
+   issues = json.load(sys.stdin)
+   candidates = [i for i in issues if any(kw in i['title'].lower()
+     for kw in ['adr','arch(','architecture:','arch:','decision record'])]
+   for i in candidates: print(f'#{i[\"number\"]} {i[\"title\"][:70]}')
+   "
+   ```
+   Flag any candidate not in the backlog as PENDING_NUMBER.
+4. Produce a priority table:
+   `| Rank | ADR | Evidence ready? | Implementing agent | Blocks | Action |`
+5. State the single recommended next action in one sentence.
+   End with: "Awaiting Engineering Lead decision before activating any ADR."
+
+This is a read-and-report task. Do not activate the Architect Agent. Do not begin drafting.
+
 ---
 
 ## Domain Intelligence Council

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,44 +232,9 @@ All agents reference the relevant ADR before implementing any significant
 feature. All agents treat the human cost ledger as a primary output,
 never an afterthought.
 
-### PM Agent — Session Commands
-
-**PM Agent: HORIZON**
-Open-issue audit against current and upcoming Milestone definitions — surfaces
-scope creep, orphaned issues, and committed work at risk. Sweep sequence:
-1. **Open-issue audit** — review all open issues against current milestone definitions; surface scope creep, orphaned issues, and committed work at risk.
-2. **Board health** — confirm zero open issues without milestone assignment, zero without a `horizon:` label.
-3. **ARCH** — Architecture Backlog priority review (see PM Agent: ARCH definition below).
-4. **TRIAGE** — one verdict per new finding surfaced during the sweep.
-
-End with a recommended next action. Full persona: `docs/process/agents.md §PM Agent`.
-
-**PM Agent: ARCH**
-Architecture Backlog priority review. Read `docs/architecture/backlog.md`,
-`docs/roadmap/worldsim-roadmap.md`, and `docs/process/agent-raci.md`. Then:
-1. For each ASSIGNED entry: confirm empirical evidence is available. If not, state
-   what evidence is required. If yes, confirm panel composition per `agent-raci.md`
-   and verify the implementing agent is named.
-2. For each ASSIGNED entry: list what is blocked until that ADR is accepted. Rank
-   by downstream impact on the current milestone.
-3. Scan open issues for architectural candidates missing from the backlog:
-   ```
-   gh issue list --repo PublicEnemage/worldsim --state open \
-     --json number,title,labels,milestone --limit 200 | python3 -c "
-   import json,sys
-   issues = json.load(sys.stdin)
-   candidates = [i for i in issues if any(kw in i['title'].lower()
-     for kw in ['adr','arch(','architecture:','arch:','decision record'])]
-   for i in candidates: print(f'#{i[\"number\"]} {i[\"title\"][:70]}')
-   "
-   ```
-   Flag any candidate not in the backlog as PENDING_NUMBER.
-4. Produce a priority table:
-   `| Rank | ADR | Evidence ready? | Implementing agent | Blocks | Action |`
-5. State the single recommended next action in one sentence.
-   End with: "Awaiting Engineering Lead decision before activating any ADR."
-
-This is a read-and-report task. Do not activate the Architect Agent. Do not begin drafting.
+PM Agent commands (`BRIEF`, `TRIAGE`, `HORIZON`, `ARCH`, `FOCUS`, `EXECUTE`) and their
+full definitions, including the HORIZON sweep sequence and ARCH priority review
+protocol, are defined in `docs/process/agents.md §PM Agent`.
 
 ---
 

--- a/docs/architecture/backlog.md
+++ b/docs/architecture/backlog.md
@@ -54,3 +54,6 @@ the current session does not automatically take priority over an older pending e
 | ARCH-002 | #397 | UX architecture — instrument cluster, viewport, interaction model | 2026-05-21 | ASSIGNED — ADR-008 | 8 | M9 | Panel must include Frontend Architect per panel composition rule |
 | ARCH-003 | #217 | Simulation engine computation model — iterative vs. matrix | 2026-04-xx | ASSIGNED — ADR-009 | 9 | M11 | Do not author until M11 Phase 1 baseline benchmarks complete |
 | ARCH-004 | #366 | Trajectory view as primary instrument | 2026-05-21 | ASSIGNED — ADR-010 | 10 | M9 | Gates M9 Frontend Architect brief |
+| ARCH-005 | #222 | MacroeconomicModule contemporaneous processing path | 2026-05-22 | PENDING_NUMBER | — | M10 | Architectural change in M10 engine scope; evaluate at M10 kickoff whether ADR required before implementation |
+| ARCH-006 | #392 | Political economy constraint modeling | 2026-05-22 | PENDING_NUMBER | — | M11 | M11 scope; add before M11 kickoff ADR work begins |
+| ARCH-007 | #53 | Information Access Architecture — role-based output visibility | 2026-04-17 | PENDING_NUMBER | — | M12 | M12 scope; add before M12 ADR work begins |

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -63,7 +63,8 @@ Operating modes:
 
 - **BRIEF:** Structured session-start brief — committed milestone work, blockers requiring Engineering Lead decision (max 3), decisions due today (max 3), everything else filed, one recommended next action.
 - **TRIAGE:** One verdict per new issue or finding — `BLOCKING NOW` / `THIS MILESTONE` / `NEXT MILESTONE` / `PARKING LOT` / `WONTFIX`. No elaboration unless asked.
-- **HORIZON:** Open-issue audit against current and upcoming Milestone definitions — surfaces scope creep, orphaned issues, and committed work at risk.
+- **HORIZON:** Open-issue audit against current and upcoming Milestone definitions — surfaces scope creep, orphaned issues, and committed work at risk. Sweep sequence: (1) open-issue audit against milestone definitions; (2) board health — zero issues without milestone, zero without `horizon:` label; (3) ARCH — Architecture Backlog priority review; (4) TRIAGE — one verdict per new finding surfaced. End with a recommended next action.
+- **ARCH:** Architecture Backlog priority review. Read `docs/architecture/backlog.md`, `docs/roadmap/worldsim-roadmap.md`, and `docs/process/agent-raci.md`. For each ASSIGNED entry: (1) confirm empirical evidence is available — if not, state what is required; if yes, confirm panel composition and verify the implementing agent is named; (2) list what is blocked until that ADR is accepted, ranked by downstream impact on the current milestone. Scan open issues for architectural candidates missing from the backlog; flag any as PENDING_NUMBER. Produce a priority table: `| Rank | ADR | Evidence ready? | Implementing agent | Blocks | Action |`. State the single recommended next action in one sentence. End with: "Awaiting Engineering Lead decision before activating any ADR." This is a read-and-report task — do not activate the Architect Agent, do not begin drafting.
 - **FOCUS:** One action and one reason. No list. No context.
 - **EXECUTE:** Execute a named task directly — file issues, update trackers, run mechanical operations as instructed.
 
@@ -76,6 +77,7 @@ Tone: Direct and short. Every response ends with a clear next action or an expli
 PM Agent: BRIEF
 PM Agent: TRIAGE — [issue or finding]
 PM Agent: HORIZON
+PM Agent: ARCH
 PM Agent: FOCUS — [question or context]
 PM Agent: EXECUTE — [task]
 ```


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — new §PM Agent Session Commands section in Agent Roster: HORIZON sweep (4-step sequence with ARCH as step 3) and PM Agent: ARCH standalone definition (read-and-report; always ends with "Awaiting Engineering Lead decision")
- **docs/architecture/backlog.md** — three PENDING_NUMBER entries added: ARCH-005 (#222, M10), ARCH-006 (#392, M11), ARCH-007 (#53, M12)
- **Issues #39, #40, #41** — closed as stale tracking issues for ADRs 4/5/6, which CLAUDE.md already declares current

## Stacks on

PR #414 (docs/architecture-backlog-process) — base branch; backlog.md must exist before this branch can merge to main.

## Closes

Partial scope of Issue #405 (ARCH command definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)