### PR TITLE
feat(frontend): wire InstrumentCluster into App.tsx — Zone 1 instruments live (Issue #463 PR 1/2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import ChoroplethMap from "./components/ChoroplethMap";
 import DeltaChoropleth from "./components/DeltaChoropleth";
 import EntityDetailDrawer from "./components/EntityDetailDrawer";
 import FidelityDashboard from "./components/FidelityDashboard";
+import { ModeIndicator } from "./components/ModeIndicator";
+import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
 import ScenarioControls from "./components/ScenarioControls";
 import ScenarioPanel from "./components/ScenarioPanel";
 import type { ScenarioDetailResponse } from "./types";
@@ -117,6 +119,7 @@ export default function App() {
                 {selectedScenarioName}
               </span>
             )}
+            <ModeIndicator />
             <ScenarioControls
               scenarioId={selectedScenarioId}
               totalSteps={selectedScenarioSteps}
@@ -139,6 +142,18 @@ export default function App() {
       {fidelityOpen && <FidelityDashboard />}
 
       <main className="app-main" style={{ position: "relative" }}>
+        {/* Instrument cluster — primary viewport when a scenario is active (CLAUDE.md UX commitment 1) */}
+        {selectedScenarioId && (
+          <div style={{ overflowX: "auto", background: "#fafafa", borderBottom: "1px solid #e8e8e8" }}>
+            <ScenarioInstrumentCluster
+              scenarioId={selectedScenarioId}
+              stepCount={selectedScenarioSteps}
+              currentStep={currentStep ?? 0}
+            />
+          </div>
+        )}
+
+        {/* Context layer — choropleth map (navigable context per CLAUDE.md UX commitment 2) */}
         {showDelta ? (
           <DeltaChoropleth
             scenarioAId={selectedScenarioId}

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -85,10 +85,8 @@ export function InstrumentCluster({
         }}
       >
         {/* Zone 1B — MDA Alert Panel (~45% of column height) */}
-        <div
-          data-testid="zone-1b-mda-alerts"
-          style={{ flex: "0 0 45%", overflow: "hidden" }}
-        >
+        {/* data-testid lives on MDAAlertPanelZone1B root — not duplicated here */}
+        <div style={{ flex: "0 0 45%", overflow: "hidden" }}>
           {mdaPanel ?? (
             <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
               MDA Alert Panel (Zone 1B)
@@ -97,10 +95,8 @@ export function InstrumentCluster({
         </div>
 
         {/* Zone 1C — PMM Widget (~25% of column height) */}
-        <div
-          data-testid="zone-1c-pmm"
-          style={{ flex: "0 0 25%", overflow: "hidden" }}
-        >
+        {/* data-testid lives on PMMWidgetZone1C root — not duplicated here */}
+        <div style={{ flex: "0 0 25%", overflow: "hidden" }}>
           {pmmWidget ?? (
             <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
               PMM Widget (Zone 1C)
@@ -109,10 +105,8 @@ export function InstrumentCluster({
         </div>
 
         {/* Zone 1D — Four-Framework Current Position (~30% of column height) */}
-        <div
-          data-testid="zone-1d-four-framework"
-          style={{ flex: "0 0 30%", overflow: "hidden" }}
-        >
+        {/* data-testid lives on FourFrameworkZone1D root — not duplicated here */}
+        <div style={{ flex: "0 0 30%", overflow: "hidden" }}>
           {fourFramework ?? (
             <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
               Four-Framework Current Position (Zone 1D)

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -1,0 +1,162 @@
+/**
+ * ScenarioInstrumentCluster — composed Zone 1 cluster for App.tsx.
+ *
+ * Wires all four Zone 1 instruments into InstrumentCluster and connects
+ * the Zustand atom to the trajectory API. Fetches trajectory when
+ * scenarioId is set; keeps store current_step in sync with ScenarioControls.
+ *
+ * Trajectory parsing: the API returns frameworks as an array; the store
+ * expects Record<string, TrajectoryFrameworkPoint>. composite_score arrives
+ * as Decimal string; the store expects number | null. Both conversions
+ * happen in parseTrajectoryResponse().
+ *
+ * MDA alerts: Zone 1B alerts are derived from the step-advance response
+ * (mda_alerts per framework_output). In M9, with no advance endpoint
+ * integration yet, mda_alerts defaults to [] (no alerts shown until
+ * the advance endpoint is wired in a follow-up PR).
+ *
+ * PMM: pmm_value and pmm_direction remain null in M9 (no PMM endpoint
+ * exists yet; the PMM widget renders "—"). This is correct per ADR-008
+ * Decision 6: null renders as "—" (instrument in validation).
+ */
+import React, { useEffect } from "react";
+import { InstrumentCluster } from "./InstrumentCluster";
+import { MDAAlertPanelZone1B } from "./MDAAlertPanelZone1B";
+import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
+import { FourFrameworkZone1D } from "./FourFrameworkZone1D";
+import { useScenarioStepStore } from "../store/scenarioStepStore";
+import type { TrajectoryResponse, TrajectoryFrameworkPoint } from "../store/scenarioStepStore";
+
+const API_BASE = "http://localhost:8000/api/v1";
+
+// ---------------------------------------------------------------------------
+// Trajectory response parsing
+// ---------------------------------------------------------------------------
+
+interface RawFrameworkPoint {
+  framework: string;
+  composite_score: string | null;
+  ci_lower: string | null;
+  ci_upper: string | null;
+  confidence_tier: number;
+  scoring_basis: "percentile_rank" | "normalized_absolute" | "boundary_proximity";
+}
+
+interface RawTrajectoryStep {
+  step_index: number;
+  effective_from: string;
+  step_event_label: string | null;
+  step_significance: "SIGNIFICANT" | "ROUTINE";
+  frameworks: RawFrameworkPoint[];
+}
+
+interface RawTrajectoryResponse {
+  scenario_id: string;
+  entity_id: string;
+  step_count: number;
+  mda_floors: Array<{
+    framework: string;
+    floor_value: string;
+    severity: "WARNING" | "CRITICAL";
+    label: string;
+  }>;
+  steps: RawTrajectoryStep[];
+}
+
+function parseTrajectoryResponse(raw: RawTrajectoryResponse): TrajectoryResponse {
+  return {
+    scenario_id: raw.scenario_id,
+    entity_id: raw.entity_id,
+    step_count: raw.step_count,
+    mda_floors: raw.mda_floors.map((f) => ({
+      framework: f.framework,
+      floor_value: parseFloat(f.floor_value),
+      label: f.label,
+      severity: f.severity,
+    })),
+    steps: raw.steps.map((step) => {
+      const frameworkMap: Record<string, TrajectoryFrameworkPoint> = {};
+      for (const fw of step.frameworks) {
+        frameworkMap[fw.framework] = {
+          composite_score:
+            fw.composite_score !== null ? parseFloat(fw.composite_score) : null,
+          ci_lower: fw.ci_lower !== null ? parseFloat(fw.ci_lower) : null,
+          ci_upper: fw.ci_upper !== null ? parseFloat(fw.ci_upper) : null,
+          confidence_tier: fw.confidence_tier,
+          scoring_basis:
+            fw.scoring_basis === "boundary_proximity"
+              ? "normalized_absolute"
+              : fw.scoring_basis,
+        };
+      }
+      return {
+        step_index: step.step_index,
+        effective_from: step.effective_from,
+        step_event_label: step.step_event_label,
+        step_significance: step.step_significance,
+        frameworks: frameworkMap,
+      };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ScenarioInstrumentCluster
+// ---------------------------------------------------------------------------
+
+interface ScenarioInstrumentClusterProps {
+  scenarioId: string;
+  stepCount: number;
+  currentStep: number;
+  entityIds?: string[];
+}
+
+export function ScenarioInstrumentCluster({
+  scenarioId,
+  stepCount,
+  currentStep,
+  entityIds,
+}: ScenarioInstrumentClusterProps) {
+  const store = useScenarioStepStore();
+
+  // Initialise store when scenario changes
+  useEffect(() => {
+    store.setScenario(scenarioId, stepCount, "MODE_1");
+  }, [scenarioId, stepCount]);
+
+  // Keep current_step in sync with ScenarioControls (prop-driven)
+  useEffect(() => {
+    if (currentStep !== store.current_step) {
+      useScenarioStepStore.setState({ current_step: currentStep });
+    }
+  }, [currentStep]);
+
+  // Fetch trajectory when scenario changes
+  useEffect(() => {
+    if (!scenarioId) return;
+    let cancelled = false;
+
+    fetch(`${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/trajectory`)
+      .then((res) => (res.ok ? (res.json() as Promise<RawTrajectoryResponse>) : null))
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        store.setTrajectory(parseTrajectoryResponse(raw));
+      })
+      .catch(() => {
+        // Non-fatal — TrajectoryView renders empty state when trajectory is null
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [scenarioId]);
+
+  return (
+    <InstrumentCluster
+      entityIds={entityIds}
+      mdaPanel={<MDAAlertPanelZone1B columnWidth={240} />}
+      pmmWidget={<PMMWidgetZone1C />}
+      fourFramework={<FourFrameworkZone1D />}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

First of two PRs for Issue #463 (Greece integration Playwright suite). Connects all four Zone 1 instruments to `App.tsx`, making all Playwright E2E guards live.

- **`ScenarioInstrumentCluster`** — composed wrapper that owns the Zustand store connection: fetches `GET /scenarios/{id}/trajectory` when `scenarioId` changes; parses API array→Record and Decimal string→number; keeps `current_step` in sync with `ScenarioControls` via prop. PMM (`pmm_value`, `pmm_direction`) and MDA alerts remain `null`/`[]` in M9 — no dedicated endpoints exist yet; PMM renders "—" per ADR-008 Decision 6 null contract.
- **`InstrumentCluster`** — removed duplicate `data-testid` from Zone 1B/1C/1D wrapper divs. The actual components (`MDAAlertPanelZone1B`, `PMMWidgetZone1C`, `FourFrameworkZone1D`) own their `data-testid` roots. Zone 1A wrapper retains `data-testid="zone-1a-trajectory-container"` (TrajectoryView has no root testid).
- **`App.tsx`** — instrument cluster renders above the choropleth map when a scenario is active (CLAUDE.md UX commitments 1+2: instruments primary, map context/navigable). `ModeIndicator` added to persistent header alongside `ScenarioControls`.

## What becomes live

All Playwright E2E guards (previously using `isVisible({ timeout: 2000 })` no-op) are now live when a scenario is selected:
- AC-003–AC-005, AC-011, AC-013, AC-014 — TrajectoryView dimensions + annotations
- AC-016–AC-021 — MDA alert panel
- AC-022–AC-029 — PMM + Four-Framework
- AC-030–AC-032 — ModeIndicator

AC-001/AC-002 (all four instruments without scroll at 1024×768 / 1280×800) are Type 2 integration tests in `instrument-cluster-integration.spec.ts` — still individually skipped; will be enabled in PR 2 (Greece Playwright suite).

## M9 scope boundaries

| Component | M9 status |
|---|---|
| TrajectoryView (Zone 1A) | ✅ Live — trajectory data from API |
| FourFrameworkZone1D (Zone 1D) | ✅ Live — derives from trajectory |
| MDAAlertPanelZone1B (Zone 1B) | ⚠ Empty — no MDA alert endpoint wired yet |
| PMMWidgetZone1C (Zone 1C) | ⚠ "—" — no PMM endpoint; null per ADR-008 Decision 6 |
| ModeIndicator | ✅ Live — "Replay" (MODE_1 default) |

## Test plan

- [x] 122/122 Vitest tests passing (`npm test -- --run`)
- [x] No regression in existing test files
- [x] `ScenarioInstrumentCluster` does not duplicate data-testid with `InstrumentCluster` wrapper divs
- [x] Trajectory parsing: Decimal string → float; array → Record<string, TrajectoryFrameworkPoint>
- [x] `boundary_proximity` scoring_basis mapped to `normalized_absolute` (store type union)

🤖 Generated with [Claude Code](https://claude.com/claude-code)