### PR TITLE
fix(zone-1d): governance null inline annotation '(in validation)' — IR-005, closes #499

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -54,6 +54,26 @@ export function getScoreClass(score: number | null): "score-value--null" | "scor
   return score === null ? "score-value--null" : "score-value--numeric";
 }
 
+/**
+ * Inline annotation shown next to the governance score when null (IR-005).
+ * Governance null means "not yet computed"; other null frameworks have
+ * different semantics that will be addressed in future milestones.
+ */
+export const GOVERNANCE_IN_VALIDATION_ANNOTATION = "(in validation)";
+
+/**
+ * Returns the inline annotation for a score cell, or null if no annotation applies.
+ * Only governance + null score produces an annotation (IR-005).
+ */
+export function getGovernanceAnnotation(
+  framework: string,
+  score: number | null,
+): string | null {
+  return framework === "governance" && score === null
+    ? GOVERNANCE_IN_VALIDATION_ANNOTATION
+    : null;
+}
+
 // ---------------------------------------------------------------------------
 // FourFrameworkZone1D
 // ---------------------------------------------------------------------------
@@ -91,6 +111,8 @@ export function FourFrameworkZone1D({
         const displayLabel = FRAMEWORK_DISPLAY_LABELS[key] ?? key;
         const color = FRAMEWORK_COLORS[key as keyof typeof FRAMEWORK_COLORS] ?? "#888";
         const isNull = score === null;
+
+        const annotation = getGovernanceAnnotation(key, score);
 
         return (
           <div
@@ -131,6 +153,14 @@ export function FourFrameworkZone1D({
               }}
             >
               {formatScore(score)}
+              {annotation !== null && (
+                <span
+                  data-testid="governance-in-validation"
+                  style={{ fontSize: 9, fontWeight: 400, marginLeft: 4, opacity: 0.8 }}
+                >
+                  {annotation}
+                </span>
+              )}
             </span>
           </div>
         );

--- a/frontend/src/components/__tests__/FourFrameworkZone1D.test.ts
+++ b/frontend/src/components/__tests__/FourFrameworkZone1D.test.ts
@@ -13,6 +13,8 @@ import { describe, it, expect } from "vitest";
 import {
   formatScore,
   getScoreClass,
+  getGovernanceAnnotation,
+  GOVERNANCE_IN_VALIDATION_ANNOTATION,
   FRAMEWORK_DISPLAY_LABELS,
   FRAMEWORK_ORDER,
 } from "../FourFrameworkZone1D";
@@ -123,6 +125,46 @@ describe("US-021 — FRAMEWORK_DISPLAY_LABELS: human-readable framework labels",
     for (const label of Object.values(FRAMEWORK_DISPLAY_LABELS)) {
       expect(label).not.toContain("_");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IR-005 — getGovernanceAnnotation: inline annotation for governance null
+// ---------------------------------------------------------------------------
+
+describe("IR-005 — getGovernanceAnnotation: governance null shows inline annotation", () => {
+  it("governance + null → GOVERNANCE_IN_VALIDATION_ANNOTATION", () => {
+    expect(getGovernanceAnnotation("governance", null)).toBe(
+      GOVERNANCE_IN_VALIDATION_ANNOTATION,
+    );
+  });
+
+  it("governance + null annotation equals '(in validation)'", () => {
+    expect(getGovernanceAnnotation("governance", null)).toBe("(in validation)");
+  });
+
+  it("governance + numeric score → null (no annotation when score is present)", () => {
+    expect(getGovernanceAnnotation("governance", 0.75)).toBeNull();
+  });
+
+  it("governance + zero score → null (zero is not null)", () => {
+    expect(getGovernanceAnnotation("governance", 0)).toBeNull();
+  });
+
+  it("financial + null → null (non-governance null has no annotation)", () => {
+    expect(getGovernanceAnnotation("financial", null)).toBeNull();
+  });
+
+  it("human_development + null → null", () => {
+    expect(getGovernanceAnnotation("human_development", null)).toBeNull();
+  });
+
+  it("ecological + null → null", () => {
+    expect(getGovernanceAnnotation("ecological", null)).toBeNull();
+  });
+
+  it("GOVERNANCE_IN_VALIDATION_ANNOTATION constant is the canonical string", () => {
+    expect(GOVERNANCE_IN_VALIDATION_ANNOTATION).toBe("(in validation)");
   });
 });
 

--- a/frontend/tests/e2e/greece-integration.spec.ts
+++ b/frontend/tests/e2e/greece-integration.spec.ts
@@ -154,14 +154,15 @@ test("Greece step-through: governance null renders as — not zero (AC-015)", as
   const govText = await govScore.textContent();
 
   if (govClass?.includes("score-value--null")) {
-    // Null case: must display "—", must not display "0" or "0.00"
-    expect(govText?.trim()).toBe("—");
+    // Null case: must start with "—" (IR-005 adds inline annotation so full
+    // textContent is "—(in validation)", not bare "—"). Must not be "0".
+    expect(govText?.trim()).toMatch(/^—/);
     expect(govText?.trim()).not.toBe("0");
     expect(govText?.trim()).not.toBe("0.00");
   } else {
     // Numeric case: class must be score-value--numeric, text must not be "—"
     expect(govClass).toContain("score-value--numeric");
-    expect(govText?.trim()).not.toBe("—");
+    expect(govText?.trim()).not.toMatch(/^—/);
   }
 });
 


### PR DESCRIPTION
## Summary

- Exports `GOVERNANCE_IN_VALIDATION_ANNOTATION = "(in validation)"` and `getGovernanceAnnotation(framework, score)` from `FourFrameworkZone1D.tsx`
- When governance `composite_score === null`, renders a small `(in validation)` span inline with the "—" score (`data-testid="governance-in-validation"`)
- Non-governance null rows unchanged — annotation is governance-specific per IR-005 spec
- 8 new Vitest cases in `FourFrameworkZone1D.test.ts` covering the annotation logic (all 31 tests pass)

## Acceptance criteria

- [x] Governance row shows "— (in validation)" when composite_score is null
- [x] Financial / human_development / ecological null rows show "—" without annotation
- [x] Vitest tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)