### PR TITLE
docs(process): PM Agent issue hierarchy rule — Epic → Feature → Task, binary spawning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,11 @@ Full roadmap: `docs/roadmap/worldsim-roadmap.md`
 
 **Everything lives in GitHub.**
 Code, tasks, documentation, ADRs, CI/CD configuration. One system of
-record that both humans and agents can read and write.
+record that both humans and agents can read and write. Issues follow a
+strict three-level hierarchy (Epic → Feature Issue → Task Issue) with a
+binary spawning rule: spawn children only when more than one agent or
+more than one PR is required. No commits directly against Epics. Full
+rule: `docs/process/agents.md §PM Agent — Issue Hierarchy`.
 
 **No significant feature without an ADR.**
 Architecture Decision Records document what was decided, why, and what

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -102,6 +102,44 @@ PM Agent: EXECUTE — [task]
 
 **Where I will offer help:** Mid-session discoveries. Any agent that has found something — a bug, a gap, a new requirement — and is uncertain whether to act now or file it: bring it to me. One sentence describing the finding, I return one word.
 
+### Issue Hierarchy
+
+WorldSim uses a strict three-level issue hierarchy. The spawning rule is
+binary and agent-count-based — not complexity-based. Complexity is never
+a criterion.
+
+**Level 1 — Epic**
+Unit: a milestone capability or feature area representing a coherent
+user-facing outcome. Exists for roadmap and milestone tracking only.
+- No implementation commits directly against an Epic
+- Closes only when all child Feature Issues are closed
+- Created by: PM Agent or PO Agent
+
+**Level 2 — Feature Issue**
+Unit: a deployable slice of an Epic — something that can be implemented,
+reviewed, and merged as a coherent PR with a clear acceptance owner.
+- Implementation commits go here
+- Spawns Level 3 Task Issues when: (a) more than one agent must act on
+  it before it can close, OR (b) more than one PR is required to close it
+- If neither condition is true, stays at Level 2 with no children
+- Created by: PM Agent, PO Agent, or implementing agent
+
+**Level 3 — Task Issue**
+Unit: a single-agent, single-session action with binary done/not-done
+state.
+- No children — never spawns further issues
+- Closes when the specific action is complete
+- Created by: the agent responsible for the action, or PM Agent
+
+**The spawning rule — applied before creating any child issues:**
+Ask: does closing this issue require more than one agent, or more than
+one PR? If yes → spawn Level 3 Task Issues. If no → no children.
+
+**Work is never committed against a Level 1 Epic.** If a commit needs
+a parent issue, it belongs to a Level 2 Feature Issue, not the Epic.
+An Epic with direct commits is a process violation equivalent to
+implementing a feature without an ADR.
+
 ---
 
 ## Architect Agent


### PR DESCRIPTION
## Summary

Encodes the WorldSim issue hierarchy rule permanently so it survives session boundaries and cannot be re-invented inconsistently.

**`docs/process/agents.md`** — `### Issue Hierarchy` subsection added to PM Agent working agreement:
- Level 1 Epic: roadmap/milestone tracking only; no implementation commits; closes when all children close
- Level 2 Feature Issue: implementation target; spawns children only when >1 agent OR >1 PR required
- Level 3 Task Issue: single-agent, single-session, binary done/not-done; no children

Spawning rule is binary and agent-count-based — not complexity-based. This prevents the rule from being bent under deadline pressure ("this feels complex enough to spawn a task" is a judgment that gets corrupted; "does this need more than one agent?" does not).

**`CLAUDE.md` §Architectural Principles** — one-sentence reference with pointer to agents.md for the full rule. Sits under the "Everything lives in GitHub" principle as a natural extension of how GitHub issues are used.

## Why agents.md, not CLAUDE.md

CLAUDE.md carries the one-sentence summary as a pointer. The full rule lives in agents.md because:
1. The PM Agent working agreement is the canonical home for backlog structure rules
2. CLAUDE.md is already dense — the full rule with examples belongs in the owning agent's section
3. Future HORIZON sweeps by the PM Agent will naturally encounter the rule in their own working agreement

## Test plan

- [ ] `docs/process/agents.md`: `### Issue Hierarchy` subsection present under PM Agent Working Agreement, before the `---` separator and Architect Agent section
- [ ] Three levels defined with spawning rule stated as binary test
- [ ] `CLAUDE.md`: one-sentence reference present under `**Everything lives in GitHub.**` paragraph, with pointer to `docs/process/agents.md §PM Agent — Issue Hierarchy`
- [ ] No existing content removed or moved