### PR TITLE
docs(process): file authority rule — agents must not write to owned files without prior owner review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,14 @@ entry ASSIGNED, (3) derive the panel composition from `docs/process/agent-raci.m
 and (4) confirm the implementing agent is included in the panel. ADR numbers must
 not appear in issue titles or documents before they are assigned from the backlog.
 
+**File authority is non-negotiable.**
+Before writing to any file, the acting agent must verify they hold R (Responsible)
+on that file per `docs/process/agent-raci.md`. If another agent holds R, the acting
+agent must produce a draft and request the owning agent's review before committing.
+Writing directly to another agent's owned files without prior owner review is a
+process violation equivalent to implementing a feature without an ADR. The file
+ownership table is in `docs/process/agent-raci.md §File Ownership`.
+
 **Tests are not optional.**
 The backtesting infrastructure is the most important test suite.
 Unit and integration tests are table stakes. A feature is not done


### PR DESCRIPTION
## Summary

- Adds the file authority rule to CLAUDE.md §Architectural Principles
- Closes the CLAUDE.md deliverable from Issue #431

## The rule added

> **File authority is non-negotiable.**
> Before writing to any file, the acting agent must verify they hold R (Responsible)
> on that file per `docs/process/agent-raci.md`. If another agent holds R, the acting
> agent must produce a draft and request the owning agent's review before committing.
> Writing directly to another agent's owned files without prior owner review is a
> process violation equivalent to implementing a feature without an ADR.

## Root cause (from Issue #431)

PR #429 committed changes to `docs/schema/api_contracts.yml` and `docs/schema/database.yml` before the Data Architect reviewed. DA review found two errors post-commit (DA-R2, DA-R3). The Engineering Lead caught the missing review before merge. This PR codifies the rule so the check is in CLAUDE.md, not just in the EL's memory.

## Remaining Issue #431 scope (not in this PR)

- File ownership table in `docs/process/agent-raci.md §File Ownership`
- PM Agent HORIZON sweep file authority audit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)