### PR TITLE
process(runbook): milestone metadata alignment check — kickoff gate step 0 and closure ceremony step 7

### DIFF
--- a/docs/MILESTONE_RUNBOOK.md
+++ b/docs/MILESTONE_RUNBOOK.md
@@ -64,7 +64,20 @@ Performed when the previous milestone closes and the next begins.
 ## Kickoff Gate — Mandatory Before First Implementation Issue
 
 Before any implementation issue is filed for this milestone, the PM Agent
-must run a scope-completeness check:
+must run the following checks in order:
+
+0. **Milestone metadata alignment check.** Before scope verification begins,
+   verify all four milestone artifacts are aligned with the milestone now
+   starting as **Current**:
+   - GitHub milestone title matches `Milestone N — <Name>` convention
+   - GitHub milestone description reflects the core deliverable of the
+     milestone now beginning — not a prior or future milestone's scope
+   - `CLAUDE.md §What We Are Building First` shows the new milestone as
+     current with bullet points matching its core deliverables
+   - `CLAUDE.md §Milestone Roadmap` shows the new milestone as Current and
+     the next as Next
+   Any misalignment found must be corrected before proceeding to step 1.
+   (Issue #561)
 
 1. Read `CLAUDE.md` and enumerate every deliverable explicitly named for
    this milestone.
@@ -227,7 +240,19 @@ Audit above is complete.**
    - [one-line summary of open finding count by severity]
    ```
 
-7. **Next milestone creation ceremony triggered.** Unless this is the final milestone,
+7. **Milestone metadata alignment check.** Before the next milestone creation
+   ceremony, verify all four artifacts have been updated to reflect this milestone
+   as complete and the next as current:
+   - GitHub milestone description updated to reflect what shipped and any explicit
+     deferrals (with issue numbers and dated rationale)
+   - `CLAUDE.md §What We Are Building First` updated to show the next milestone
+     as current with correct bullet points
+   - `CLAUDE.md §Milestone Roadmap` updated to show the next milestone as Current
+   - `docs/roadmap/worldsim-roadmap.md` revision header updated; scope deferrals
+     noted with dated rationale
+   Any misalignment found must be corrected before step 8. (Issue #561)
+
+8. **Next milestone creation ceremony triggered.** Unless this is the final milestone,
    immediately initiate the creation ceremony for Milestone N+1. Do not leave a gap
    between milestones — the gap is where work loses coherence and Issues accumulate
    without context.


### PR DESCRIPTION
## Summary

- Adds **Kickoff Gate step 0**: verify GitHub milestone title/description, CLAUDE.md §What We Are Building First, and CLAUDE.md §Milestone Roadmap are all aligned with the milestone now starting as Current before scope verification begins
- Adds **Closure Ceremony step 7**: verify all four artifacts (GitHub milestone description, CLAUDE.md §What We Are Building First, CLAUDE.md §Milestone Roadmap, roadmap.md) are updated to reflect the closing milestone as complete and the next as Current before the next milestone creation ceremony starts

Renumbers existing Closure Ceremony step 7 → step 8.

Both steps cite Issue #561 for traceability.

## Root Cause

Six metadata misalignments were found manually at the M10 kickoff gate (2026-05-30) — GitHub milestones describing wrong-milestone scope, CLAUDE.md still showing M9 as current. No runbook step had prompted this check. Closes #561.

## File Authority

`docs/MILESTONE_RUNBOOK.md` follows the docs/standards pattern: EL holds R. **Engineering Lead review required before merge.**

## Test Plan

- [ ] Step 0 appears in §Kickoff Gate before existing step 1, lists all four artifacts, cites Issue #561
- [ ] Step 7 appears in §Milestone Closure Ceremony before existing step 7 (now renumbered 8), lists all four artifacts, cites Issue #561
- [ ] Issue #561 is closed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)