### PR TITLE
fix(zone-1d): loading and error states during trajectory fetch — IR-006, closes #500

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -151,31 +151,25 @@ export function FourFrameworkZone1D({
     );
   }
 
-  // Error state: does not block the rest of the instrument cluster (IR-006).
-  if (isError) {
-    return (
-      <div
-        data-testid={dataTestId}
-        data-current-step={current_step}
-        data-error="true"
-        style={{ ...CONTAINER_STYLE, alignItems: "center", justifyContent: "center" }}
-      >
-        <span
-          data-testid="zone-1d-error"
-          style={{ fontSize: 11, color: "#aaa", fontStyle: "italic" }}
-        >
-          Data unavailable
-        </span>
-      </div>
-    );
-  }
-
+  // Normal render — framework rows always present in DOM regardless of error
+  // state (IR-006). Error indicator is inline above the rows so existing
+  // testids remain discoverable. When isError=true, trajectory is null so
+  // all scores render as "—" (same as pre-fetch state).
   return (
     <div
       data-testid={dataTestId}
       data-current-step={current_step}
+      {...(isError ? { "data-error": "true" } : {})}
       style={CONTAINER_STYLE}
     >
+      {isError && (
+        <span
+          data-testid="zone-1d-error"
+          style={{ fontSize: 9, color: "#aaa", fontStyle: "italic", paddingBottom: 2 }}
+        >
+          Data unavailable
+        </span>
+      )}
       {FRAMEWORK_ORDER.map((key) => {
         const point = currentStepData?.frameworks[key] ?? null;
         const score = point?.composite_score ?? null;

--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -80,10 +80,25 @@ export function getGovernanceAnnotation(
 
 interface FourFrameworkZone1DProps {
   "data-testid"?: string;
+  /** True while the trajectory fetch is in flight (IR-006). */
+  isLoading?: boolean;
+  /** True if the trajectory fetch failed (IR-006). */
+  isError?: boolean;
 }
+
+const CONTAINER_STYLE: React.CSSProperties = {
+  padding: "6px 10px",
+  boxSizing: "border-box",
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-around",
+};
 
 export function FourFrameworkZone1D({
   "data-testid": dataTestId = "zone-1d-four-framework",
+  isLoading = false,
+  isError = false,
 }: FourFrameworkZone1DProps) {
   const { trajectory, current_step } = useScenarioStepStore();
 
@@ -91,18 +106,75 @@ export function FourFrameworkZone1D({
     (s) => s.step_index === current_step,
   ) ?? null;
 
+  // Loading skeleton: maintain DOM structure so framework-row testids are
+  // always present — existing E2E tests can locate them immediately (IR-006).
+  if (isLoading) {
+    return (
+      <div
+        data-testid={dataTestId}
+        data-current-step={current_step}
+        data-loading="true"
+        style={CONTAINER_STYLE}
+      >
+        {FRAMEWORK_ORDER.map((key) => {
+          const color = FRAMEWORK_COLORS[key as keyof typeof FRAMEWORK_COLORS] ?? "#888";
+          return (
+            <div
+              key={key}
+              data-testid={`framework-row-${key}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                borderLeft: `3px solid ${color}`,
+                paddingLeft: 6,
+                paddingTop: 3,
+                paddingBottom: 3,
+                borderLeftStyle: "dashed",
+                opacity: 0.35,
+              }}
+            >
+              <span style={{ fontSize: 11, color: "#555", fontWeight: 500 }}>
+                {FRAMEWORK_DISPLAY_LABELS[key] ?? key}
+              </span>
+              <span
+                data-testid={`framework-score-${key}`}
+                className="score-value--loading"
+                style={{ fontSize: 13, fontWeight: 700, color: "#bbb", fontVariantNumeric: "tabular-nums" }}
+              >
+                …
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Error state: does not block the rest of the instrument cluster (IR-006).
+  if (isError) {
+    return (
+      <div
+        data-testid={dataTestId}
+        data-current-step={current_step}
+        data-error="true"
+        style={{ ...CONTAINER_STYLE, alignItems: "center", justifyContent: "center" }}
+      >
+        <span
+          data-testid="zone-1d-error"
+          style={{ fontSize: 11, color: "#aaa", fontStyle: "italic" }}
+        >
+          Data unavailable
+        </span>
+      </div>
+    );
+  }
+
   return (
     <div
       data-testid={dataTestId}
       data-current-step={current_step}
-      style={{
-        padding: "6px 10px",
-        boxSizing: "border-box",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-around",
-      }}
+      style={CONTAINER_STYLE}
     >
       {FRAMEWORK_ORDER.map((key) => {
         const point = currentStepData?.frameworks[key] ?? null;
@@ -126,7 +198,6 @@ export function FourFrameworkZone1D({
               paddingLeft: 6,
               paddingTop: 3,
               paddingBottom: 3,
-              // Dashed border treatment for null axes (DD-011 extension into Zone 1)
               borderLeftStyle: isNull ? "dashed" : "solid",
               opacity: isNull ? 0.6 : 1,
             }}

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -19,7 +19,7 @@
  * exists yet; the PMM widget renders "—"). This is correct per ADR-008
  * Decision 6: null renders as "—" (instrument in validation).
  */
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { InstrumentCluster } from "./InstrumentCluster";
 import { MDAAlertPanelZone1B } from "./MDAAlertPanelZone1B";
 import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
@@ -172,6 +172,11 @@ export function ScenarioInstrumentCluster({
 }: ScenarioInstrumentClusterProps) {
   const store = useScenarioStepStore();
 
+  // Fetch lifecycle state for Zone 1D loading/error display (IR-006).
+  // Local state — not Zustand — because this is fetch lifecycle, not simulation state.
+  const [trajectoryLoading, setTrajectoryLoading] = useState(false);
+  const [trajectoryError, setTrajectoryError] = useState(false);
+
   // Initialise store when scenario changes
   useEffect(() => {
     store.setScenario(scenarioId, stepCount, "MODE_1");
@@ -189,14 +194,23 @@ export function ScenarioInstrumentCluster({
     if (!scenarioId) return;
     let cancelled = false;
 
+    setTrajectoryLoading(true);
+    setTrajectoryError(false);
+
     fetch(`${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/trajectory`)
-      .then((res) => (res.ok ? (res.json() as Promise<RawTrajectoryResponse>) : null))
+      .then((res) => {
+        if (!res.ok) throw new Error(`trajectory fetch failed: ${res.status}`);
+        return res.json() as Promise<RawTrajectoryResponse>;
+      })
       .then((raw) => {
-        if (cancelled || !raw) return;
+        if (cancelled) return;
         store.setTrajectory(parseTrajectoryResponse(raw));
+        setTrajectoryLoading(false);
       })
       .catch(() => {
-        // Non-fatal — TrajectoryView renders empty state when trajectory is null
+        if (cancelled) return;
+        setTrajectoryLoading(false);
+        setTrajectoryError(true);
       });
 
     return () => {
@@ -234,7 +248,12 @@ export function ScenarioInstrumentCluster({
       entityIds={entityIds}
       mdaPanel={<MDAAlertPanelZone1B columnWidth={240} />}
       pmmWidget={<PMMWidgetZone1C />}
-      fourFramework={<FourFrameworkZone1D />}
+      fourFramework={
+        <FourFrameworkZone1D
+          isLoading={trajectoryLoading}
+          isError={trajectoryError}
+        />
+      }
     />
   );
 }

--- a/frontend/tests/e2e/greece-integration.spec.ts
+++ b/frontend/tests/e2e/greece-integration.spec.ts
@@ -226,6 +226,39 @@ test("Greece step-through: cluster consistent at all 3 steps", async ({
 });
 
 // ---------------------------------------------------------------------------
+// IR-006: Zone 1D loading state — framework rows present immediately,
+// data-loading attribute absent once trajectory fetch completes.
+//
+// The loading state may be sub-second on fast connections. The test
+// verifies the post-loading invariant: data-loading is gone and all four
+// framework-row testids are present. The loading skeleton maintains DOM
+// structure so testids are discoverable throughout the fetch window.
+// ---------------------------------------------------------------------------
+
+test("Greece step-through: Zone 1D loading state resolves to data after scenario selection (IR-006)", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await createAndSelectScenario(page, `GRC-ir006-${Date.now()}`);
+
+  const zone1d = page.locator('[data-testid="zone-1d-four-framework"]');
+  await expect(zone1d).toBeVisible({ timeout: 10_000 });
+
+  // After loading completes, data-loading attribute must be absent
+  await expect(zone1d).not.toHaveAttribute("data-loading", "true", {
+    timeout: 10_000,
+  });
+
+  // All four framework rows must be present (skeleton preserved them during fetch)
+  for (const fw of ["financial", "human_development", "ecological", "governance"]) {
+    await expect(
+      page.locator(`[data-testid="framework-row-${fw}"]`),
+    ).toBeVisible();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // IR-001: Zone 1B shows data-driven alert state after step advance
 //
 // After advancing to step 1, Zone 1B must reflect real measurement-output


### PR DESCRIPTION
## Summary

- `ScenarioInstrumentCluster` tracks `trajectoryLoading` / `trajectoryError` as local React state (fetch lifecycle — not Zustand, which owns simulation state). Loading starts on every `scenarioId` change; error state is set on any non-ok HTTP response or network failure
- Non-ok responses now throw instead of returning null so the `.catch()` block correctly sets the error state
- `FourFrameworkZone1D` gains `isLoading` and `isError` props with two new render paths:
  - **Loading:** four skeleton rows at 0.35 opacity with `…` placeholder text; `data-loading="true"` on the container; DOM structure preserved so `framework-row-{key}` testids are always discoverable during the fetch window
  - **Error:** `"Data unavailable"` message; `data-testid="zone-1d-error"`; does not block any other Zone 1 instrument
- Inline style object extracted to `CONTAINER_STYLE` constant to avoid duplication across three render paths

## Acceptance criteria

- [x] While trajectory fetch is in progress, Zone 1D shows skeleton rows (distinct from permanent null "—" — loading uses `…`, not `—`)
- [x] On fetch completion, Zone 1D transitions to normal score rendering (`data-loading` attribute removed)
- [x] On fetch failure, Zone 1D shows "Data unavailable" error state; rest of cluster unaffected

## Test plan

- [x] `FourFrameworkZone1D.test.ts` — 31 Vitest unit tests pass (pure functions unchanged)
- [x] IR-006 Playwright guard in `greece-integration.spec.ts` — asserts `data-loading` absent after scenario selection settles
- [ ] Manual: create scenario on throttled connection, confirm skeleton rows visible before data arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)