### PR TITLE
docs(adr+schema): ADR-010 D6+D2 amendments; CM reference range consultation; schema updates

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated:** 2026-05-22 (Three EL decisions recorded — Path A selected, MDA floors deferred, step_metadata JSONB confirmed; CM reference range consultation is next hard gate; PR #427 open)
+**Last updated:** 2026-05-23 (Issue #428 prerequisites complete — CM consultation done; ADR-010 D2+D6 amendments applied; api_contracts.yml + database.yml updated; trajectory endpoint implementation unblocked; PR #429 open)
 **Current milestone:** M9 — Standards Foundation
 
 ---
@@ -72,7 +72,8 @@ Twelve issues filed 2026-05-19. Must complete before M9 UX implementation begins
 
 | PR | Title | Date |
 |---|---|---|
-| #427 | docs(frontend): EL decisions A/B/C recorded — unblock trajectory endpoint implementation | 2026-05-22 |
+| #429 | docs(adr+schema): ADR-010 D6+D2 amendments; CM reference range consultation; schema updates | 2026-05-23 |
+| #427 | docs(frontend): EL decisions A/B/C recorded — unblock trajectory endpoint implementation | 2026-05-22 — MERGED |
 | #426 | docs(frontend): Six-agent parallel consultation — DA-F2/F4/F5 pre-implementation record | 2026-05-22 — MERGED |
 | #425 | docs(frontend): Architect Agent review of Data Architect findings (DA-F1–F5) | 2026-05-22 — MERGED |
 | #424 | docs(schema+frontend): Data Architect review — trajectory endpoint stub and 5 schema findings | 2026-05-22 — MERGED |
@@ -159,9 +160,7 @@ All Horizon:Immediate issues are now closed. M8 feature-complete.
 
 | Decision | Context | Status |
 |---|---|---|
-| CM reference range consultation — financial + HD indicator reference ranges | IMMEDIATE NEXT GATE. Path A (Decision B) cannot be implemented until CM defines reference ranges for financial and HD composite indicators. Without declared reference ranges, the trajectory endpoint cannot compute normalized absolute composite scores. CM activation required: define reference ranges for each indicator contributing to the financial and HD framework composites, and document in a consultation artifact. | Pending — CM activation required |
-| ADR-010 Decision 2 amendment | Required to record: (1) scoring_basis field on FrameworkCurvePoint; (2) single-entity endpoint behavior (Path A); (3) Tier 3 confidence floor for normalized absolute scores; (4) step_metadata JSONB storage contract (Decision C). Architect Agent: EXECUTE after CM reference range consultation is complete. | Pending — after CM consultation |
-| ADR-010 Decision 6 amendment | Required to record: M9 deferral of composite-score MDA floor overlays; ecological WARNING at 1.0 authorized for M9; M10-B schema (mda_composite_floors table) confirmed. Architect Agent: EXECUTE. | Pending |
+| Trajectory endpoint implementation | FastAPI route + Pydantic model + normalized_absolute_strategy backend function. All prerequisites complete. May begin. | Ready — unblocked |
 |---|---|---|
 | Decision A (DA-F2): MDA floor overlays deferred to M10 | M9 trajectory view ships without MDA floor ReferenceLines except ecological WARNING at y=1.0 (boundary-crossing, defensible without backtesting). CM consultation on indicator inventory + reference ranges authorized as M10 prerequisite. M10-B schema confirmed (new mda_composite_floors table with cm_approval_reference column). ADR-010 Decision 6 amendment pending. | Complete ✅ — 2026-05-22 |
 | Decision B (DA-F4): Path A selected — normalized absolute composite for single-entity trajectory | Path A: four framework curves rendered for single-entity scenarios; financial/HD use normalized absolute value composite (Tier 3 floor); strokeDasharray="8 3"; "single-country index" legend + tooltip; Zone 3 methodology note mandatory. CM reference range consultation is the hard implementation gate. ADR-010 Decision 2 amendment + Issue #193 update required. | Complete ✅ — 2026-05-22 |
@@ -181,6 +180,7 @@ All Horizon:Immediate issues are now closed. M8 feature-complete.
 
 | Decision | Rationale | Date |
 |---|---|---|
+| Issue #428 prerequisites complete — trajectory endpoint unblocked | (1) ADR-010 Decision 6 amendment: M9 deferral of MDA floor overlays; ecological WARNING at 1.0 authorized; M10-B schema confirmed. (2) CM reference range consultation complete: gdp_growth [-0.10, 0.06]; reserve_coverage_months [0.0, 12.0]; unemployment_rate [0.02, 0.30] inverted; net_enrollment_secondary [0.40, 1.00]; health_expenditure excluded (non-monotonic); Tier 3 floor for all normalized_absolute scores. (3) ADR-010 Decision 2 amendment: scoring_basis field, single-entity scoring contract, step_metadata JSONB. api_contracts.yml and database.yml updated. Trajectory endpoint implementation now unblocked. PR #429. | 2026-05-23 |
 | EL Decisions A/B/C recorded — trajectory endpoint implementation unblocked | Decision A: MDA floor overlays deferred to M10; ecological WARNING at 1.0 authorized for M9; CM consultation on reference ranges authorized; M10-B schema confirmed. Decision B: Path A selected — normalized absolute composite for single-entity trajectory; four curves; Tier 3 confidence floor; CM reference range consultation is the hard next gate. Decision C: step_metadata JSONB option (a) confirmed. All recorded on Issue #366. Issue #193 updated. PR #427. | 2026-05-22 |
 | Six-agent parallel consultation — DA-F2/F4/F5 pre-implementation record | CM, UX Design Thinking, UX Designer, Data Architect, QA Lead, Frontend Architect activated simultaneously. Key rulings: (1) CM: single-entity normalized absolute composite is methodologically sound (Tier 3 floor); Path A requires pre-declared reference ranges before endpoint can compute. (2) CM: composite-score MDA floors cannot be defined without backtesting — defer to M10; ecological WARNING at 1.0 is only M9 exception. (3) UT: four-curve Mode 1 Greece is M9 exit requirement; DA-F4 is demo scope decision. (4) UD: Path A rulings (strokeDasharray="8 3", legend labels, tooltip) and Path B rulings (40px amber strip, approved text) recorded. (5) DA: step_metadata JSONB confirmed valid; scoring_basis field for Path A; single_entity_advisory at response root for Path B; mda_floors structural error in stub identified. (6) QA: AC-009 corrected (3 shock ReferenceLines, not 6+); AC-015 broadened to all four Lines. (7) FA: atom unchanged for all paths; connectNulls={false} confirmed on all 8 Lines; single_entity_advisory must not be atom field. Three EL decisions still pending. PR #426. | 2026-05-22 |
 | Architect Agent review of Data Architect findings — three EL decisions required | Data Architect found 5 schema gaps (DA-F1–F5). Architect dispositions: DA-F1 stub adequate; DA-F2 defer MDA floor overlays to M10 + CM consultation; DA-F3 correct as-is; DA-F4 CRITICAL (Greece Mode 1 blocked — single-entity null; CM + ADR-010 amendment required); DA-F5 step_metadata JSONB approach confirmed. Arch-F1: "STANDARD" → "ROUTINE" correction applied. Three EL decisions pending. PR #425. | 2026-05-22 |

--- a/docs/adr/ADR-010-trajectory-view.md
+++ b/docs/adr/ADR-010-trajectory-view.md
@@ -179,7 +179,7 @@ interface FrameworkCurvePoint {
                                               //   "ecological" | "governance"
   composite_score: number | null;             // null = governance in validation
   confidence_tier: 1 | 2 | 3 | 4 | 5;
-  scoring_basis: "percentile_rank" | "normalized_absolute";  // Amendment 2026-05-23
+  scoring_basis: "percentile_rank" | "normalized_absolute" | "boundary_proximity";  // Amendment 2026-05-23
   // ADR-006 banding fields (present when BandingEngine is invoked)
   ci_lower: number | null;
   ci_upper: number | null;
@@ -235,9 +235,13 @@ Key properties of the normalized absolute composite:
 - **Confidence tier floor:** Tier 3 minimum for all normalized absolute scores,
   regardless of the individual indicator confidence tiers
 - **Scoring basis field:** `FrameworkCurvePoint.scoring_basis` distinguishes
-  `"percentile_rank"` from `"normalized_absolute"`. This field is mandatory on every
-  `FrameworkCurvePoint` — it is never absent. Multi-entity scenarios carry
-  `"percentile_rank"` on all four frameworks.
+  `"percentile_rank"` from `"normalized_absolute"` from `"boundary_proximity"`. This
+  field is mandatory on every `FrameworkCurvePoint` — it is never absent. Values by
+  framework in multi-entity scenarios: financial → `"percentile_rank"`;
+  human_development → `"percentile_rank"`; ecological → `"boundary_proximity"` (always
+  entity-intrinsic, calibrated to planetary boundary); governance → `"percentile_rank"`
+  (null composite_score when in-validation). In single-entity scenarios: financial and
+  human_development → `"normalized_absolute"`; ecological and governance unchanged.
 - **`null` composite_score semantics in single-entity scenarios:** A null
   `composite_score` on a financial or HD curve in a single-entity scenario means
   zero normalizable indicators were present for that framework at that step — not

--- a/docs/adr/ADR-010-trajectory-view.md
+++ b/docs/adr/ADR-010-trajectory-view.md
@@ -179,6 +179,7 @@ interface FrameworkCurvePoint {
                                               //   "ecological" | "governance"
   composite_score: number | null;             // null = governance in validation
   confidence_tier: 1 | 2 | 3 | 4 | 5;
+  scoring_basis: "percentile_rank" | "normalized_absolute";  // Amendment 2026-05-23
   // ADR-006 banding fields (present when BandingEngine is invoked)
   ci_lower: number | null;
   ci_upper: number | null;
@@ -188,9 +189,9 @@ interface FrameworkCurvePoint {
 
 interface MDAFloor {
   framework: string;
-  indicator_key: string;
   floor_value: number;
   severity: "WARNING" | "CRITICAL" | "TERMINAL";
+  label: string;                              // e.g. "Planetary boundary"
 }
 ```
 
@@ -215,6 +216,55 @@ state update within the already-fetched trajectory data.
 the current trajectory response is frozen as the baseline state in the shared
 step atom (Decision 4). Subsequent trajectory fetches return the active
 (modified) trajectory. The baseline is held in client state, not re-fetched.
+
+**Amendment — single-entity scoring and step_metadata storage (2026-05-23, EL
+Decisions B and C, Issue #428):**
+
+**Single-entity composite scoring (Path A).** When a scenario contains fewer than
+two entities, percentile-rank composite scores are unavailable for the financial and
+human_development frameworks (ecological uses boundary-proximity scoring, which is
+entity-intrinsic; governance null is handled by Decision 5). In single-entity scenarios,
+the trajectory endpoint uses normalized absolute value composite scoring for financial
+and human_development, as specified in the Chief Methodologist consultation
+`docs/architecture/cm-reference-range-consultation-2026-05-23.md`.
+
+Key properties of the normalized absolute composite:
+
+- **Score range:** [0.0, 1.0] — same as percentile-rank composite; ecological [0.0, 2.0]
+  scale unchanged
+- **Confidence tier floor:** Tier 3 minimum for all normalized absolute scores,
+  regardless of the individual indicator confidence tiers
+- **Scoring basis field:** `FrameworkCurvePoint.scoring_basis` distinguishes
+  `"percentile_rank"` from `"normalized_absolute"`. This field is mandatory on every
+  `FrameworkCurvePoint` — it is never absent. Multi-entity scenarios carry
+  `"percentile_rank"` on all four frameworks.
+- **`null` composite_score semantics in single-entity scenarios:** A null
+  `composite_score` on a financial or HD curve in a single-entity scenario means
+  zero normalizable indicators were present for that framework at that step — not
+  governance-in-validation and not an uncomputed step. The three null sources remain
+  semantically distinct: (1) absent step = uncomputed; (2) null governance = in
+  validation; (3) null financial/HD in single-entity = no normalizable indicators
+  at that step. The `scoring_basis` field disambiguates cases (2) and (3) at render
+  time.
+
+**Step metadata storage (Decision C).** The `step_event_label` and `step_significance`
+fields on `TrajectoryStep` are sourced from the `step_metadata` key in
+`scenarios.configuration` JSONB. Structure:
+
+```json
+{
+  "step_metadata": {
+    "1": { "step_event_label": "Capital controls imposed", "step_significance": "SIGNIFICANT" },
+    "3": { "step_event_label": "ESM programme begins", "step_significance": "SIGNIFICANT" }
+  }
+}
+```
+
+Keys are 1-based step index strings. Absence of a key means the step is ROUTINE —
+`step_event_label` returns `null` and `step_significance` returns `"ROUTINE"` in the
+response. The value `"STANDARD"` is incorrect and must be rejected by fixture
+validation (see Decision 7). No database migration is required — `scenarios.configuration`
+is an unconstrained JSONB column.
 
 ---
 
@@ -369,6 +419,45 @@ alert panel are complementary surfaces for the same threshold crossing. The
 trajectory view shows the crossing in spatial context (which step, how deep
 below the floor); Zone 1B shows the crossing with causal attribution and cohort
 detail. Both must be consistent — the same step and the same threshold.
+
+**Amendment — M9 deferral (2026-05-23, EL Decision A, Issue #428):**
+
+Composite-score-level MDA floor values cannot be defined responsibly for M9.
+Defining them requires: (1) a complete indicator inventory per framework, (2)
+backtesting evidence showing historical composite score values at which MDA
+threshold violations co-occurred, and (3) a validated mapping function from
+indicator-level thresholds to composite score space. None of these conditions
+are satisfied at M9. Rendering invented floor values as authoritative
+`<ReferenceLine>` elements violates the No False Precision principle.
+
+**M9 trajectory view ships with `mda_floors: []` (empty array) for all
+frameworks** — except the ecological exception below. The `mda_floors.map()`
+render loop produces no SVG elements for an empty array; no conditional render
+guard or placeholder is needed.
+
+**Ecological exception — WARNING floor at y=1.0 authorized for M9:** An
+ecological composite score of 1.0 means the entity is at the planetary boundary
+for at least one indicator. This is a boundary-crossing event by definition.
+No backtesting is required to establish this floor value — it is inherent to the
+ecological scoring scale. The M9 trajectory endpoint may include:
+
+```typescript
+{ framework: "ecological", floor_value: 1.0, severity: "WARNING",
+  label: "Planetary boundary" }
+```
+
+in `mda_floors` when the ecological framework is active in the scenario.
+All other framework floors remain deferred.
+
+**M10 schema path — M10-B confirmed:** A new `mda_composite_floors` table
+(separate from `mda_thresholds`) is the correct M10 home for composite-score-level
+floors. The `mda_thresholds` table stores indicator-level thresholds; mixing
+composite-level floors into it blurs the Zone 1A / Zone 2B architectural boundary.
+The new table must include a non-null `cm_approval_reference` column — no composite
+floor value may be seeded without a traceable Chief Methodologist consultation
+reference. The `MDAFloor` response interface (above) remains correct; the backend
+will read from `mda_composite_floors` rather than `mda_thresholds` when that table
+exists.
 
 ---
 

--- a/docs/architecture/cm-reference-range-consultation-2026-05-23.md
+++ b/docs/architecture/cm-reference-range-consultation-2026-05-23.md
@@ -1,0 +1,454 @@
+# Chief Methodologist Consultation — Reference Ranges for Single-Entity Composite Scoring
+
+> **Artifact type:** Chief Methodologist consultation
+> **Activation:** `Chief Methodologist: VALIDATE — financial and HD indicator reference
+> ranges for Path A single-entity normalized absolute composite scoring`
+> **Date:** 2026-05-23
+> **Requested by:** EL Decision B (2026-05-22, PR #427, Issue #428)
+> **Status:** Complete — implementation contract at §7
+> **Related:** ADR-010 Decision 2 amendment (blocked on this consultation)
+
+---
+
+## 1. Scope and What I Was Asked
+
+EL Decision B selected Path A: single-entity trajectory scenarios (where N < 2 entities
+makes percentile-rank composite scoring unavailable) will use normalized absolute value
+composite scoring. The score is entity-intrinsic — measured against pre-declared reference
+ranges rather than a comparison population.
+
+I was asked to define:
+
+1. Reference ranges for the financial framework indicators present in the Greece fixture
+2. Reference ranges for the human development framework indicators present in the Greece fixture
+3. The aggregation function for per-indicator normalized scores → framework composite
+4. The confidence tier floor for all single-entity normalized scores
+
+**What I am not defining:** Reference ranges for the ecological or governance frameworks.
+Ecological uses boundary proximity scoring (already entity-intrinsic — no change needed).
+Governance null rendering is handled separately by Decision 5. This consultation covers
+financial and human development only.
+
+---
+
+## 2. Financial Framework Indicators — Greece Fixture
+
+The Greece fixture includes two financial indicators:
+
+| Indicator | Unit | Direction | Source | Greece 2010 value |
+|---|---|---|---|---|
+| `gdp_growth` | ratio (e.g., -0.054) | Higher is better | IMF WEO Apr 2010 | -0.054 |
+| `reserve_coverage_months` | months | Higher is better | IMF CR10/110 | 2.0 |
+
+The MDA threshold table also includes `debt_gdp_ratio` (financial, floor: 1.20 gte) but
+this indicator does not appear in the Greece fixture's `initial_attributes`. I address it
+in §6 (open question).
+
+### 2a. gdp_growth — Reference Range
+
+**Economic grounding:** IMF sustainability literature and historical crisis episodes
+establish the following bands:
+- Below -0.10 (−10%): severe contraction; the bottom 5th percentile of outcomes in
+  the post-WWII advanced economy dataset
+- 0.0: stagnation boundary
+- 0.02–0.05 (2–5%): healthy growth corridor for advanced economies
+- Above 0.06: strong growth; sustainable for middle-income economies but rare in
+  advanced economies over multi-year windows
+
+**Reference range decision:** [-0.10, 0.06]
+
+Rationale: -0.10 anchors the worst plausible sustained outcome (not the extreme
+tail — Greek GDP contracted 7% in 2011, the year after the baseline). 0.06 anchors
+strong but credible growth. Values below -0.10 are clamped to 0.0 on the normalized
+scale; values above 0.06 are clamped to 1.0.
+
+**Normalization:** Linear interpolation within the reference range.
+
+```
+normalized_gdp_growth = clamp((value - (-0.10)) / (0.06 - (-0.10)), 0.0, 1.0)
+                      = clamp((value + 0.10) / 0.16, 0.0, 1.0)
+```
+
+At Greece 2010 (-0.054): (0.046) / 0.16 = **0.288** (in lower third of range —
+consistent with a country in fiscal crisis but not at the most extreme contractionary
+point)
+
+**Confidence tier for this range:** Tier 2 for the range boundaries themselves (IMF
+and World Bank literature provides empirical backing). The Tier 3 floor for the
+composite output is set by the single-entity scoring method, not the range quality.
+
+### 2b. reserve_coverage_months — Reference Range
+
+**Economic grounding:** IMF reserve adequacy framework (2011, revised 2013) and the
+ARA (Assessing Reserve Adequacy) metric establish:
+- Below 2.0 months: CRITICAL — insufficient to cover import demands under stress
+- 2.5 months: MDA CRITICAL floor (already defined in mda_thresholds)
+- 3.0 months: minimum safe corridor for most economies
+- 6.0+ months: comfortable; the modal recommendation for emerging markets under
+  the IMF's ARA framework
+- 12.0+ months: robust; characteristic of export-surplus economies (China, Norway)
+
+**Reference range decision:** [0.0, 12.0] months
+
+Rationale: 0.0 is the lower bound by definition (cannot hold negative reserves in
+this metric). 12.0 represents robust adequacy for any economy — values above 12
+exist but represent extreme reserve accumulation (e.g., oil exporters with sovereign
+wealth funds) that is not the target population for this normalization. Values above
+12.0 are clamped to 1.0.
+
+**Normalization:**
+
+```
+normalized_reserve_coverage = clamp(value / 12.0, 0.0, 1.0)
+```
+
+At Greece 2010 (2.0 months): 2.0 / 12.0 = **0.167** (in CRITICAL zone — consistent
+with the Greece fixture's MDA CRITICAL alert from step 1 onward)
+
+**Confidence tier for this range:** Tier 2 (IMF ARA framework documentation).
+
+---
+
+## 3. Human Development Framework Indicators — Greece Fixture
+
+The Greece fixture includes three HD indicators:
+
+| Indicator | Unit | Direction | Source | Greece 2010 value |
+|---|---|---|---|---|
+| `unemployment_rate` | ratio | Lower is better | Eurostat LFS Q1 2010 | 0.127 |
+| `health_expenditure_pct_gdp` | ratio | Non-monotonic (see §3b) | WDI 2010 | 0.095 |
+| `net_enrollment_secondary` | ratio | Higher is better | WDI 2010 | 0.991 |
+
+### 3a. unemployment_rate — Reference Range
+
+**Economic grounding:** Labour economics literature and OECD employment outlook data:
+- 0.02–0.04 (2–4%): structural minimum in modern economies (frictional unemployment)
+- 0.05–0.07 (5–7%): within normal range for most advanced economies
+- 0.10 (10%): elevated; triggers automatic stabilizer responses in most OECD systems
+- 0.20 (20%): severe; characteristic of crisis-era youth unemployment in Southern Europe
+- 0.30 (30%): extreme; Greece's youth unemployment peak (2013) approached this level
+
+**Reference range decision:** [0.02, 0.30]; normalized as "lower is better" (inverted)
+
+Rationale: 0.02 is the frictional minimum — the best plausible value. 0.30 represents
+severe crisis conditions; values above this exist but are historically rare for total
+(not youth) unemployment rates over sustained periods.
+
+**Normalization:**
+
+```
+normalized_unemployment = clamp((0.30 - value) / (0.30 - 0.02), 0.0, 1.0)
+                        = clamp((0.30 - value) / 0.28, 0.0, 1.0)
+```
+
+At Greece 2010 (0.127): (0.30 - 0.127) / 0.28 = 0.173 / 0.28 = **0.618** (above
+midpoint — consistent with 12.7% being elevated but not yet at the crisis peak that
+Greece would reach by 2012)
+
+**Confidence tier for this range:** Tier 2 (OECD and Eurostat empirical literature).
+
+### 3b. health_expenditure_pct_gdp — Methodological Flag
+
+I am flagging this indicator as **methodologically problematic for normalized absolute
+scoring** and recommending it be **excluded from the financial/HD composite normalization
+until an outcome-based indicator is substituted**.
+
+**Reason:** `health_expenditure_pct_gdp` is a spending indicator, not a health outcome
+indicator. The relationship between health spending and health outcomes is non-monotonic
+in a cross-country comparison, and the relationship is particularly distorted for:
+
+1. **Crisis contexts:** Spending may decline sharply due to austerity while population
+   health outcomes (life expectancy, infant mortality) lag and may not deteriorate as
+   quickly. Conversely, spending may drop while still being well-allocated.
+2. **High-income vs middle-income:** 9.5% of GDP (Greece 2010) is comparable to the
+   EU-15 average; in a low-income economy 5% of GDP would represent strong commitment.
+   Without a comparison population, the normalization has no anchor.
+3. **The "is more better?" problem:** Above ~10% of GDP, marginal health spending
+   exhibits diminishing returns in the OECD literature. A country spending 15% of GDP
+   on health is not necessarily in better health than one spending 9%.
+
+**Recommended substitution (M10):** The correct HD outcome indicators for health
+are `life_expectancy_at_birth` or `under_5_mortality_rate` — both have internationally
+validated reference ranges (WHO global standards) and unambiguous directionality. Issue
+for M10 backlog: add at least one health outcome indicator to the HD framework for the
+Greece fixture; retire `health_expenditure_pct_gdp` as a composite scoring input.
+
+**For M9:** Exclude `health_expenditure_pct_gdp` from the single-entity normalized
+absolute composite calculation. The Greece single-entity HD composite will be computed
+over `unemployment_rate` and `net_enrollment_secondary` only (two indicators). This
+is explicitly flagged in the trajectory view methodology note (Zone 3).
+
+### 3c. net_enrollment_secondary — Reference Range
+
+**Economic grounding:** UNESCO Institute for Statistics and World Bank data:
+- 0.40 (40%): low — characteristic of low-income countries with structural barriers
+  to secondary enrollment
+- 0.75 (75%): middle — the global median for upper-middle-income countries
+- 0.90 (90%): high — characteristic of high-income OECD countries
+- 1.00 (100%): full enrollment; achieved in some high-income countries with compulsory
+  secondary education
+
+**Reference range decision:** [0.40, 1.00]
+
+Rationale: 0.40 represents the low end of middle-income trajectories; 1.00 represents
+full enrollment. Values below 0.40 are clamped to 0.0; values above 1.00 are not
+possible (rate is bounded by definition).
+
+**Normalization:**
+
+```
+normalized_net_enrollment = clamp((value - 0.40) / (1.00 - 0.40), 0.0, 1.0)
+                          = clamp((value - 0.40) / 0.60, 0.0, 1.0)
+```
+
+At Greece 2010 (0.991): (0.991 - 0.40) / 0.60 = 0.591 / 0.60 = **0.985** (near the
+top of the range — consistent with Greece's strong secondary enrollment rates; this
+is the one positive indicator in the M9 HD picture)
+
+**Confidence tier for this range:** Tier 2 (UNESCO and World Bank education data).
+
+---
+
+## 4. Aggregation Function
+
+**Decision: Unweighted arithmetic mean of the non-excluded indicators.**
+
+All indicators that pass the inclusion criteria (numeric, not flagged for exclusion,
+reference range defined) receive equal weight. The unweighted mean is the defensible
+default for the following reasons:
+
+1. **No validated differential weights exist for these frameworks.** Weighting schemes
+   that assign more importance to one indicator over another require empirical validation
+   that we do not have for the M9 indicator set. Inventing weights implies precision that
+   does not exist — a No False Precision violation.
+2. **Equal weighting is transparently auditable.** Users can compute the aggregate from
+   the per-indicator scores without knowing a hidden weighting schema.
+3. **The set is small.** With 2–3 indicators per framework at M9, differential weighting
+   has limited effect and adds no analytical value.
+
+**Aggregation formula:**
+
+```python
+def normalized_absolute_composite(normalized_scores: list[Decimal]) -> Decimal | None:
+    """Unweighted mean of normalized indicator scores. Returns None if empty."""
+    if not normalized_scores:
+        return None
+    return sum(normalized_scores) / Decimal(len(normalized_scores))
+```
+
+**Example for Greece 2010 financial framework:**
+- `gdp_growth`: 0.288
+- `reserve_coverage_months`: 0.167
+- Composite: (0.288 + 0.167) / 2 = **0.228**
+
+**Example for Greece 2010 HD framework (two indicators — health expenditure excluded):**
+- `unemployment_rate`: 0.618
+- `net_enrollment_secondary`: 0.985
+- Composite: (0.618 + 0.985) / 2 = **0.802**
+
+These are plausible values: Greece's financial position was severely stressed (0.228) while
+HD indicators, though deteriorating, had not yet reached crisis-level suppression by 2010.
+The 0.802 HD composite reflects this — high enrollment, elevated but not catastrophic
+unemployment at programme entry.
+
+---
+
+## 5. Confidence Tier Floor
+
+All single-entity normalized absolute composite scores carry a **Tier 3 confidence floor**,
+regardless of the confidence tier of the individual indicator observations.
+
+**Rationale:** The Tier 3 floor applies because:
+
+1. **The reference ranges are methodologically uncertain.** The ranges defined in §2
+   and §3 are grounded in literature but are not empirically validated for the specific
+   simulation engine's scoring scale. A range that is slightly wrong produces a systematic
+   bias in the composite score that cannot be detected from the output alone.
+2. **The aggregation function is unweighted by methodological necessity, not by evidence.**
+   A weighting scheme that more accurately reflects domain knowledge might change the
+   composite materially; we cannot know by how much.
+3. **Single-entity scores are not comparable across scenarios.** A Greece financial
+   composite of 0.228 is not comparable to an Argentina financial composite of 0.35
+   computed via percentile rank — the scoring bases are different. The Tier 3 floor
+   signals this comparability limitation to users.
+
+The Tier 3 floor does not mean the output is unreliable — it means it carries
+acknowledged methodological uncertainty that the user should factor into their
+interpretation. This is consistent with the No False Precision principle.
+
+---
+
+## 6. Open Questions for M10
+
+**OQ-1: debt_gdp_ratio.** This indicator has an MDA threshold but does not appear in
+the Greece fixture's initial_attributes. If it is added to the Greece fixture in a
+future PR, the reference range is: [0.0, 2.0]; lower is better; normalization:
+`1 - clamp(value / 2.0, 0.0, 1.0)`. Tier 2 confidence for the range (IMF DSA framework).
+This is not an M9 prerequisite.
+
+**OQ-2: health outcome indicator.** §3b recommends replacing `health_expenditure_pct_gdp`
+with a health outcome indicator (`life_expectancy_at_birth` or `under_5_mortality_rate`)
+for M10. Reference ranges:
+- `life_expectancy_at_birth` in years: [40.0, 85.0], higher is better,
+  normalization: `(value - 40.0) / 45.0`. Source: WHO global health statistics.
+- `under_5_mortality_rate` per 1000: [3.0, 150.0], lower is better,
+  normalization: `1 - ((value - 3.0) / 147.0)`. Source: UNICEF/WHO joint estimates.
+Not M9 scope — backlog item.
+
+**OQ-3: food_insecurity_rate and poverty_headcount_ratio.** These appear in the MDA
+threshold table (HD framework) but not in the Greece fixture. If added in future
+scenarios, reference ranges are:
+- `food_insecurity_rate`: [0.0, 0.50]; lower is better; normalization: `1 - (value / 0.50)`.
+- `poverty_headcount_ratio`: [0.0, 0.70]; lower is better; normalization: `1 - (value / 0.70)`.
+These are estimates; empirical validation against FAOSTAT and World Bank poverty data
+required before M10 deployment. Not M9 scope.
+
+**OQ-4: Step-level indicator availability.** The Greece fixture provides initial
+attributes; step-level attribute updates are driven by the simulation engine. The
+trajectory endpoint must query step-level attributes (not just initial_attributes)
+to compute normalized absolute scores for each step. This is an implementation
+question, not a methodology question — but the CM flags it to ensure the backend
+implementation reads step-state snapshots, not only the scenario initial_attributes.
+
+---
+
+## 7. Implementation Contract
+
+This consultation produces the following formal contract for the trajectory endpoint
+implementation. All items are M9 scope unless marked M10.
+
+### 7a. Reference Ranges Table
+
+| Framework | Indicator | Range low | Range high | Direction | Formula |
+|---|---|---|---|---|---|
+| financial | `gdp_growth` | -0.10 | 0.06 | higher better | `clamp((v + 0.10) / 0.16, 0, 1)` |
+| financial | `reserve_coverage_months` | 0.0 | 12.0 | higher better | `clamp(v / 12.0, 0, 1)` |
+| human_development | `unemployment_rate` | 0.02 | 0.30 | lower better | `clamp((0.30 - v) / 0.28, 0, 1)` |
+| human_development | `net_enrollment_secondary` | 0.40 | 1.00 | higher better | `clamp((v - 0.40) / 0.60, 0, 1)` |
+| human_development | `health_expenditure_pct_gdp` | — | — | EXCLUDED | Do not include in composite |
+
+### 7b. Composite Score Contract
+
+```python
+SINGLE_ENTITY_REFERENCE_RANGES: dict[str, dict] = {
+    "gdp_growth": {
+        "low": Decimal("-0.10"), "high": Decimal("0.06"), "direction": "higher_better"
+    },
+    "reserve_coverage_months": {
+        "low": Decimal("0.0"), "high": Decimal("12.0"), "direction": "higher_better"
+    },
+    "unemployment_rate": {
+        "low": Decimal("0.02"), "high": Decimal("0.30"), "direction": "lower_better"
+    },
+    "net_enrollment_secondary": {
+        "low": Decimal("0.40"), "high": Decimal("1.00"), "direction": "higher_better"
+    },
+    # health_expenditure_pct_gdp: EXCLUDED — methodologically non-monotonic
+    # See cm-reference-range-consultation-2026-05-23.md §3b
+}
+
+SINGLE_ENTITY_COMPOSITE_TIER_FLOOR = 3  # All normalized absolute scores: min Tier 3
+
+
+def _normalized_absolute_strategy(
+    entity_indicators: dict[str, QuantitySchema],
+    framework: str,
+) -> Decimal | None:
+    """Entity-intrinsic composite from pre-declared reference ranges.
+
+    Used when N < 2 entities makes percentile-rank scoring unavailable.
+    Returns [0.0, 1.0] Decimal or None if no normalizable indicators.
+    Excludes indicators not in SINGLE_ENTITY_REFERENCE_RANGES.
+    """
+    scores: list[Decimal] = []
+    for attr_key, qty in entity_indicators.items():
+        if (qty.measurement_framework or "financial") != framework:
+            continue
+        spec = SINGLE_ENTITY_REFERENCE_RANGES.get(attr_key)
+        if spec is None:
+            continue  # indicator excluded or not yet defined
+        try:
+            v = Decimal(qty.value)
+        except Exception:  # noqa: BLE001
+            continue
+        low, high = spec["low"], spec["high"]
+        if spec["direction"] == "higher_better":
+            score = (v - low) / (high - low)
+        else:  # lower_better
+            score = (high - v) / (high - low)
+        scores.append(max(Decimal("0"), min(Decimal("1"), score)))
+    if not scores:
+        return None
+    return (sum(scores) / Decimal(len(scores))).quantize(Decimal("0.0001"))
+```
+
+### 7c. Mandatory Zone 3 Methodology Note
+
+When `scoring_basis == "normalized_absolute"` for any curve, the trajectory view's
+Zone 3 panel must display:
+
+> "Scores for [country_name] reflect absolute indicator position against declared
+> reference ranges, not ranking against a comparison population. Cross-scenario
+> comparison is not valid. Two indicators excluded from HD composite in this
+> scenario: health expenditure (spending proxy, not outcome indicator)."
+
+The parenthetical after "health expenditure" is mandatory if and only if
+`health_expenditure_pct_gdp` is present in the scenario's indicator set but
+excluded from the composite. The "[country_name]" slot is populated from the
+entity's display name.
+
+### 7d. api_contracts.yml additions required
+
+The trajectory endpoint stub (DA-F1, PR #424) must be updated to include:
+
+```yaml
+scoring_basis:
+  type: string
+  enum: ["percentile_rank", "normalized_absolute"]
+  description: >
+    Scoring method for this framework curve at this step.
+    "percentile_rank" — standard cross-entity composite; requires N≥2 entities.
+    "normalized_absolute" — entity-intrinsic; reference ranges defined in
+    docs/architecture/cm-reference-range-consultation-2026-05-23.md §7a.
+    Single-entity scenarios use "normalized_absolute" for financial and
+    human_development; ecological and governance are unaffected.
+```
+
+---
+
+## 8. Epistemic Limitations — What This Consultation Does Not Resolve
+
+I am flagging these explicitly so they appear in the institutional record:
+
+1. **Reference ranges are not backtested.** The ranges in §2 and §3 are grounded in
+   published economic literature and IMF/World Bank frameworks. They have not been
+   validated by running the simulation against the Greece fixture and checking that the
+   composite scores match historical assessments of Greece's financial/HD position.
+   Backtesting validation is a Tier 2 confidence requirement — until it runs, these
+   ranges carry Tier 3 confidence. This is why the single-entity composite floor is Tier 3.
+
+2. **The exclusion of health_expenditure_pct_gdp reduces the HD indicator set to two.**
+   An unweighted mean of two indicators is sensitive to outliers in a way that a
+   larger set would not be. The Greece 2010 baseline happens to have a clean picture
+   (unemployment elevated, enrollment high), but a scenario where both indicators move
+   in the same direction will produce composite scores near the extremes [0, 1] with
+   no moderating third indicator. This is flagged, not remedied, in M9.
+
+3. **Step-level indicator availability is engine-dependent.** The trajectory endpoint
+   reads step-state snapshots for each computed step. If the simulation engine does not
+   update `gdp_growth` or `unemployment_rate` at every step (because the module that
+   drives these attributes is not active), the normalized absolute composite for that
+   step will be computed over fewer indicators than expected — potentially zero, which
+   produces `null`. This is a correct null (no normalizable indicators computed at that
+   step), not an error.
+
+4. **These ranges are provisional pending backtesting.** The Architect Agent should
+   add backtesting gates (similar to existing Greece DIRECTION_ONLY thresholds) that
+   verify the normalized absolute composite at each historical step falls within
+   plausible historical assessment ranges. This is M10 work.
+
+---
+
+*Chief Methodologist — 2026-05-23*
+*Consultation reference: cm-reference-range-consultation-2026-05-23*
+*This document gates ADR-010 Decision 2 amendment and the trajectory endpoint implementation.*

--- a/docs/architecture/cm-reference-range-consultation-2026-05-23.md
+++ b/docs/architecture/cm-reference-range-consultation-2026-05-23.md
@@ -404,14 +404,17 @@ The trajectory endpoint stub (DA-F1, PR #424) must be updated to include:
 ```yaml
 scoring_basis:
   type: string
-  enum: ["percentile_rank", "normalized_absolute"]
+  enum: ["percentile_rank", "normalized_absolute", "boundary_proximity"]
   description: >
     Scoring method for this framework curve at this step.
-    "percentile_rank" — standard cross-entity composite; requires N≥2 entities.
-    "normalized_absolute" — entity-intrinsic; reference ranges defined in
-    docs/architecture/cm-reference-range-consultation-2026-05-23.md §7a.
-    Single-entity scenarios use "normalized_absolute" for financial and
-    human_development; ecological and governance are unaffected.
+    "percentile_rank" — cross-entity composite; financial and human_development in
+    multi-entity scenarios; governance (null when in-validation).
+    "normalized_absolute" — entity-intrinsic against declared reference ranges;
+    financial and human_development in single-entity scenarios. Tier 3 floor.
+    "boundary_proximity" — ecological only; distance from planetary boundary;
+    always entity-intrinsic. Scale [0.0, 2.0]. Amended from two-value to three-value
+    enum per DA review (DA-R3, PR #429): "percentile_rank" on ecological was
+    semantically incorrect — ecological is never a cross-entity percentile rank.
 ```
 
 ---

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -415,10 +415,10 @@ endpoints:
     summary: >
       Multi-step trajectory for all four measurement frameworks. Returns computed
       steps only (dense array — ADR-010 Decision 2, FA-R3). null composite_score
-      on a returned step means governance-in-validation only, not an uncomputed step.
-      PARTIAL SCHEMA — three open EL decisions must be resolved before implementation.
-      See Data Architect findings DA-F1 through DA-F5 in docs/frontend/fa-brief-m9-instrument-cluster.md.
-    status: PENDING — EL decisions required on DA-F2 (MDA floor schema), DA-F4 (single-entity null handling)
+      on a returned step means governance-in-validation OR no normalizable indicators
+      at that step for single-entity scenarios (see scoring_basis). Schema updated
+      2026-05-23 — EL Decisions A/B/C resolved; DA-F2/F4/F5 PENDINGs cleared.
+      ci_lower/ci_upper remain pending ADR-007.
     auth: none
     path_params:
       scenario_id: {type: string}
@@ -427,11 +427,25 @@ endpoints:
       body:
         scenario_id: {type: string}
         entity_id: {type: string}
+        step_count: {type: integer}
+        mda_floors:
+          type: array
+          description: >
+            Composite-score-level MDA floor lines for the trajectory view Y-axis.
+            At the TrajectoryResponse root — NOT per-step (ADR-010 Decision 2).
+            In M9: contains at most one entry (ecological WARNING at floor_value=1.0).
+            All other framework floors deferred to M10 (EL Decision A, Issue #428).
+            Empty array produces no ReferenceLine SVG elements — no render guard needed.
+          items:
+            framework: {type: string, values: ["financial", "human_development", "ecological", "governance"]}
+            floor_value: {type: string, description: "Decimal as string. Composite-score-level — not indicator-level projection (CM-R3, ADR-010 Decision 6)."}
+            severity: {type: string, values: ["WARNING", "CRITICAL", "TERMINAL"]}
+            label: {type: string, description: "e.g. 'Planetary boundary'"}
         steps:
           type: array
           description: >
             Computed steps only — dense array (ADR-010 Decision 2). Absent steps
-            were not yet computed at response time. Step 0 = initial state.
+            were not yet computed at response time.
           items:
             step_index: {type: integer}
             effective_from:
@@ -441,91 +455,89 @@ endpoints:
             step_event_label:
               type: "string|null"
               description: >
-                PENDING DA-F5 — storage schema not yet defined. Event label for
-                SIGNIFICANT steps in Mode 1. Must be ≤ 8 words AND ≤ 32 characters
-                (FA brief §Mode 1 Step Axis Annotation, DD-014).
+                Event label for SIGNIFICANT steps in Mode 1. Must be ≤ 8 words AND
+                ≤ 32 characters (FA brief §Mode 1 Step Axis Annotation, DD-014).
+                null when step_significance is ROUTINE. Sourced from
+                scenarios.configuration.step_metadata[step_index] (EL Decision C,
+                ADR-010 Decision 2 amendment 2026-05-23).
             step_significance:
-              type: "string|null"
+              type: string
+              values: ["SIGNIFICANT", "ROUTINE"]
               description: >
-                PENDING DA-F5 — storage schema not yet defined.
-              values: ["SIGNIFICANT", "STANDARD", null]
-            financial:
-              composite_score:
-                type: "string|null"
-                description: >
-                  Decimal as string. null for governance-in-validation.
-                  PENDING DA-F4 — null also occurs in single-entity scenarios
-                  (single_entity_warning=true); EL decision required on trajectory
-                  endpoint behaviour for single-entity Mode 1.
-              confidence_tier: {type: integer, range: [1, 5]}
-              ci_lower:
-                type: "string|null"
-                description: >
-                  PENDING ADR-007 (DA-F3) — BandingEngine not yet implemented.
-                  null until ADR-007 accepted. Decimal as string when present.
-              ci_upper:
-                type: "string|null"
-                description: "PENDING ADR-007 (DA-F3) — same as ci_lower."
-            human_development:
-              composite_score: {type: "string|null", description: "Same null semantics as financial — see DA-F4"}
-              confidence_tier: {type: integer}
-              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
-              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
-            ecological:
-              composite_score: {type: "string|null"}
-              confidence_tier: {type: integer}
-              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
-              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
-            governance:
-              composite_score:
-                type: "string|null"
-                description: >
-                  null = governance-in-validation (GovernanceModule deferred M9,
-                  ADR-005 Amendment 3 Decision M8-4). Distinct from single-entity
-                  null in financial/human_development — see DA-F4.
-              confidence_tier: {type: integer}
-              ci_lower: {type: "string|null", description: "PENDING ADR-007"}
-              ci_upper: {type: "string|null", description: "PENDING ADR-007"}
+                Per ADR-010 Decision 7. "STANDARD" is incorrect — rejected by
+                fixture validation. Sourced from scenarios.configuration.step_metadata.
+                Absent key in step_metadata = ROUTINE.
+            frameworks:
+              type: array
+              description: "Per-framework curve point for this step. One entry per active framework."
+              items:
+                framework:
+                  type: string
+                  values: ["financial", "human_development", "ecological", "governance"]
+                composite_score:
+                  type: "string|null"
+                  description: >
+                    Decimal as string. Three distinct null sources — use scoring_basis
+                    to disambiguate:
+                    (1) absent step = uncomputed (step absent from response, not null);
+                    (2) governance null = in-validation (scoring_basis: "percentile_rank");
+                    (3) single-entity financial/HD null = no normalizable indicators at
+                        this step (scoring_basis: "normalized_absolute").
+                scoring_basis:
+                  type: string
+                  values: ["percentile_rank", "normalized_absolute"]
+                  description: >
+                    "percentile_rank" — standard cross-entity composite; requires N≥2 entities.
+                    "normalized_absolute" — entity-intrinsic; financial and human_development
+                    in single-entity scenarios. Reference ranges in
+                    docs/architecture/cm-reference-range-consultation-2026-05-23.md §7a.
+                    Tier 3 confidence floor applies to all normalized_absolute scores.
+                    Ecological and governance always use "percentile_rank" (ecological uses
+                    boundary-proximity internally but the scoring_basis field value is
+                    "percentile_rank" for consistency — ecological is always entity-intrinsic).
+                confidence_tier:
+                  type: integer
+                  range: [1, 5]
+                  description: >
+                    Minimum Tier 3 when scoring_basis is "normalized_absolute" (single-entity
+                    normalized scores carry acknowledged range uncertainty).
+                ci_lower:
+                  type: "string|null"
+                  description: "PENDING ADR-007 — BandingEngine not yet implemented. null until ADR-007 accepted."
+                ci_upper:
+                  type: "string|null"
+                  description: "PENDING ADR-007 — same as ci_lower."
+                ci_coverage:
+                  type: "number|null"
+                  description: "PENDING ADR-007 — 0.80 when present."
+                is_pre_calibration:
+                  type: "boolean|null"
+                  description: "PENDING ADR-007."
             policy_inputs:
               type: array
-              description: Policy input events applied at this step. Source: scenario_scheduled_inputs.
+              description: "Policy input events applied at this step. Source: scenario_scheduled_inputs."
               items:
                 input_type: {type: string}
                 input_data: {type: object}
             shock_events:
               type: array
-              description: Exogenous shock events at this step.
+              description: "Exogenous shock events at this step."
               items:
                 event_type: {type: string}
                 metadata: {type: object}
-            mda_floors:
-              type: array
-              description: >
-                PENDING DA-F2 — composite-score-level MDA floors have no storage in
-                current schema. mda_thresholds.floor_value is indicator-level.
-                EL decision required: (a) add composite_floor_value field to
-                mda_thresholds with migration; or (b) defer MDA floor overlays until
-                composite-score-level threshold table is defined. Projection from
-                indicator-level to composite-score-level is prohibited (CM-R3, ADR-010
-                Decision 6 — methodologically dishonest).
-              items:
-                framework: {type: string, values: ["financial", "human_development", "ecological", "governance"]}
-                floor_value:
-                  type: "string|null"
-                  description: "PENDING DA-F2 — composite-score-level; not indicator-level projection"
-                threshold_type: {type: string, values: ["WARNING", "CRITICAL", "TERMINAL"]}
       status_404: "Scenario not found"
     db_reads:
       - scenarios
       - scenario_state_snapshots
-      - mda_thresholds
-      - "[PENDING DA-F5] step_annotations or equivalent per-step metadata source"
+      - mda_composite_floors  # M10 — table does not exist in M9; mda_floors array empty except ecological
     notes:
-      - "DA-F1: Endpoint added 2026-05-22. Schema PARTIAL — five Data Architect findings pending EL decisions."
-      - "DA-F2: mda_floors blocked — no composite-score-level floor storage in current schema."
-      - "DA-F3: ci_lower/ci_upper fields registered as pending-ADR-007 placeholders."
-      - "DA-F4: single-entity null handling for financial/human_development composite_score requires EL decision."
-      - "DA-F5: step_event_label/step_significance have no schema home — storage design required."
+      - "Schema updated 2026-05-23 — EL Decisions A/B/C resolved. All DA-F2/F4/F5 PENDINGs cleared."
+      - "DA-F2 resolved: mda_floors at response root (not per-step); M9 returns [] except ecological WARNING at 1.0."
+      - "DA-F3 remains: ci_lower/ci_upper pending ADR-007."
+      - "DA-F4 resolved: scoring_basis field added; Path A selected (normalized_absolute for single-entity financial/HD)."
+      - "DA-F5 resolved: step_event_label/step_significance sourced from scenarios.configuration.step_metadata JSONB."
+      - "step_significance values are SIGNIFICANT or ROUTINE only — STANDARD is incorrect (ADR-010 Decision 7)."
+      - "CM reference range consultation: docs/architecture/cm-reference-range-consultation-2026-05-23.md"
 
   - method: GET
     path: "/scenarios/{scenario_id}/measurement-output"

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -485,16 +485,16 @@ endpoints:
                         this step (scoring_basis: "normalized_absolute").
                 scoring_basis:
                   type: string
-                  values: ["percentile_rank", "normalized_absolute"]
+                  values: ["percentile_rank", "normalized_absolute", "boundary_proximity"]
                   description: >
-                    "percentile_rank" — standard cross-entity composite; requires N≥2 entities.
-                    "normalized_absolute" — entity-intrinsic; financial and human_development
-                    in single-entity scenarios. Reference ranges in
+                    "percentile_rank" — cross-entity composite; financial and human_development
+                    in multi-entity scenarios; governance (null composite_score when in-validation).
+                    "normalized_absolute" — entity-intrinsic against declared reference ranges;
+                    financial and human_development in single-entity scenarios (Path A). Tier 3
+                    confidence floor. Reference ranges:
                     docs/architecture/cm-reference-range-consultation-2026-05-23.md §7a.
-                    Tier 3 confidence floor applies to all normalized_absolute scores.
-                    Ecological and governance always use "percentile_rank" (ecological uses
-                    boundary-proximity internally but the scoring_basis field value is
-                    "percentile_rank" for consistency — ecological is always entity-intrinsic).
+                    "boundary_proximity" — ecological only; distance from planetary boundary;
+                    entity-intrinsic by definition. Scale [0.0, 2.0] (1.0 = at boundary).
                 confidence_tier:
                   type: integer
                   range: [1, 5]
@@ -529,7 +529,10 @@ endpoints:
     db_reads:
       - scenarios
       - scenario_state_snapshots
-      - mda_composite_floors  # M10 — table does not exist in M9; mda_floors array empty except ecological
+      # mda_composite_floors: M10 only — table does not exist in M9.
+      # In M9, mda_floors is constructed in application code:
+      # ecological WARNING entry (floor_value=1.0) added when ecological is active;
+      # all other framework floors return empty until mda_composite_floors is created (M10-B).
     notes:
       - "Schema updated 2026-05-23 — EL Decisions A/B/C resolved. All DA-F2/F4/F5 PENDINGs cleared."
       - "DA-F2 resolved: mda_floors at response root (not per-step); M9 returns [] except ecological WARNING at 1.0."

--- a/docs/schema/database.yml
+++ b/docs/schema/database.yml
@@ -255,6 +255,28 @@ tables:
               module-specific config. e.g. {"demographic": {"enabled": true,
               "cohort_resolution_entity_ids": ["GRC"]}}.
               Usually {} (no extra modules active).
+          step_metadata:
+            type: object
+            nullable: true
+            description: >
+              Per-step annotation data. Keys are 1-based step index strings (e.g. "1", "3").
+              Absence of the key (or absence of the step_metadata key itself) means the step
+              is ROUTINE. No migration required — configuration is an unconstrained JSONB.
+              Added: EL Decision C 2026-05-23 (Issue #428); ADR-010 Decision 2 amendment.
+            key_structure:
+              "{step_index}":
+                type: object
+                description: "1-based step index as string key"
+                step_event_label:
+                  type: "string|null"
+                  description: "≤ 8 words AND ≤ 32 characters (FA brief DD-014). null for ROUTINE steps."
+                step_significance:
+                  type: string
+                  values: ["SIGNIFICANT", "ROUTINE"]
+                  description: >
+                    Per ADR-010 Decision 7. Values are SIGNIFICANT or ROUTINE only.
+                    The value 'STANDARD' is incorrect and must be rejected by fixture
+                    CI validation (pytest tests/fixtures/).
           scheduled_inputs:
             type: array
             description: >


### PR DESCRIPTION
## Summary

Closes all three checklist items from Issue #428 — the prerequisite gate for trajectory endpoint implementation.

- [x] **ADR-010 Decision 6 amendment** — M9 deferral of MDA floor overlays recorded; ecological WARNING at y=1.0 authorized; M10-B schema confirmed
- [x] **CM reference range consultation** — `docs/architecture/cm-reference-range-consultation-2026-05-23.md`; reference ranges for financial and HD indicators defined; implementation contract (§7) produced
- [x] **ADR-010 Decision 2 amendment** — `scoring_basis` field added; single-entity scoring contract documented; step_metadata JSONB storage contract recorded

## CM consultation output (§7 implementation contract)

| Framework | Indicator | Reference range | Direction |
|---|---|---|---|
| financial | `gdp_growth` | [-0.10, 0.06] | higher better |
| financial | `reserve_coverage_months` | [0.0, 12.0] | higher better |
| human_development | `unemployment_rate` | [0.02, 0.30] | lower better |
| human_development | `net_enrollment_secondary` | [0.40, 1.00] | higher better |
| human_development | `health_expenditure_pct_gdp` | EXCLUDED | non-monotonic spending proxy |

- Aggregation: unweighted arithmetic mean
- Confidence tier floor: **Tier 3** for all normalized_absolute scores
- Greece 2010 example: financial composite ≈ 0.228; HD composite ≈ 0.802

## Schema changes

**`api_contracts.yml`:** Trajectory endpoint stub fully resolved — all DA-F2/F4/F5 PENDINGs cleared; `mda_floors` moved to response root (structural fix); `scoring_basis` field added; `step_significance` values corrected to SIGNIFICANT|ROUTINE; ci_lower/ci_upper remain pending ADR-007.

**`database.yml`:** `step_metadata` key added to `scenarios.configuration.key_structure`.

## What is now unblocked

The `GET /scenarios/{id}/trajectory` endpoint implementation. All prerequisites satisfied — the trajectory endpoint PR may now open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)