### PR TITLE
process(nm-019): milestone kickoff gate, HORIZON step 6, roadmap linkage requirement

### DIFF
--- a/docs/MILESTONE_RUNBOOK.md
+++ b/docs/MILESTONE_RUNBOOK.md
@@ -61,6 +61,33 @@ Performed when the previous milestone closes and the next begins.
 
 ---
 
+## Kickoff Gate — Mandatory Before First Implementation Issue
+
+Before any implementation issue is filed for this milestone, the PM Agent
+must run a scope-completeness check:
+
+1. Read `CLAUDE.md` and enumerate every deliverable explicitly named for
+   this milestone.
+2. Read `docs/roadmap/worldsim-roadmap.md` and enumerate every blocking
+   deliverable listed for this milestone.
+3. For each named deliverable, verify a corresponding GitHub issue exists
+   with: an owner agent named, a `horizon:immediate` or `horizon:near-term`
+   label, and the correct milestone assigned.
+4. Any named deliverable with no corresponding issue is a
+   `scope-gap:untracked` finding. File it as an issue before proceeding.
+5. Present the kickoff baseline to the Engineering Lead: a table of all
+   named deliverables, their tracking issues, and their owners.
+
+**No implementation begins until this verification is complete and the
+Engineering Lead has confirmed the baseline.**
+
+This gate exists because named deliverables can live in prose documents
+for an entire milestone without ever becoming tracked work. The gate
+converts constitutional scope into board visibility at the moment it
+matters — before implementation begins, not at exit review. (NM-019)
+
+---
+
 ## Milestone Execution Workflow
 
 **Issues are the unit of work.** Every meaningful change has a GitHub Issue. PRs

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -69,6 +69,7 @@ Operating modes:
   3. COMMITTED WORK AT RISK — current milestone issues that are blocked, stale, or behind expected merge cadence; surface to Engineering Lead.
   4. CROSS-MILESTONE EXPOSURE — upcoming milestone items that depend on unfinished current milestone work; name the dependency chain.
   5. FILE AUTHORITY AUDIT — scan PRs merged since the last HORIZON sweep: did any PR write to a file owned (R) by an agent other than the PR author, without a review comment from the owning agent? Flag any violation. Check against `docs/process/agent-raci.md §File Ownership`. The audit is retroactive — catches violations after the fact for documentation and process correction. Not a merge gate but creates accountability at the HORIZON level.
+  6. SCOPE-COMPLETENESS CHECK — compare the current milestone's open-issue list against all deliverables named in `CLAUDE.md` and `docs/roadmap/worldsim-roadmap.md` for this milestone. Flag any named deliverable with no corresponding GitHub issue as `scope-gap:untracked` and surface immediately to the Engineering Lead. This check is not retrospective — it is a standing obligation every HORIZON sweep. A deliverable that is named in the constitution but absent from the board is not deferred; it is untracked. Those are different things. (NM-019)
 - **FOCUS:** One action and one reason. No list. No context.
 - **EXECUTE:** Execute a named task directly — file issues, update trackers, run mechanical operations as instructed.
 

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -37,6 +37,30 @@ The story is the democratization mission made concrete. The tool that showed Gre
 
 ---
 
+## Scope Linkage Requirement
+
+Each milestone entry in this document must enumerate its blocking deliverables
+explicitly — not just narratively — and link to the tracking GitHub issue once
+filed. A deliverable named here without a linked issue is a visible scope gap.
+
+Format for each blocking deliverable within a milestone entry:
+```
+- [Deliverable name] → Issue #NNN (horizon:immediate)
+```
+
+If the issue has not yet been filed, the entry reads:
+```
+- [Deliverable name] → UNTRACKED (file issue before kickoff begins)
+```
+
+This requirement exists because roadmap.md is designated as the canonical
+milestone scope reference in CLAUDE.md. A canonical reference that does not
+link to tracked work cannot be audited. The linkage makes the roadmap a diff
+surface: any milestone entry with UNTRACKED items is an open kickoff gate.
+(NM-019)
+
+---
+
 ## Milestone by Milestone
 
 ### Milestone 9 — Standards Foundation *(current)*


### PR DESCRIPTION
Closes #504

## Summary

Three process fixes for NM-019 — named deliverables invisible on the board for an entire milestone.

- **MILESTONE_RUNBOOK.md §Kickoff Gate** (new section before Execution Workflow): mandatory 5-step scope-completeness check before first implementation issue is filed. PM Agent enumerates CLAUDE.md and roadmap.md deliverables, verifies each has a tracked issue with owner and horizon label, presents a kickoff baseline to the EL. No implementation begins until the EL confirms the baseline.
- **docs/process/agents.md §PM Agent HORIZON step 6**: SCOPE-COMPLETENESS CHECK — every HORIZON sweep now compares the open-issue list against CLAUDE.md-stated deliverables; flags any named deliverable with no issue as `scope-gap:untracked`. Standing obligation, not retrospective.
- **docs/roadmap/worldsim-roadmap.md §Scope Linkage Requirement** (new section before Milestone by Milestone): each milestone entry must enumerate blocking deliverables with linked issue numbers (`→ Issue #NNN`) or mark them `UNTRACKED`. An UNTRACKED item is a visible kickoff gate — the roadmap becomes a diff surface.

## Test plan

- [ ] `MILESTONE_RUNBOOK.md` contains `## Kickoff Gate — Mandatory Before First Implementation Issue` immediately before `## Milestone Execution Workflow`
- [ ] Kickoff Gate has all 5 enumerated steps and the mandatory-pre-condition statement
- [ ] `docs/process/agents.md` HORIZON list now has 6 numbered steps; step 6 is SCOPE-COMPLETENESS CHECK referencing NM-019
- [ ] `docs/roadmap/worldsim-roadmap.md` contains `## Scope Linkage Requirement` before `## Milestone by Milestone` with the `→ Issue #NNN` / `UNTRACKED` format
- [ ] All three documents reference NM-019 in the added text
- [ ] Issue #504 is closed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)