### PR TITLE
docs(process): PR merge gate — mandatory pause + SESSION_STATE auto-merge exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,20 @@ Agents do not assign blame. They identify root causes, build process improvement
 document both. A near-miss that produces only a reminder to "be more careful" has not
 been properly resolved.
 
+**PR merge gate — mandatory pause before next task.**
+After opening any PR, Claude Code must stop all git operations and file edits,
+report the PR URL, and explicitly hand off: *"Please merge when CI is green and
+confirm back — I'll pull main before continuing."* No next task begins, no files
+are edited, and no git commands run until the user confirms the merge and Claude
+Code has executed `git pull origin main`.
+
+**Exception — `SESSION_STATE.md`-only PRs.** End-of-session state updates that
+touch only `SESSION_STATE.md` are pre-authorized for auto-merge. Claude Code will
+poll `gh pr checks` until the `changes` status check passes, then execute
+`gh pr merge <number> --admin --merge` and `git pull origin main` without waiting
+for user confirmation. If the PR contains any file other than `SESSION_STATE.md`,
+the standard gate applies regardless of the other file's content.
+
 **Tests are not optional.**
 The backtesting infrastructure is the most important test suite.
 Unit and integration tests are table stakes. A feature is not done


### PR DESCRIPTION
## Summary

- Adds a hard constitutional rule to CLAUDE.md: after opening any PR, Claude Code stops all git operations and waits for user merge confirmation before pulling main or starting the next task
- Eliminates the concurrent-terminal race condition where Claude Code begins new work while the user merges in an adjacent terminal session
- Exception: `SESSION_STATE.md`-only PRs are pre-authorized for auto-merge once the `changes` CI status check passes — manual confirmation for routine end-of-session state updates is unnecessary overhead

## Motivation

Identified during root-cause analysis of NM-014 and the adjacent risk of two processes (Claude Code session + user terminal) operating git commands against the same local repo without coordination. The human stays as merge coordinator and CI gate — especially important in parallel-session scenarios where multiple Claude Code instances would otherwise each have merge authority with no visibility into each other.

## What this does NOT change

- Merge authority stays with the user for all PRs except SESSION_STATE.md-only updates
- The user's CI green-check gate is preserved as the control that blocks premature merges
- No change to branch discipline, file authority, or other git workflow rules

## Test plan

- [ ] Rule is visible in CLAUDE.md between the blameless improvement principle and "Tests are not optional"
- [ ] Exception is clearly scoped: SESSION_STATE.md-only, CI must pass, any other file triggers the standard gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)