### PR TITLE
process(ki): Known Issues registry — establish KI framework, file KI-001

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,18 @@ Agents do not assign blame. They identify root causes, build process improvement
 document both. A near-miss that produces only a reminder to "be more careful" has not
 been properly resolved.
 
+**Known Issues are distinct from near-misses.**
+A Known Issue is a confirmed limitation of external infrastructure or tooling
+(GitHub Actions, third-party APIs, OS behaviour) that cannot be fixed by redesigning
+internal processes. The response to a Known Issue is a documented workaround, not a
+process improvement. Filing an external infrastructure failure as a near-miss produces
+a process improvement recommendation against something that cannot be redesigned.
+
+Rule: if the fix requires changing our own code, process, or documents → near-miss.
+If the fix requires waiting for an upstream vendor → Known Issue.
+
+Known Issues are filed in `docs/process/known-issues-registry.md`.
+
 **PR merge gate — mandatory pause before next task.**
 After opening any PR, Claude Code must stop all git operations and file edits,
 report the PR URL, and explicitly hand off: *"Please merge when CI is green and
@@ -538,6 +550,8 @@ the artifact type and cannot be caught by CI.
 | Architecture Decision Records | `docs/adr/` | `ADR-NNN-short-name.md` | New file per decision |
 | ADR Panel Reviews | `docs/adr/reviews/` | `ADR-NNN-panel-review.md` | New file per ADR; one review per ADR number |
 | Module Capability Registry | `docs/scenarios/module-capability-registry.md` | Single file | Updated in place with each milestone |
+| Near-Miss Registry | `docs/process/near-miss-registry.md` | Single file — append NM entries only | Append only; never insert mid-registry |
+| Known Issues Registry | `docs/process/known-issues-registry.md` | Single file — append KI entries only | Append only; never insert mid-registry |
 
 ### Pre-creation checklist for documents
 

--- a/docs/process/agent-raci.md
+++ b/docs/process/agent-raci.md
@@ -499,6 +499,8 @@ finalized — not afterward.
 | `.github/` | EL | Ar | CI/CD pipeline changes require Architect review |
 | `docs/process/agents.md` | PM | EL | Agent persona definitions; EL approves new agent additions |
 | `docs/process/agent-raci.md` | PM | EL, Ar | RACI matrix; Architect consulted when decision-type grounding changes |
+| `docs/process/near-miss-registry.md` | PM | EL | PM files entries; EL informed of High severity entries |
+| `docs/process/known-issues-registry.md` | PM | EL | PM files entries; EL informed of Medium/High severity entries |
 | `docs/schema/api_contracts.yml` | DA | Ar | Ar consulted when response shape changes (API response shape is Architect territory) |
 | `docs/schema/database.yml` | DA | Ar, QA | Ar consulted on schema shape; QA consulted on CI enforcement gates |
 | `docs/schema/simulation_state.yml` | DA | Ar, QA | Same rules as database.yml |

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -97,6 +97,7 @@ PM Agent: EXECUTE — [task]
 - SESSION_STATE.md accuracy is my accountability. If it is stale, my next BRIEF is wrong, and everything downstream of that BRIEF is working from a corrupted map. I update it at session end, unconditionally.
 - I flag scope creep in the session it appears — not in a later retrospective.
 - I never make the decision I am escalating. I surface the choice clearly and pass it to the Engineering Lead.
+- When a process hazard is identified, I determine its category before filing: internal hazard (root cause within the project's control) → near-miss entry in `docs/process/near-miss-registry.md`; external infrastructure limitation (root cause outside the project's control, workaround required) → Known Issue entry in `docs/process/known-issues-registry.md`. Filing an external failure as a near-miss produces a process improvement recommendation against something that cannot be redesigned — that is a triage failure.
 
 **Where I will ask for help:** When two committed work streams have a genuine dependency conflict — when doing X now means Y cannot be done this sprint — I bring both to the Engineering Lead with a specific question: which is the right sacrifice? I do not choose by default.
 

