### PR TITLE
feat(app): IR-003 — persistent scenario state and demonstrative entry (Issue #497)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,44 @@ const API_BASE = "http://localhost:8000/api/v1";
 
 const DEFAULT_ATTRIBUTE = "gdp_usd_millions";
 
+// ---------------------------------------------------------------------------
+// Persistent scenario state — IR-003
+// ---------------------------------------------------------------------------
+
+const LAST_SCENARIO_KEY = "worldsim_last_scenario";
+
+interface StoredScenario {
+  id: string;
+  name: string;
+  totalSteps: number;
+}
+
+function readStoredScenario(): StoredScenario | null {
+  try {
+    const raw = localStorage.getItem(LAST_SCENARIO_KEY);
+    return raw ? (JSON.parse(raw) as StoredScenario) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredScenario(s: StoredScenario): void {
+  try {
+    localStorage.setItem(LAST_SCENARIO_KEY, JSON.stringify(s));
+  } catch {
+    // Non-fatal — private browsing or quota exceeded
+  }
+}
+
+// Returns ?scenario= URL param value, or null if absent.
+function getUrlScenarioId(): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get("scenario");
+  } catch {
+    return null;
+  }
+}
+
 export default function App() {
   const [attributeName, setAttributeName] = useState(DEFAULT_ATTRIBUTE);
   const [selectedScenarioId, setSelectedScenarioId] = useState<string | null>(null);
@@ -42,11 +80,46 @@ export default function App() {
     setSelectedScenarioSteps(totalSteps);
     setCurrentStep(null);
     setSelectedEntityId(null);
+    writeStoredScenario({ id, name, totalSteps });
   };
 
   const handleEntityClick = (entityId: string) => {
     setSelectedEntityId(entityId);
   };
+
+  // Restore last active scenario on mount (IR-003).
+  // URL ?scenario= takes precedence; falls back to localStorage.
+  // Non-fatal: if the stored ID no longer exists, clear stale localStorage silently.
+  useEffect(() => {
+    const urlId = getUrlScenarioId();
+    const stored = readStoredScenario();
+    const scenarioId = urlId ?? stored?.id ?? null;
+    if (!scenarioId) return;
+
+    let cancelled = false;
+    fetch(`${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}`)
+      .then((res) => (res.ok ? (res.json() as Promise<ScenarioDetailResponse>) : null))
+      .then((detail) => {
+        if (cancelled || !detail) {
+          if (!urlId) localStorage.removeItem(LAST_SCENARIO_KEY);
+          return;
+        }
+        setSelectedScenarioId(detail.scenario_id);
+        setSelectedScenarioName(detail.name);
+        setSelectedScenarioSteps(detail.configuration.n_steps);
+        // Fast-forward step if already completed — mirrors the existing completed-scenario effect.
+        if (detail.status === "completed") {
+          setCurrentStep(detail.configuration.n_steps);
+        }
+      })
+      .catch(() => {
+        if (!cancelled && !urlId) localStorage.removeItem(LAST_SCENARIO_KEY);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentionally runs once on mount
 
   // Playwright E2E test seam — DEV mode only, eliminated from production builds.
   // Exposes entity-selection handler so tests can open the drawer without clicking

--- a/frontend/tests/e2e/persistent-scenario-state.spec.ts
+++ b/frontend/tests/e2e/persistent-scenario-state.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * E2E: IR-003 — Persistent scenario state and demonstrative entry (Issue #497).
+ *
+ * Tests two complementary entry paths:
+ *   1. localStorage persistence — selecting a scenario writes to localStorage;
+ *      reloading the page restores the instrument cluster without user action.
+ *   2. URL ?scenario= param — navigating to /?scenario={id} selects that
+ *      scenario and renders the instrument cluster without user action.
+ *
+ * Both paths satisfy the entry state requirements from the IR-003 finding:
+ *   - Demonstrative entry (Persona 5 — Aicha): cluster visible on load.
+ *   - Reactive entry (Persona 2 — Eleni): last completed scenario auto-loads.
+ *
+ * Source: Issue #497 — persistent scenario state + demonstrative entry.
+ */
+import { test, expect } from "@playwright/test";
+
+const LAST_SCENARIO_KEY = "worldsim_last_scenario";
+
+async function waitForAppReady(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as Record<string, unknown>).__worldsim_selectEntity ===
+      "function",
+    { timeout: 10_000 },
+  );
+}
+
+async function createAndSelectScenario(
+  page: import("@playwright/test").Page,
+  name: string,
+): Promise<void> {
+  await waitForAppReady(page);
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+  await page.locator('input[placeholder="Scenario name"]').fill(name);
+  await page.locator(".scenario-btn--create").click();
+  const row = page.locator(".scenario-row").filter({ hasText: name });
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  await row.getByTitle("Select as primary scenario").click();
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+}
+
+// ---------------------------------------------------------------------------
+// localStorage persistence: selecting a scenario writes to localStorage
+// ---------------------------------------------------------------------------
+
+test("IR-003: selecting a scenario writes ID to localStorage", async ({ page }) => {
+  await page.goto("/");
+  const name = `IR003-storage-${Date.now()}`;
+  await createAndSelectScenario(page, name);
+
+  // Instrument cluster must be visible after selection
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // localStorage must have the scenario ID stored
+  const stored = await page.evaluate((key) => {
+    return localStorage.getItem(key);
+  }, LAST_SCENARIO_KEY);
+  expect(stored).not.toBeNull();
+
+  const parsed = JSON.parse(stored!) as { id: string; name: string; totalSteps: number };
+  expect(parsed.id).toBeTruthy();
+  expect(parsed.name).toBe(name);
+  expect(parsed.totalSteps).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// localStorage restore: reloading the page restores the instrument cluster
+// ---------------------------------------------------------------------------
+
+test("IR-003: reloading page restores instrument cluster from localStorage", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const name = `IR003-reload-${Date.now()}`;
+  await createAndSelectScenario(page, name);
+
+  // Cluster must be visible after selection
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Reload — no user interaction, cluster must reappear automatically
+  await page.reload();
+  await waitForAppReady(page);
+
+  // Cluster must be visible without opening Scenarios panel or selecting anything
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // The restored scenario name should appear in the header
+  await expect(page.locator("header")).toContainText(name, { timeout: 5_000 });
+});
+
+// ---------------------------------------------------------------------------
+// URL param: ?scenario={id} loads cluster without user action
+// ---------------------------------------------------------------------------
+
+test("IR-003: ?scenario= URL param selects scenario on load", async ({ page }) => {
+  // First: create a scenario via the UI to get a real ID
+  await page.goto("/");
+  const name = `IR003-url-${Date.now()}`;
+  await createAndSelectScenario(page, name);
+
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Extract the stored scenario ID from localStorage
+  const stored = await page.evaluate((key) => {
+    return localStorage.getItem(key);
+  }, LAST_SCENARIO_KEY);
+  expect(stored).not.toBeNull();
+  const { id } = JSON.parse(stored!) as { id: string };
+
+  // Navigate to the app with a fresh context (clear localStorage) but pass the
+  // scenario ID via URL param — cluster must appear without user setup
+  await page.evaluate((key) => localStorage.removeItem(key), LAST_SCENARIO_KEY);
+  await page.goto(`/?scenario=${encodeURIComponent(id)}`);
+  await waitForAppReady(page);
+
+  // Cluster must appear automatically from URL param alone
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
+// ---------------------------------------------------------------------------
+// URL param takes precedence over localStorage when both are present
+// ---------------------------------------------------------------------------
+
+test("IR-003: URL ?scenario= takes precedence over localStorage", async ({ page }) => {
+  // Create two scenarios
+  await page.goto("/");
+  const nameA = `IR003-urlA-${Date.now()}`;
+  await createAndSelectScenario(page, nameA);
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Scenario A is now in localStorage
+  const storedA = await page.evaluate((key) => localStorage.getItem(key), LAST_SCENARIO_KEY);
+  const { id: idA } = JSON.parse(storedA!) as { id: string };
+
+  // Open panel and create scenario B, but do NOT select it — localStorage stays as A
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+  const nameB = `IR003-urlB-${Date.now()}`;
+  await page.locator('input[placeholder="Scenario name"]').fill(nameB);
+  await page.locator(".scenario-btn--create").click();
+  const rowB = page.locator(".scenario-row").filter({ hasText: nameB });
+  await expect(rowB).toBeVisible({ timeout: 15_000 });
+
+  // Get scenario B's ID from localStorage after — need to select it briefly
+  await rowB.getByTitle("Select as primary scenario").click();
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+  const storedB = await page.evaluate((key) => localStorage.getItem(key), LAST_SCENARIO_KEY);
+  const { id: idB } = JSON.parse(storedB!) as { id: string };
+  expect(idA).not.toBe(idB);
+
+  // Restore localStorage to scenario A — simulates returning user
+  await page.evaluate(
+    ([key, val]) => localStorage.setItem(key!, val!),
+    [LAST_SCENARIO_KEY, storedA!],
+  );
+
+  // Navigate with ?scenario=idB — URL param should win
+  await page.goto(`/?scenario=${encodeURIComponent(idB)}`);
+  await waitForAppReady(page);
+
+  await expect(
+    page.locator('[data-testid="zone-1d-four-framework"]'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // The scenario name shown in the header must be B, not A
+  await expect(page.locator("header")).toContainText(nameB, { timeout: 5_000 });
+  const headerText = await page.locator("header").textContent();
+  expect(headerText).not.toContain(nameA);
+});


### PR DESCRIPTION
## Summary

- **localStorage persistence**: selecting a scenario writes `{id, name, totalSteps}` to `worldsim_last_scenario` in localStorage; mounting the app reads it back and pre-selects the last active scenario without user action (returning user entry — Persona 2 Eleni)
- **URL `?scenario={id}` param**: navigating to `/?scenario={id}` fetches the scenario detail on mount and renders the cluster immediately without any user action (demo entry — Persona 5 Aicha)
- URL param takes precedence over localStorage when both are present
- Both paths are non-fatal: 404 or network error silently clears stale localStorage and leaves the landing screen unchanged

## Architecture

The fix is entirely in `App.tsx` app initialization — no instrument cluster architecture changes. Three module-level pure functions (`readStoredScenario`, `writeStoredScenario`, `getUrlScenarioId`) keep the localStorage/URL logic isolated and testable. The mount `useEffect` fires once with empty deps and calls the same state setters as `handleSelectScenario`.

Completed scenarios are fast-forwarded to their final step (mirrors the existing `completed` scenario effect at line ~65 in the original).

## Test plan

- [ ] TypeScript compiles with no errors
- [ ] 130 Vitest unit tests pass unchanged
- [ ] E2E: `IR-003: selecting a scenario writes ID to localStorage`
- [ ] E2E: `IR-003: reloading page restores instrument cluster from localStorage`
- [ ] E2E: `IR-003: ?scenario= URL param selects scenario on load`
- [ ] E2E: `IR-003: URL ?scenario= takes precedence over localStorage`

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)