### PR TITLE
docs(roadmap): #221 mean-reversion M11 deferral confirmed — EL decision 2026-05-30

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-05-30 (M10 kickoff gate complete — #556 filed, roadmap updated PR #557; EL decision pending on #221)**
+**Last updated: 2026-05-30 (M10 kickoff gate fully resolved — #221 Option B accepted; roadmap final; implementation unblocked pending #523/#524/#514/#550)**
 **Current milestone:** M10 — Engine Integrity and Backtesting (M9 formally closed; M10 active)
 
 ---
@@ -202,7 +202,7 @@ All Horizon:Immediate issues are now closed. M8 feature-complete.
 
 | Decision | Context | Status |
 |---|---|---|
-| #221 mean-reversion channel — M10 or M11? | Roadmap stated "hard constraint, cannot be deferred past M10." Board split 2026-05-30 moved #221 to M11 (EL approved split). Conflict identified at M10 kickoff gate. Option A: revert #221 to M10 (roadmap constraint stands, M10 scope grows). Option B: accept M11 deferral (confirm split decision supersedes roadmap; roadmap will be updated to remove hard-constraint language with rationale). Kickoff gate is blocked on this decision. | **PENDING** |
+| #221 mean-reversion channel — M10 or M11? | Option B selected 2026-05-30: M11 deferral confirmed. Greece MAGNITUDE fidelity gap at stabilisation cases acknowledged. Demo 3 proceeds without mean-reversion channel. Roadmap updated (hard-constraint language removed; rationale recorded). Decision posted on #261 and #221. | Complete ✅ — 2026-05-30 |
 |---|---|---|
 | Trajectory endpoint implementation | FastAPI route + Pydantic model + normalized_absolute_strategy backend function. All prerequisites complete. May begin. | Ready — unblocked |
 | US-GAP-001 — Andreas Mode 1 comparative case surface | **Resolved.** EL decision 2026-05-23: M10 gap. Issue #451 filed. information-hierarchy.md §COMPARE_VIEW Mode 1 placeholder added. user-stories file updated to reflect partial M9 service for Persona 3. | Complete ✅ — PR #452 |

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -94,7 +94,7 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 - GovernanceModule promoted — governance axis live with real data; five ADR-005 Amendment 4 promotion criteria → Issue #556 (horizon:immediate) [filed 2026-05-30; blocking prerequisite: #523 IB+DQ agent definitions]
 - PMM (Policy Manoeuvre Margin) live computation → Issue #496 (horizon:immediate)
 - Second country backtesting fixture — Argentina 2000–2002 (confirmed 2026-05-30) → Issue #553 (horizon:immediate) [CM data availability check is blocking prerequisite before implementation]
-- Mean-reversion channel → Issue #221 [**EL DECISION PENDING** — roadmap previously stated "hard constraint, cannot be deferred past M10"; issue moved to M11 per 2026-05-30 board split; EL must either re-milestone #221 to M10 or confirm M11 deferral and remove this constraint]
+- Mean-reversion channel → Issue #221 (M11) [EL decision 2026-05-30: M11 deferral accepted. Greece MAGNITUDE fidelity gap at stabilisation cases is acknowledged. Demo 3 proceeds without the mean-reversion channel. Deferred to M11 where engine integrity is the milestone theme and MacroeconomicModule fidelity work is in scope alongside ADR-009.]
 - Phase 1 baseline benchmarks — iterative engine on target hardware (4-core/8GB laptop AND GitHub Actions free-tier runner) → Issue #514 (horizon:immediate) [moved from M11 to M10 per NM-020, 2026-05-25; prerequisite for ADR-009 authoring in M11; Chief Engineer activation required]
 - step_event_label mandatory field on all Mode 1 fixtures → Issue #395 (horizon:immediate)
 - Playwright demo advancement test and legibility assertions → Issues #376, #377 (horizon:immediate)


### PR DESCRIPTION
## Summary

EL chose Option B: M11 deferral accepted for Issue #221 (mean-reversion channel).

- Roadmap hard-constraint language removed; M11 rationale recorded
- SESSION_STATE.md pending EL decision entry closed
- Decision posted on #261 (kickoff gate) and #221 (issue itself)

## What this resolves

M10 kickoff gate Finding 2 — roadmap/board conflict on #221. All named M10 deliverables are now tracked. The kickoff gate is fully resolved.

## Implementation gate sequence (now active)

No implementation PR opens until: **#523 → #524 → #514 → #550**.

## PR Cross-references

Updates: `docs/roadmap/worldsim-roadmap.md`, `SESSION_STATE.md`