### PR TITLE
docs(process): PM Agent pre-EL consultation — standing automatic capability (closes #464)

### DIFF
--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -140,6 +140,47 @@ a parent issue, it belongs to a Level 2 Feature Issue, not the Epic.
 An Epic with direct commits is a process violation equivalent to
 implementing a feature without an ADR.
 
+### Pre-EL Consultation
+
+Pre-EL consultation is a standing PM Agent responsibility — not a mode
+requiring explicit activation.
+
+**Trigger conditions (any one is sufficient):**
+- An `[EL-DECISION]` tag appears in any document
+- A pending decision appears in `SESSION_STATE.md §Pending Engineering
+  Lead Decisions` without a "Complete ✅" status
+- Any agent raises a question or gap finding that requires EL authority
+  to resolve
+
+**The four-step consultation process:**
+
+1. **Identify** — which agents hold relevant domain authority or
+   analytical perspective for this decision? Consult `docs/process/agent-raci.md`
+   and the decision's subject domain.
+2. **Activate independently** — each agent produces their assessment
+   without seeing the others' conclusions first. Independence is the
+   epistemic value; pre-contaminated assessments defeat the purpose.
+3. **Synthesize** — the PM Agent identifies where agents agree, where
+   they diverge, and why. The synthesis names the key finding that
+   changes the frame (if any), states all options with their costs,
+   and produces a single recommendation.
+4. **Surface the recommendation** — the EL receives the recommendation,
+   not the raw question. The consultation output is: "Three agents
+   assessed this. The unanimous/majority verdict is X. The key finding
+   is Y. If you decide Z instead, the cost is W."
+
+**What the EL receives:** A confirmation opportunity, not an executive
+judgment made cold. EL decisions should arrive pre-reasoned — the EL
+holds A (accountable) but the consultation that informs the decision is
+the PM Agent's R (responsible). A cold question reaching the EL without
+prior consultation is a PM Agent process failure.
+
+**When agents disagree:** The PM Agent does not resolve the disagreement.
+It names the disagreement clearly — which agents diverged, on what
+specific point, and what each side's cost argument is — and surfaces all
+positions to the EL. The EL decides with full visibility into the
+dissent.
+
 ---
 
 ## Architect Agent


### PR DESCRIPTION
## Summary

Implements Issue #464. Adds `### Pre-EL Consultation` subsection to the PM Agent working agreement in `docs/process/agents.md`.

## What changes

The pre-EL consultation is now a **standing automatic responsibility** of the PM Agent, not a command requiring explicit activation. Any of three trigger conditions fires the consultation:
- An `[EL-DECISION]` tag appears in any document
- A pending decision appears in `SESSION_STATE.md §Pending Engineering Lead Decisions`
- Any agent raises a question requiring EL authority

**Four-step process documented:**
1. Identify agents with relevant domain authority
2. Activate independently (no cross-contamination)
3. Synthesize — agreement, divergence, framing correction, single recommendation
4. Surface the recommendation to EL — not the raw question

**RACI framing:** EL holds A (accountable); PM Agent holds R (responsible) for the consultation. A cold question reaching EL without prior consultation is a PM Agent process failure.

**Disagreement handling:** PM Agent does not resolve inter-agent disagreement — it names it clearly and surfaces all positions. EL decides with full visibility into dissent.

## Why this matters

The US-GAP-001 consultation (2026-05-23) produced the right outcome (three-agent framing correction, unanimous verdict, narrowed gap, cost-stated recommendation) but required explicit activation. The standing capability rule ensures the same quality of decision preparation happens automatically — including when the EL might not think to ask for it.

## Test plan

- [ ] `docs/process/agents.md`: `### Pre-EL Consultation` subsection present after `### Issue Hierarchy` and before `---` separator
- [ ] Three trigger conditions documented
- [ ] Four-step process present (identify → activate independently → synthesize → surface)
- [ ] RACI framing (EL = A, PM Agent = R) present
- [ ] Disagreement handling documented
- [ ] Closes #464