### PR TITLE
feat(ui): IR-004 — start_year field seeds trajectory tick date labels (Issue #498)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -260,6 +260,11 @@ body,
   border-color: rgba(59, 130, 246, 0.6);
 }
 
+.scenario-create-input--year {
+  flex: 0 0 72px;
+  text-align: center;
+}
+
 .scenario-btn--create {
   background: rgba(59, 130, 246, 0.3);
   border-color: rgba(59, 130, 246, 0.5);

--- a/frontend/src/components/ScenarioPanel.tsx
+++ b/frontend/src/components/ScenarioPanel.tsx
@@ -21,6 +21,7 @@ export default function ScenarioPanel({
   const [scenarios, setScenarios] = useState<ScenarioResponse[]>([]);
   const [listError, setListError] = useState<string | null>(null);
   const [createName, setCreateName] = useState("");
+  const [createStartYear, setCreateStartYear] = useState(2020);
   const [creating, setCreating] = useState(false);
   const [createSuccess, setCreateSuccess] = useState<string | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -70,6 +71,7 @@ export default function ScenarioPanel({
     setCreateSuccess(null);
 
     try {
+      const startDate = `${createStartYear}-01-01`;
       const res = await fetch(`${API_BASE}/scenarios`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -80,6 +82,7 @@ export default function ScenarioPanel({
             entities: ["GRC"],
             n_steps: 3,
             timestep_label: "annual",
+            start_date: startDate,
             initial_attributes: {},
           },
           scheduled_inputs: [],
@@ -89,6 +92,7 @@ export default function ScenarioPanel({
       if (res.ok) {
         setCreateSuccess(`"${name}" created.`);
         setCreateName("");
+        setCreateStartYear(2020);
         void fetchScenarios();
       } else {
         const body = await res.json().catch(() => ({})) as { detail?: string };
@@ -180,6 +184,16 @@ export default function ScenarioPanel({
               }}
               disabled={creating}
             />
+            <input
+              className="scenario-create-input scenario-create-input--year"
+              type="number"
+              aria-label="Start year"
+              min={1900}
+              max={2100}
+              value={createStartYear}
+              onChange={(e) => setCreateStartYear(Number(e.target.value))}
+              disabled={creating}
+            />
             <button
               className="scenario-btn scenario-btn--create"
               type="submit"
@@ -195,7 +209,7 @@ export default function ScenarioPanel({
             <div className="scenario-panel-error">{createError}</div>
           )}
           <div className="scenario-create-hint">
-            Creates a GRC scenario with 3 annual steps.
+            Creates a GRC scenario with 3 annual steps starting at the given year.
           </div>
         </div>
       </div>

--- a/frontend/tests/e2e/greece-integration.spec.ts
+++ b/frontend/tests/e2e/greece-integration.spec.ts
@@ -28,6 +28,7 @@ import { test, expect } from "@playwright/test";
 async function createAndSelectScenario(
   page: import("@playwright/test").Page,
   name: string,
+  startYear?: number,
 ) {
   await page.waitForFunction(
     () =>
@@ -37,6 +38,9 @@ async function createAndSelectScenario(
   );
   await page.getByRole("button", { name: /Scenarios/ }).click();
   await page.locator('input[placeholder="Scenario name"]').fill(name);
+  if (startYear !== undefined) {
+    await page.locator('input[aria-label="Start year"]').fill(String(startYear));
+  }
   await page.locator(".scenario-btn--create").click();
   const row = page.locator(".scenario-row").filter({ hasText: name });
   await expect(row).toBeVisible({ timeout: 15_000 });
@@ -323,4 +327,52 @@ test("Greece step-through: mode switch updates indicator label (guard)", async (
   await mode2Trigger.click();
   await expect(indicator).toHaveText("Simulation");
   await expect(indicator).toHaveAttribute("data-mode", "MODE_2");
+});
+
+// ---------------------------------------------------------------------------
+// IR-004: start_year field populates trajectory tick date labels (Issue #498)
+//
+// Creates a scenario with start_year=2015. After advancing steps the trajectory
+// view X-axis ticks must include years from the 2015–2018 range, not the
+// default 2000-era dates. Uses a relaxed guard: if the trajectory SVG is not
+// rendered at the test viewport, the assertion is skipped (same pattern as
+// AC-011 in trajectory-view.spec.ts).
+// ---------------------------------------------------------------------------
+
+test("IR-004: start_year input seeds trajectory tick year labels", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await createAndSelectScenario(page, `GRC-ir004-${Date.now()}`, 2015);
+
+  const zone1d = page.locator('[data-testid="zone-1d-four-framework"]');
+  await expect(zone1d).toBeVisible({ timeout: 10_000 });
+
+  // Wait for loading state to clear — trajectory must be fetched before
+  // tick dates are meaningful.
+  await expect(zone1d).not.toHaveAttribute("data-loading", "true", {
+    timeout: 10_000,
+  });
+
+  // Advance one step so the trajectory SVG has tick labels to inspect.
+  await advanceStep(page, 1, 3);
+
+  // Guard: trajectory SVG may not render at all viewports (no-op if absent).
+  const svg = page.locator('[data-testid="zone-1a-trajectory"] svg').first();
+  const hasSvg = await svg.isVisible({ timeout: 3_000 }).catch(() => false);
+  if (!hasSvg) return;
+
+  // Collect all text node contents from the SVG tick labels.
+  const allText = await svg.locator("text").allTextContents();
+  const joined = allText.join(" ");
+
+  // The tick labels must reference years in the 2015–2018 window (start_year
+  // to start_year + n_steps), NOT the 2000-era default.
+  const hasExpectedYear =
+    joined.includes("2015") ||
+    joined.includes("2016") ||
+    joined.includes("2017") ||
+    joined.includes("2018");
+  expect(hasExpectedYear).toBe(true);
 });


### PR DESCRIPTION
## Summary

- Adds a numeric **Start year** input (default 2020, range 1900–2100) to the scenario create form
- Passes `start_date` as an ISO date string (`"{year}-01-01"`) in the configuration POST body
- The backend's existing `_base_timestep()` logic already reads `start_date` and advances by one calendar year per step, so no backend changes are needed
- `CustomStepTick` in `TrajectoryView` already formats `effective_from` into human-readable month/year labels — IR-004 is purely a wiring gap

## Changes

- `ScenarioPanel.tsx` — adds `createStartYear` state (default 2020), year input with `aria-label="Start year"`, resets to 2020 on successful create, passes `start_date` in the POST configuration body
- `App.css` — adds `.scenario-create-input--year` modifier (`flex: 0 0 72px`, `text-align: center`) to keep the year field compact alongside the name input and Create button
- `greece-integration.spec.ts` — extends `createAndSelectScenario` helper to accept optional `startYear`, adds IR-004 E2E test that creates a scenario with `startYear=2015` and asserts trajectory SVG tick labels contain years from the 2015–2018 window

## Test plan

- [ ] All 130 Vitest unit tests pass
- [ ] TypeScript compiles with no errors
- [ ] E2E: `IR-004: start_year input seeds trajectory tick year labels` passes (guard skips if SVG not rendered at test viewport)
- [ ] Manual: create scenario with year 2010 → advance steps → trajectory ticks show "Jan 2010", "Jan 2011", etc.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)