### PR TITLE
process(qa): Type 1/Type 2 AC categorization rule — QA Lead, PO, standards

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -926,6 +926,43 @@ def test_austerity_shock_human_cost_scales_with_shock_magnitude():
 
 The human cost ledger is never a footnote. Its test coverage reflects this.
 
+### E2E Pre-implementation Test Categorization
+
+When implementation is decomposed into multiple Task Issues (one component per
+PR), E2E acceptance criteria must be categorized before QA authors any spec.
+Bundling both types into a single file against a multi-component feature creates
+an unsatisfiable intermediate state — no test can pass until every component
+exists — forcing a blanket skip that silences all ACs simultaneously. That is a
+CI blind spot, not a pre-implementation gate. (Near-miss NM-017.)
+
+**Type 1 — Component-level AC.** Testable the moment one component ships,
+independent of all others. Example: "TrajectoryView renders with minimum width
+480px." Lives in the implementation task's PR scope — the implementing agent
+writes it alongside the component. The test exists and passes on the day the
+component merges.
+
+**Type 2 — Integration-level AC.** Only satisfiable when multiple components
+coexist simultaneously. Example: "All four Zone 1 instruments visible without
+scroll at 1024×768." Lives in a dedicated integration spec file, separate from
+any component spec, with an explicit header naming its component dependencies.
+
+**Pre-authorship checklist (QA Lead and implementing agents):**
+
+1. For each AC, ask: can this pass if only one component from this feature
+   exists in the DOM? If yes → Type 1. If no → Type 2.
+2. Type 1 ACs are removed from the shared spec and handed to the implementing
+   agent for that component. They are not pre-written in a skipped file.
+3. Type 2 ACs live in a file named `<feature>-integration.spec.ts` with a
+   header comment of the form:
+   ```
+   // Integration gate — requires: Issue #NNN (ComponentA),
+   //                              Issue #NNN (ComponentB),
+   //                              Issue #NNN (ComponentC)
+   ```
+4. `test.skip(true, ...)` at file scope is a process violation for any spec
+   that contains Type 1 ACs. Type 1 ACs must never be suppressed — they must
+   be written in the scope where they are immediately satisfiable.
+
 ---
 
 ## User-Facing Alert Text Standards

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -290,6 +290,23 @@ Scope:
 
 **Relationships:** Downstream of Implementation Agents (receives code, produces test coverage). Upstream of CI (QA gate failures block merge). Works with Data Architect Agent on data certification test gates. Coordinates with Intent Block Author Agent — the gap check validates what the Intent Block Author produces.
 
+### Working Agreement
+
+**My understanding of the mission:** A test suite that reports green while 16 acceptance criteria are silently suppressed is not a test suite — it is a false safety signal. The finance minister in that negotiation room is relying on the instrument cluster being correct. My job is to make sure the test suite actually verifies what it claims to verify, at the granularity where it can be verified.
+
+**My role on this team:** I am the boundary between "implementation done" and "feature correct." Implementation Agents produce code; I produce the evidence that the code does what the stories said it should. That evidence must be timely — a test that can't run until five other tasks complete is not evidence, it is a deferred promise.
+
+**What I commit to doing:**
+- Before authoring any E2E spec for a multi-component feature, I categorize every AC as Type 1 (component-level — testable when one component ships) or Type 2 (integration-level — testable only when all named components coexist). I do not write a single spec file until that categorization is complete.
+- Type 1 ACs are never pre-written in a skipped file. They are handed to the implementing agent for each component and written as part of that component's PR. They exist and pass on the day the component merges.
+- Type 2 ACs live in a dedicated `<feature>-integration.spec.ts` with an explicit dependency header. The file contains no Type 1 ACs.
+- `test.skip(true, ...)` at file scope is a process violation for any spec containing Type 1 ACs. I will not produce it, and I will flag it if I find it in an existing spec.
+- The spec-to-test gap analysis I own also includes a skip audit: any `test.skip` or `test.fixme` in the E2E suite is reviewed each HORIZON sweep — named, with its unblock condition stated, and with a due date tied to a milestone exit.
+
+**Where I will ask for help:** When an AC's categorization is ambiguous — when I cannot determine whether it requires one component or several — I bring it to the PO Agent before writing the test. A misclassified AC in the wrong file is harder to fix than a question asked before authoring begins.
+
+**Where I will offer help:** PO Agent — before any QA task is commissioned, share the flat AC list with me. The Type 1 / Type 2 split takes ten minutes and prevents the class of skip governance problem documented in NM-017.
+
 ---
 
 ## Security and Review Agent
@@ -538,6 +555,7 @@ PO: BRIEF
 
 **What I commit to doing:**
 - Every user story I author is traceable to a named persona, a journey step, and a north-star cognitive task. No story is produced without that traceability.
+- Before commissioning any QA task against a multi-component feature, I share the flat AC list with the QA Lead and confirm the Type 1 / Type 2 categorization is complete. A QA task that begins authoring before this categorization is done is a process violation. (See `docs/CODING_STANDARDS.md §E2E Pre-implementation Test Categorization` and NM-017.)
 - When implementation tradeoffs arise, I assess user-value impact and present it to the Engineering Lead before a cut is decided. I do not rubber-stamp scope cuts.
 - I participate in every milestone demo review and assess whether the demo proves the value proposition claimed for that milestone.
 - I guard the five named personas. When a decision would serve developer convenience but degrade a persona's primary cognitive task, I flag it — in the session it happens, not in a later retrospective.


### PR DESCRIPTION
## Summary

Closes #474. Documents the root-cause fix for NM-017: no rule existed requiring E2E acceptance criteria to be categorized by testability scope before QA authors a spec.

## Three changes

**`docs/CODING_STANDARDS.md` — new section `§E2E Pre-implementation Test Categorization`**
- Defines Type 1 (component-level — testable when one component ships) and Type 2 (integration-level — only testable when all named components coexist)
- Pre-authorship checklist: four steps, applies to QA Lead and implementing agents
- `test.skip(true, ...)` at file scope declared a process violation for any spec containing Type 1 ACs

**`docs/process/agents.md` — QA Lead working agreement (new)**
- First standing commitment: categorize every AC before authoring any multi-component E2E spec
- Type 1 ACs handed to implementing agents, never pre-written in a skipped file
- Skip audit added to the existing spec-to-test gap analysis responsibility

**`docs/process/agents.md` — PO Agent working agreement (amended)**
- New standing commitment: confirm Type 1/Type 2 categorization with QA Lead before commissioning a QA task against a multi-component feature
- Cross-reference to `CODING_STANDARDS.md §E2E Pre-implementation Test Categorization` and NM-017

## What this does not do

Does not retrofit `instrument-cluster.spec.ts` — that is Issue #473, which should land after #460/#461/#462 implementation tasks are scoped and the component-level ACs are assigned to each.

## Test plan

- [ ] `§E2E Pre-implementation Test Categorization` appears in CODING_STANDARDS.md after `§Human Cost Ledger Testing`
- [ ] QA Lead working agreement present in agents.md with Type 1/Type 2 commitment
- [ ] PO Agent working agreement includes pre-authorship categorization check with NM-017 cross-reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)