--- a/docs/process/known-issues-registry.md
+++ b/docs/process/known-issues-registry.md
@@ -1,0 +1,142 @@
+# WorldSim Known Issues Registry
+
+A Known Issue is a confirmed limitation or unreliable behaviour of external
+infrastructure, tooling, or third-party services that:
+
+- Has a real, recurrent impact on the development process
+- Cannot be fixed by redesigning internal systems or processes
+- Has a documented workaround or mitigation procedure
+
+## Distinction from near-misses
+
+**Near-misses** are internal hazards. The response is always a process improvement
+that eliminates or structurally reduces the hazard. The countermeasure is never
+"be more careful" — it is always "redesign the system so careful isn't required."
+
+**Known Issues** are external limitations. The root cause lies outside the
+project's control (GitHub's infrastructure, a third-party API, an OS behaviour).
+The response is a documented workaround and awareness — not a process change,
+because there is no internal process to change. Filing a Known Issue as a
+near-miss would produce a process improvement recommendation against something
+we cannot redesign.
+
+When in doubt: if the fix requires changing our own code, process, or documents,
+it is a near-miss. If the fix requires waiting for an upstream vendor to change
+their system, it is a Known Issue.
+
+---
+
+## KI-001 — GitHub Actions: `pull_request` Event Silently Fails to Fire
+
+**Date first observed:** 2026-05-23
+**Infrastructure:** GitHub Actions (GitHub-hosted)
+**Severity:** Low — workaround is fast and lossless; no data loss, no incorrect
+output, no CI false-positive
+**Recurrence:** Sporadic — not reproducible on demand; observed once in this
+project's history as of filing date
+
+### Symptom
+
+A pull request is opened against `main`. The GitHub PR merge status page shows
+all required status checks as "Expected — Waiting for status to be reported"
+indefinitely. `gh run list --branch <branch-name>` returns empty — no CI run
+has been queued or started. The checks are not skipped; they have simply never
+been triggered.
+
+### Trigger condition
+
+Unknown. The condition is not reproducible on demand. The `pull_request` workflow
+trigger (`on: pull_request: branches: [main]`) failed to fire when a PR was
+opened via `gh pr create`. All other PRs opened in the same session triggered
+CI normally.
+
+First observed on PR #481 (a `SESSION_STATE.md`-only PR opened 2026-05-23).
+All previous PRs in the session triggered CI without issue.
+
+### Workaround
+
+Push an empty retriggering commit to the branch:
+
+```bash
+git commit --allow-empty -m "chore: retrigger CI — empty commit (GH Actions pull_request event did not fire)"
+git push origin <branch-name>
+```
+
+This triggers the `pull_request` event for the existing PR. CI starts within
+seconds. No content changes are needed.
+
+### Impact on SESSION_STATE.md auto-merge
+
+The `auto-merge SESSION_STATE.md` workflow depends on CI triggering. If the
+`pull_request` event fails to fire, the PR will hang with all checks "Waiting."
+The `gh pr merge --admin` bypass also fails in this state ("5 of 5 required
+status checks are expected") because GitHub requires checks to have been
+reported before admin bypass is permitted.
+
+The retriggering commit resolves both: once CI fires, the auto-merge workflow
+runs and merges the PR without further intervention.
+
+### Upstream
+
+No upstream issue filed. Sporadic GitHub Actions event delivery failures are a
+known class of GitHub infrastructure issues. Filing an upstream report is
+appropriate if the symptom recurs consistently (three or more times).
+
+---
+
+## Registry Maintenance
+
+### When to file a Known Issue
+
+File a Known Issue when:
+- The same external infrastructure problem recurs, OR
+- A new external limitation is encountered that required a non-obvious workaround
+  to resolve
+
+Do not file a Known Issue for:
+- One-time external outages (HTTP 5xx from GitHub, etc.) that resolved without
+  a workaround
+- Problems that turn out to have an internal root cause (file as a near-miss)
+
+### Entry template
+
+```markdown
+## KI-NNN — [Infrastructure]: [Short description]
+
+**Date first observed:** YYYY-MM-DD
+**Infrastructure:** [Service or tooling name]
+**Severity:** [Low / Medium / High] — [one-line consequence]
+**Recurrence:** [Sporadic / Consistent / Resolved]
+
+### Symptom
+
+[What the engineer sees when the issue occurs.]
+
+### Trigger condition
+
+[What causes it, if known. "Unknown" is acceptable.]
+
+### Workaround
+
+[Step-by-step resolution. Include exact commands where relevant.]
+
+### Upstream
+
+[Whether an upstream issue has been filed, and the link if so.]
+```
+
+### Severity levels
+
+| Level | Meaning |
+|---|---|
+| Low | Workaround is quick; no data loss; development continues with minor delay |
+| Medium | Workaround exists but requires significant effort; blocks a PR or session |
+| High | No reliable workaround; blocks a release or causes incorrect output |
+
+### Recurrence field
+
+| Value | Meaning |
+|---|---|
+| Sporadic | Observed rarely; not reproducible on demand |
+| Consistent | Reproducible; occurs predictably under known conditions |
+| Resolved | Upstream fixed; workaround no longer needed (keep entry for historical record) |


### PR DESCRIPTION
## Summary

Establishes `docs/process/known-issues-registry.md` as a distinct category from near-misses, and files the first entry.

**The distinction:**
- **Near-misses** — internal hazards; root cause is within our control; response is always a process improvement that eliminates the hazard
- **Known Issues** — external infrastructure limitations; root cause is outside our control; response is a documented workaround

Filing an external infrastructure failure as a near-miss produces a process improvement recommendation against something that cannot be redesigned. That is a triage failure, not a process improvement.

**KI-001:** GitHub Actions `pull_request` event silently fails to fire. All required status checks show "Expected — Waiting for status to be reported" indefinitely. Workaround: push an empty retriggering commit. Severity: Low.

## Changes

- `docs/process/known-issues-registry.md` — new registry with definition, KI-001, entry template, and severity/recurrence taxonomy
- `CLAUDE.md §Blameless continuous improvement` — adds Known Issues distinction and the categorisation rule
- `CLAUDE.md §Canonical Artifact Locations` — adds Near-Miss Registry and Known Issues Registry to the artifact table (both were previously undocumented here)
- `docs/process/agents.md §PM Agent working agreement` — PM Agent now categorises hazards before filing; triage failure named explicitly
- `docs/process/agent-raci.md §File Ownership` — adds ownership rows for both registries

## Test plan

- [ ] `docs/process/known-issues-registry.md` exists and contains KI-001
- [ ] CLAUDE.md §Blameless continuous improvement distinguishes near-misses from Known Issues with the categorisation rule
- [ ] CLAUDE.md §Canonical Artifact Locations contains rows for both registries
- [ ] agents.md PM Agent working agreement references both registries
- [ ] agent-raci.md File Ownership table contains rows for both registries
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)