### PR TITLE
docs(schema+frontend): Data Architect review — trajectory endpoint stub and 5 schema findings

### DIFF
--- a/docs/frontend/fa-brief-m9-instrument-cluster.md
+++ b/docs/frontend/fa-brief-m9-instrument-cluster.md
@@ -760,6 +760,128 @@ The following sequencing ensures no blocking dependency is encountered mid-imple
 | UD-R2: Multi-case tick format | §Mode 1 Step Axis Annotation | ✓ Stacked dates; must appear |
 | UD-R3: Curve-face badge | §Confidence Tier Visual | ✓ "(exp)" at rightmost data point; 11px min (UD-F2) |
 
+## Appendix — Data Architect Review Findings
+
+Data Architect Agent: REVIEW — 2026-05-22. Schema files read: `api_contracts.yml` v1.0,
+`database.yml` v1.1, `simulation_state.yml` v1.0.
+
+**Five findings. Three require EL decisions before the trajectory endpoint can be implemented.**
+
+| ID | Finding | Severity | Status |
+|---|---|---|---|
+| DA-F1 | `GET /scenarios/{id}/trajectory` absent from `api_contracts.yml` | Schema gap | Partial stub added 2026-05-22 — full spec blocked by DA-F2 and DA-F4 |
+| DA-F2 | No composite-score-level MDA floor storage in current schema | Blocking — EL decision required | Pending |
+| DA-F3 | `ci_lower`/`ci_upper` absent from all schema files | Schema gap | Registered as pending-ADR-007 in stub — no action required until ADR-007 |
+| DA-F4 | Single-entity null handling for financial/human_development undefined | Blocking — EL decision required | Pending |
+| DA-F5 | `step_event_label`/`step_significance` have no schema home | Blocking schema design | Pending |
+
+### DA-F1 — Trajectory Endpoint Absent from api_contracts.yml
+
+`GET /scenarios/{scenario_id}/trajectory` did not exist in `api_contracts.yml`. A partial
+schema stub has been added (2026-05-22) documenting the known fields and flagging the three
+open EL decisions as PENDING. The stub prevents implementation agents from calling or
+implementing the endpoint without a schema contract, and registers the pending gaps so they
+are visible in the schema file.
+
+**Action taken:** Partial entry added to `docs/schema/api_contracts.yml` with PENDING tags
+on DA-F2, DA-F3, DA-F4, DA-F5 elements.
+
+### DA-F2 — No Composite-Score-Level MDA Floor Storage (EL Decision Required)
+
+`mda_thresholds.floor_value` (`database.yml`) stores indicator-level breach thresholds
+(e.g., `poverty_headcount_ratio < 0.40`, `reserve_coverage_months < 2.5`). The trajectory
+view's Y-axis is the composite score. MDA floor lines on the trajectory view must be at the
+composite-score level (ADR-010 Decision 6, CM-R3 disposition). Projecting indicator-level
+floors to composite-score-level floors is explicitly prohibited by CM-R3 ("implies false
+precision; projection is methodologically dishonest"). There is no composite-score-level floor
+field or table in the current schema.
+
+**Two options for EL decision:**
+
+(a) **Add `composite_floor_value` field to `mda_thresholds`** — populated by a separate
+    process (not derived from `floor_value` projection). Requires Alembic migration.
+    Establishes a schema-native location for composite-score-level MDA floors.
+    New `mda_thresholds` rows can carry both `floor_value` (indicator-level, for Zone 2B)
+    and `composite_floor_value` (composite-level, for Zone 1A trajectory view).
+
+(b) **Defer MDA floor overlays on the trajectory view** — do not render MDA floor
+    `<ReferenceLine>` elements until a composite-score-level threshold table or field is
+    defined. Trajectory view renders without floor lines; Zone 2B retains indicator-level
+    MDA alert rows. MDA floor overlays are added in a future PR once the schema is resolved.
+
+**Implementation must not proceed on MDA floor overlays until EL chooses (a) or (b).**
+
+### DA-F3 — ci_lower / ci_upper Not in Any Schema File
+
+`ci_lower` and `ci_upper` fields appear in the FA brief's uncertainty band `<Area>` component
+and in the `TrajectoryResponse.FrameworkCurvePoint` shape. They do not exist in `database.yml`,
+`api_contracts.yml`, or `simulation_state.yml`. These fields will be populated by the
+BandingEngine (pending ADR-007). They are registered as PENDING in the trajectory endpoint
+stub added under DA-F1.
+
+**No immediate action required** — they are correctly gated on ADR-007 acceptance. The schema
+stub registration prevents silent addition without schema contract. When ADR-007 is accepted,
+update `api_contracts.yml` and `database.yml` in the same PR that implements the BandingEngine.
+
+### DA-F4 — Single-Entity Null: Trajectory View Undefined for Mode 1 Greece (EL Decision Required)
+
+In the existing `measurement-output` endpoint, `composite_score` is null for financial and
+human_development frameworks when `single_entity_warning=true` (Issue #193). The Greece demo
+fixture is a single-entity scenario. If the trajectory endpoint propagates this null, the
+trajectory view for Greece Mode 1 would show no financial or human_development curves —
+defeating the purpose of the primary demo scenario.
+
+The FA brief's null governance guard (`connectNulls={false}` on the governance `<Line>`) is
+correct. But it does not address the separate null case for financial/human_development in
+single-entity Mode 1.
+
+**Two options for EL decision:**
+
+(a) **Trajectory endpoint uses raw indicator signal for single-entity scenarios** — instead of
+    percentile rank composite score (which requires ≥2 entities), the trajectory endpoint
+    returns a single-entity-specific composite score derivation. Requires an ADR or EL
+    decision on the methodology. Unblocks Mode 1 Greece demo trajectory view.
+
+(b) **Mode 1 single-entity trajectory view shows "single-entity advisory" overlay** — financial
+    and human_development curves are suppressed; a user-visible label explains that composite
+    percentile rank requires a comparison entity. Trajectory view shows ecological and
+    governance curves only (both of which have different null reasons).
+
+**Issue #193 is a prerequisite for Mode 1 single-entity trajectory rendering.** The FA brief's
+implementation sequencing must note this dependency.
+
+### DA-F5 — step_event_label and step_significance Have No Schema Home
+
+The FA brief references `step_event_label` (≤ 8 words AND ≤ 32 characters) and
+`step_significance` ("SIGNIFICANT" | "STANDARD") as mandatory fields for Mode 1 step
+annotation. `effective_from` maps to `scenario_state_snapshots.timestep`. The other two
+fields have no schema home.
+
+**Three candidate storage approaches for EL/Architect decision:**
+
+(a) **Per-step metadata in scenario configuration JSONB** — add a `step_annotations` key to
+    `scenarios.configuration` with structure `{step_index: {label, significance}}`. Populated
+    at scenario creation. No migration needed (JSONB extension). Query: read from
+    `scenarios.configuration->'step_annotations'` in the trajectory endpoint.
+
+(b) **New `step_annotations` table** — one row per (scenario_id, step_index), columns:
+    `step_event_label text nullable`, `step_significance text nullable`. Alembic migration
+    required. More structured; supports future step-level metadata.
+
+(c) **Embedded in fixture JSON only; not DB-persisted** — fixture files carry the annotation
+    fields as configuration metadata; the trajectory endpoint derives them from the scenario
+    configuration at request time. No migration needed for historical fixtures.
+
+**Recommendation:** Option (a) for M9 (minimum viable; no migration). Option (b) if
+step-level metadata grows beyond two fields. The FA brief's fixture CI gate
+(`pytest tests/fixtures/`) enforces the character constraints; the storage schema question
+is orthogonal to validation.
+
+**The trajectory endpoint cannot return `step_event_label` or `step_significance` until
+this storage design is decided.**
+
+---
+
 ## Appendix — Review Findings Log
 
 Three-agent review conducted 2026-05-22 (UX Design Thinking, UX Designer, QA Lead).

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -411,6 +411,123 @@ endpoints:
     db_reads: [scenarios, scenario_state_snapshots]
 
   - method: GET
+    path: "/scenarios/{scenario_id}/trajectory"
+    summary: >
+      Multi-step trajectory for all four measurement frameworks. Returns computed
+      steps only (dense array — ADR-010 Decision 2, FA-R3). null composite_score
+      on a returned step means governance-in-validation only, not an uncomputed step.
+      PARTIAL SCHEMA — three open EL decisions must be resolved before implementation.
+      See Data Architect findings DA-F1 through DA-F5 in docs/frontend/fa-brief-m9-instrument-cluster.md.
+    status: PENDING — EL decisions required on DA-F2 (MDA floor schema), DA-F4 (single-entity null handling)
+    auth: none
+    path_params:
+      scenario_id: {type: string}
+    response:
+      status: 200
+      body:
+        scenario_id: {type: string}
+        entity_id: {type: string}
+        steps:
+          type: array
+          description: >
+            Computed steps only — dense array (ADR-010 Decision 2). Absent steps
+            were not yet computed at response time. Step 0 = initial state.
+          items:
+            step_index: {type: integer}
+            effective_from:
+              type: string
+              format: "ISO 8601"
+              description: "From scenario_state_snapshots.timestep at this step"
+            step_event_label:
+              type: "string|null"
+              description: >
+                PENDING DA-F5 — storage schema not yet defined. Event label for
+                SIGNIFICANT steps in Mode 1. Must be ≤ 8 words AND ≤ 32 characters
+                (FA brief §Mode 1 Step Axis Annotation, DD-014).
+            step_significance:
+              type: "string|null"
+              description: >
+                PENDING DA-F5 — storage schema not yet defined.
+              values: ["SIGNIFICANT", "STANDARD", null]
+            financial:
+              composite_score:
+                type: "string|null"
+                description: >
+                  Decimal as string. null for governance-in-validation.
+                  PENDING DA-F4 — null also occurs in single-entity scenarios
+                  (single_entity_warning=true); EL decision required on trajectory
+                  endpoint behaviour for single-entity Mode 1.
+              confidence_tier: {type: integer, range: [1, 5]}
+              ci_lower:
+                type: "string|null"
+                description: >
+                  PENDING ADR-007 (DA-F3) — BandingEngine not yet implemented.
+                  null until ADR-007 accepted. Decimal as string when present.
+              ci_upper:
+                type: "string|null"
+                description: "PENDING ADR-007 (DA-F3) — same as ci_lower."
+            human_development:
+              composite_score: {type: "string|null", description: "Same null semantics as financial — see DA-F4"}
+              confidence_tier: {type: integer}
+              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
+              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
+            ecological:
+              composite_score: {type: "string|null"}
+              confidence_tier: {type: integer}
+              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
+              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
+            governance:
+              composite_score:
+                type: "string|null"
+                description: >
+                  null = governance-in-validation (GovernanceModule deferred M9,
+                  ADR-005 Amendment 3 Decision M8-4). Distinct from single-entity
+                  null in financial/human_development — see DA-F4.
+              confidence_tier: {type: integer}
+              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
+              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
+            policy_inputs:
+              type: array
+              description: Policy input events applied at this step. Source: scenario_scheduled_inputs.
+              items:
+                input_type: {type: string}
+                input_data: {type: object}
+            shock_events:
+              type: array
+              description: Exogenous shock events at this step.
+              items:
+                event_type: {type: string}
+                metadata: {type: object}
+            mda_floors:
+              type: array
+              description: >
+                PENDING DA-F2 — composite-score-level MDA floors have no storage in
+                current schema. mda_thresholds.floor_value is indicator-level.
+                EL decision required: (a) add composite_floor_value field to
+                mda_thresholds with migration; or (b) defer MDA floor overlays until
+                composite-score-level threshold table is defined. Projection from
+                indicator-level to composite-score-level is prohibited (CM-R3, ADR-010
+                Decision 6 — methodologically dishonest).
+              items:
+                framework: {type: string, values: ["financial", "human_development", "ecological", "governance"]}
+                floor_value:
+                  type: "string|null"
+                  description: "PENDING DA-F2 — composite-score-level; not indicator-level projection"
+                threshold_type: {type: string, values: ["WARNING", "CRITICAL", "TERMINAL"]}
+      status_404: "Scenario not found"
+    db_reads:
+      - scenarios
+      - scenario_state_snapshots
+      - mda_thresholds
+      - "[PENDING DA-F5] step_annotations or equivalent per-step metadata source"
+    notes:
+      - "DA-F1: Endpoint added 2026-05-22. Schema PARTIAL — five Data Architect findings pending EL decisions."
+      - "DA-F2: mda_floors blocked — no composite-score-level floor storage in current schema."
+      - "DA-F3: ci_lower/ci_upper fields registered as pending-ADR-007 placeholders."
+      - "DA-F4: single-entity null handling for financial/human_development composite_score requires EL decision."
+      - "DA-F5: step_event_label/step_significance have no schema home — storage design required."
+
+  - method: GET
     path: "/scenarios/{scenario_id}/measurement-output"
     summary: >
       Multi-framework measurement output for one entity at one step.


### PR DESCRIPTION
## Summary

- Data Architect Agent review of M9 FA brief data contract assumptions
- Schema files read: `api_contracts.yml` v1.0, `database.yml` v1.1, `simulation_state.yml` v1.0
- 5 findings; 2 require EL decisions before trajectory endpoint implementation can begin

## Findings

| ID | Finding | Status |
|---|---|---|
| DA-F1 | `GET /scenarios/{id}/trajectory` absent from `api_contracts.yml` | **Partial stub added** — gaps flagged as PENDING |
| DA-F2 | No composite-score-level MDA floor storage in current schema | **EL decision required** before MDA floor overlays can be implemented |
| DA-F3 | `ci_lower`/`ci_upper` absent from all schema files | **Registered** as pending-ADR-007 in stub; no action until ADR-007 |
| DA-F4 | Single-entity composite_score null undefined for Mode 1 | **EL decision required** — Issue #193 is a prerequisite; Greece demo would show no financial/HD curves |
| DA-F5 | `step_event_label`/`step_significance` have no schema home | **Three storage options presented** — decision needed before trajectory endpoint can return these fields |

## Changes

- `docs/schema/api_contracts.yml` — added partial stub for `GET /scenarios/{id}/trajectory` with PENDING tags on all unresolved fields
- `docs/frontend/fa-brief-m9-instrument-cluster.md` — added Data Architect Review appendix with full finding texts and resolution options

## EL decisions required before trajectory view implementation

**DA-F2:** Choose between:
- (a) Add `composite_floor_value` field to `mda_thresholds` (migration required)  
- (b) Defer MDA floor overlays until composite-score-level threshold schema is defined

**DA-F4:** Choose between:
- (a) Trajectory endpoint uses different scoring for single-entity scenarios (requires methodology decision)
- (b) Single-entity Mode 1 trajectory view suppresses financial/HD curves with advisory overlay

**DA-F5:** Choose between:
- (a) `step_annotations` key in `scenarios.configuration` JSONB (no migration needed)
- (b) New `step_annotations` table (migration required)
- (c) Fixture-only; not DB-persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)