### PR TITLE
feat(zone-1c): PMM live computation — Issue #496 (IR-002)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -48,6 +48,7 @@ from app.schemas import (
     MDAAlert,
     MDAFloorRecord,
     MultiFrameworkOutput,
+    PMMRecord,
     QuantitySchema,
     RunSummaryResponse,
     ScenarioConfigSchema,
@@ -546,6 +547,105 @@ _TRAJECTORY_FRAMEWORKS = ["financial", "human_development", "ecological", "gover
 # Minimum confidence tier for the normalized_absolute strategy (CM-R3).
 _NORMALIZED_ABSOLUTE_MIN_TIER = 3
 
+# ---------------------------------------------------------------------------
+# PMM computation — Issue #496
+# ---------------------------------------------------------------------------
+
+_PMM_DIRECTION_THRESHOLD = Decimal("0.01")
+
+
+def _pmm_indicator_margin(
+    current_value: Decimal,
+    floor_value: Decimal,
+    approach_pct: Decimal,
+    comparison_operator: str,
+) -> Decimal:
+    """Compute [0, 1] margin for one indicator against its MDA threshold.
+
+    margin = 0.0 at or past the floor; 1.0 when outside the approach window.
+    The approach window is floor_value * approach_pct wide.
+
+    lte (lower-bound, breach when current <= floor):
+      safe zone: current > floor*(1+approach_pct)
+      approach zone: floor < current <= floor*(1+approach_pct)
+
+    gte (upper-bound, breach when current >= floor):
+      safe zone: current < floor*(1-approach_pct)
+      approach zone: floor*(1-approach_pct) <= current < floor
+    """
+    approach_span = floor_value * approach_pct
+    if approach_span <= Decimal("0"):
+        # Degenerate threshold — treat as binary.
+        if comparison_operator == "gte":
+            return Decimal("0") if current_value >= floor_value else Decimal("1")
+        return Decimal("0") if current_value <= floor_value else Decimal("1")
+
+    if comparison_operator == "gte":
+        if current_value >= floor_value:
+            return Decimal("0")
+        raw = (floor_value - current_value) / approach_span
+    else:
+        if current_value <= floor_value:
+            return Decimal("0")
+        raw = (current_value - floor_value) / approach_span
+
+    return min(Decimal("1"), raw)
+
+
+def _compute_pmm_for_step(
+    entity_id: str,
+    entity_attrs: dict[str, QuantitySchema],
+    mda_thresholds: list[dict[str, object]],
+    prev_pmm: Decimal | None,
+) -> PMMRecord | None:
+    """Compute PMM for one trajectory step from indicator values and MDA thresholds.
+
+    Only 'all'-scoped thresholds are evaluated — cohort-scoped thresholds
+    require cohort entity lookups not available at the trajectory level.
+    Returns None when no threshold has a matching indicator in entity_attrs.
+
+    Direction is computed relative to prev_pmm:
+      delta > _PMM_DIRECTION_THRESHOLD  → "up"
+      delta < -_PMM_DIRECTION_THRESHOLD → "down"
+      otherwise                         → "flat"
+    """
+    margins: list[Decimal] = []
+
+    for row in mda_thresholds:
+        entity_scope = str(row.get("entity_scope", "all"))
+        if entity_scope != "all" and entity_scope != entity_id:
+            continue
+
+        indicator_key = str(row["indicator_key"])
+        qty = entity_attrs.get(indicator_key)
+        if qty is None:
+            continue
+
+        with contextlib.suppress(Exception):
+            current = Decimal(qty.value)
+            floor_value = Decimal(str(row["floor_value"]))
+            approach_pct = Decimal(str(row["approach_pct"]))
+            op = str(row.get("comparison_operator", "lte"))
+            margins.append(_pmm_indicator_margin(current, floor_value, approach_pct, op))
+
+    if not margins:
+        return None
+
+    pmm_value = min(margins)
+
+    if prev_pmm is None:
+        direction = "flat"
+    else:
+        delta = pmm_value - prev_pmm
+        if delta > _PMM_DIRECTION_THRESHOLD:
+            direction = "up"
+        elif delta < -_PMM_DIRECTION_THRESHOLD:
+            direction = "down"
+        else:
+            direction = "flat"
+
+    return PMMRecord(value=str(pmm_value), direction=direction)
+
 
 async def _compute_trajectory_framework_point(
     entity_id: str,
@@ -657,9 +757,14 @@ async def get_trajectory(
     """Multi-step trajectory for all four measurement frameworks.
 
     Returns computed steps as a dense array. Each step carries per-framework
-    composite scores and optional policy inputs. mda_floors is at the response
-    root (not per-step). In M9, mda_floors contains at most one entry:
-    ecological WARNING at floor_value=1.0 when EcologicalModule is active.
+    composite scores, optional policy inputs, and PMM (Policy Maneuver Margin).
+    mda_floors is at the response root (not per-step). In M9, mda_floors
+    contains at most one entry: ecological WARNING at floor_value=1.0 when
+    EcologicalModule is active.
+
+    PMM computation (Issue #496): each step's pmm field is derived from all
+    'all'-scoped MDA thresholds in the database. PMM = min(indicator margins)
+    across thresholds with matching indicator data; null when no matching data.
 
     Composite score dispatch (Issue #458, CM consultation 2026-05-23; ADR-005 Amendment 4):
     - Single-entity: financial/HD use normalized_absolute; ecological uses
@@ -724,6 +829,16 @@ async def get_trajectory(
             {"input_type": r["input_type"], "input_data": input_data}
         )
 
+    # Fetch MDA thresholds once for PMM computation (Issue #496).
+    mda_threshold_rows = await conn.fetch(
+        """
+        SELECT indicator_key, entity_scope, floor_value, approach_pct, comparison_operator
+        FROM mda_thresholds
+        ORDER BY mda_id
+        """
+    )
+    mda_thresholds_for_pmm: list[dict[str, object]] = [dict(r) for r in mda_threshold_rows]
+
     # Collect all state dicts for MDA floor detection and composite score dispatch.
     all_step_states: list[dict[str, Any]] = []
     for snap in snapshot_rows:
@@ -753,6 +868,7 @@ async def get_trajectory(
         mda_floors = []
 
     steps: list[TrajectoryStep] = []
+    prev_pmm_value: Decimal | None = None
     for snap, state_dict in zip(snapshot_rows, all_step_states, strict=True):
         step_index: int = snap["step"]
         timestep = snap["timestep"]
@@ -807,6 +923,15 @@ async def get_trajectory(
             )
             framework_points.append(point)
 
+        pmm_record = _compute_pmm_for_step(
+            entity_id=entity_id,
+            entity_attrs=target_attrs,
+            mda_thresholds=mda_thresholds_for_pmm,
+            prev_pmm=prev_pmm_value,
+        )
+        if pmm_record is not None:
+            prev_pmm_value = Decimal(pmm_record.value)
+
         steps.append(
             TrajectoryStep(
                 step_index=step_index,
@@ -816,6 +941,7 @@ async def get_trajectory(
                 frameworks=framework_points,
                 policy_inputs=policy_by_step.get(step_index, []),
                 shock_events=[],
+                pmm=pmm_record,
             )
         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -65,6 +65,28 @@ class TrajectoryFrameworkPoint(BaseModel):
     is_pre_calibration: None = None
 
 
+class PMMRecord(BaseModel):
+    """Per-step Policy Maneuver Margin — Zone 1C (ADR-008 Decision 6, Issue #496).
+
+    value in [0, 1]: 0.0 = at or below an MDA floor; 1.0 = outside all approach zones.
+    direction: "up" | "down" | "flat" relative to the previous step.
+    Both fields are present when any 'all'-scoped MDA threshold has a matching
+    indicator in entity state. Null when no thresholds can be evaluated.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    value: str
+    direction: str
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _coerce(cls, v: object) -> str:
+        if isinstance(v, int | float | Decimal):
+            return str(Decimal(str(v)))
+        return str(v)
+
+
 class TrajectoryStep(BaseModel):
     """One computed step in the trajectory response.
 
@@ -72,6 +94,7 @@ class TrajectoryStep(BaseModel):
     step_event_label is null when step_significance is ROUTINE.
     policy_inputs lists ControlInput events applied at this step.
     shock_events is empty for M9.
+    pmm is null when no 'all'-scoped MDA thresholds have indicator data for this step.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -83,6 +106,7 @@ class TrajectoryStep(BaseModel):
     frameworks: list[TrajectoryFrameworkPoint]
     policy_inputs: list[dict[str, Any]]
     shock_events: list[dict[str, Any]] = []
+    pmm: PMMRecord | None = None
 
 
 class TrajectoryResponse(BaseModel):
@@ -91,6 +115,7 @@ class TrajectoryResponse(BaseModel):
     mda_floors is at the response root, not per-step (ADR-010 Decision 2).
     entity_id is the first entity in scenario configuration.entities.
     steps is a dense array of computed steps only.
+    Each step carries pmm (Policy Maneuver Margin) derived from MDA thresholds (Issue #496).
     """
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/unit/test_pmm_computation.py
+++ b/backend/tests/unit/test_pmm_computation.py
@@ -1,0 +1,307 @@
+"""Unit tests for PMM (Policy Maneuver Margin) computation — Issue #496.
+
+Covers:
+  - _pmm_indicator_margin: lte thresholds (lower-bound, breach when too low)
+  - _pmm_indicator_margin: gte thresholds (upper-bound, breach when too high)
+  - _pmm_indicator_margin: degenerate approach_pct=0
+  - _pmm_indicator_margin: clamping to [0, 1]
+  - _compute_pmm_for_step: no indicators matched → None
+  - _compute_pmm_for_step: single threshold in approach zone → correct margin
+  - _compute_pmm_for_step: min-of-margins (most constrained dimension)
+  - _compute_pmm_for_step: direction tracking across steps
+  - _compute_pmm_for_step: cohort-scoped thresholds skipped
+  - _compute_pmm_for_step: entity-scoped threshold matches exact entity
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.api.scenarios import _compute_pmm_for_step, _pmm_indicator_margin
+from app.schemas import QuantitySchema
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _qty(value: str, framework: str = "financial") -> QuantitySchema:
+    return QuantitySchema(
+        value=value,
+        unit="dimensionless",
+        variable_type="ratio",
+        confidence_tier=3,
+        measurement_framework=framework,
+    )
+
+
+def _threshold(
+    indicator_key: str,
+    floor_value: str,
+    approach_pct: str,
+    comparison_operator: str = "lte",
+    entity_scope: str = "all",
+) -> dict[str, object]:
+    return {
+        "indicator_key": indicator_key,
+        "entity_scope": entity_scope,
+        "floor_value": floor_value,
+        "approach_pct": approach_pct,
+        "comparison_operator": comparison_operator,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _pmm_indicator_margin — lte (lower-bound)
+# ---------------------------------------------------------------------------
+
+
+class TestPmmIndicatorMarginLte:
+    def test_at_floor_returns_zero(self) -> None:
+        # reserve_coverage_months = 2.5 at floor 2.5
+        m = _pmm_indicator_margin(Decimal("2.5"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert m == Decimal("0")
+
+    def test_below_floor_returns_zero(self) -> None:
+        m = _pmm_indicator_margin(Decimal("2.0"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert m == Decimal("0")
+
+    def test_at_outer_edge_of_approach_zone_returns_one(self) -> None:
+        # floor=2.5, approach_pct=0.20 → outer edge = 2.5 * 1.20 = 3.0
+        m = _pmm_indicator_margin(Decimal("3.0"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert m == Decimal("1")
+
+    def test_above_approach_zone_capped_at_one(self) -> None:
+        m = _pmm_indicator_margin(Decimal("5.0"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert m == Decimal("1")
+
+    def test_midpoint_of_approach_zone_returns_half(self) -> None:
+        # floor=2.5, span=0.5 → midpoint = 2.75
+        m = _pmm_indicator_margin(Decimal("2.75"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert m == Decimal("0.5")
+
+    def test_just_above_floor_near_zero(self) -> None:
+        m = _pmm_indicator_margin(Decimal("2.51"), Decimal("2.5"), Decimal("0.20"), "lte")
+        assert Decimal("0") < m < Decimal("0.1")
+
+
+# ---------------------------------------------------------------------------
+# _pmm_indicator_margin — gte (upper-bound)
+# ---------------------------------------------------------------------------
+
+
+class TestPmmIndicatorMarginGte:
+    def test_at_floor_returns_zero(self) -> None:
+        # debt_gdp_ratio = 1.20 at floor 1.20
+        m = _pmm_indicator_margin(Decimal("1.20"), Decimal("1.20"), Decimal("0.10"), "gte")
+        assert m == Decimal("0")
+
+    def test_above_floor_returns_zero(self) -> None:
+        m = _pmm_indicator_margin(Decimal("1.50"), Decimal("1.20"), Decimal("0.10"), "gte")
+        assert m == Decimal("0")
+
+    def test_at_outer_edge_of_approach_zone_returns_one(self) -> None:
+        # floor=1.20, approach_pct=0.10 → outer edge = 1.20 * (1-0.10) = 1.08
+        m = _pmm_indicator_margin(Decimal("1.08"), Decimal("1.20"), Decimal("0.10"), "gte")
+        assert m == Decimal("1")
+
+    def test_below_approach_zone_capped_at_one(self) -> None:
+        m = _pmm_indicator_margin(Decimal("0.50"), Decimal("1.20"), Decimal("0.10"), "gte")
+        assert m == Decimal("1")
+
+    def test_midpoint_of_approach_zone_returns_half(self) -> None:
+        # floor=1.20, span=0.12 → midpoint = 1.14
+        m = _pmm_indicator_margin(Decimal("1.14"), Decimal("1.20"), Decimal("0.10"), "gte")
+        assert m == Decimal("0.5")
+
+    def test_ecological_proximity_at_boundary_zero(self) -> None:
+        # planetary_boundary_co2_proximity = 1.0 at floor 1.0
+        m = _pmm_indicator_margin(Decimal("1.0"), Decimal("1.0"), Decimal("0.10"), "gte")
+        assert m == Decimal("0")
+
+    def test_ecological_proximity_well_below_boundary_one(self) -> None:
+        m = _pmm_indicator_margin(Decimal("0.5"), Decimal("1.0"), Decimal("0.10"), "gte")
+        assert m == Decimal("1")
+
+
+# ---------------------------------------------------------------------------
+# _pmm_indicator_margin — degenerate (approach_pct = 0)
+# ---------------------------------------------------------------------------
+
+
+class TestPmmIndicatorMarginDegenerate:
+    def test_lte_at_floor_returns_zero(self) -> None:
+        m = _pmm_indicator_margin(Decimal("2.5"), Decimal("2.5"), Decimal("0"), "lte")
+        assert m == Decimal("0")
+
+    def test_lte_above_floor_returns_one(self) -> None:
+        m = _pmm_indicator_margin(Decimal("3.0"), Decimal("2.5"), Decimal("0"), "lte")
+        assert m == Decimal("1")
+
+    def test_gte_at_floor_returns_zero(self) -> None:
+        m = _pmm_indicator_margin(Decimal("1.2"), Decimal("1.2"), Decimal("0"), "gte")
+        assert m == Decimal("0")
+
+    def test_gte_below_floor_returns_one(self) -> None:
+        m = _pmm_indicator_margin(Decimal("1.0"), Decimal("1.2"), Decimal("0"), "gte")
+        assert m == Decimal("1")
+
+
+# ---------------------------------------------------------------------------
+# _compute_pmm_for_step
+# ---------------------------------------------------------------------------
+
+
+class TestComputePmmForStep:
+    def test_no_matching_indicators_returns_none(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={},
+            mda_thresholds=[
+                _threshold("reserve_coverage_months", "2.5", "0.20", "lte")
+            ],
+            prev_pmm=None,
+        )
+        assert result is None
+
+    def test_no_thresholds_returns_none(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("4.0")},
+            mda_thresholds=[],
+            prev_pmm=None,
+        )
+        assert result is None
+
+    def test_indicator_well_outside_approach_zone_returns_one(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("10.0")},
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=None,
+        )
+        assert result is not None
+        assert Decimal(result.value) == Decimal("1")
+        assert result.direction == "flat"
+
+    def test_indicator_in_approach_zone_returns_partial_margin(self) -> None:
+        # reserve_coverage_months = 2.75, floor=2.5, approach=0.20 → margin=0.5
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("2.75")},
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=None,
+        )
+        assert result is not None
+        assert Decimal(result.value) == Decimal("0.5")
+
+    def test_min_across_thresholds(self) -> None:
+        # reserves margin = 1.0 (well above), debt margin = 0 (at breach)
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={
+                "reserve_coverage_months": _qty("10.0"),
+                "debt_gdp_ratio": _qty("1.20"),  # at floor for gte
+            },
+            mda_thresholds=[
+                _threshold("reserve_coverage_months", "2.5", "0.20", "lte"),
+                _threshold("debt_gdp_ratio", "1.20", "0.10", "gte"),
+            ],
+            prev_pmm=None,
+        )
+        assert result is not None
+        assert Decimal(result.value) == Decimal("0")
+
+    def test_direction_up_when_pmm_improves(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("10.0")},
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=Decimal("0.5"),
+        )
+        assert result is not None
+        assert result.direction == "up"
+
+    def test_direction_down_when_pmm_deteriorates(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("2.75")},  # margin = 0.5
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=Decimal("1.0"),
+        )
+        assert result is not None
+        assert result.direction == "down"
+
+    def test_direction_flat_when_within_threshold(self) -> None:
+        # margin = 1.0, prev = 0.995 → delta = 0.005 < threshold 0.01
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("10.0")},
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=Decimal("0.995"),
+        )
+        assert result is not None
+        assert result.direction == "flat"
+
+    def test_cohort_scoped_threshold_skipped(self) -> None:
+        # Cohort-scoped entity_scope like '*:CHT:*' — not 'all' or exact entity_id
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"poverty_headcount_ratio": _qty("0.50")},
+            mda_thresholds=[
+                _threshold(
+                    "poverty_headcount_ratio",
+                    "0.40",
+                    "0.15",
+                    "gte",
+                    entity_scope="*:CHT:1-*-*",  # cohort scope — skipped
+                )
+            ],
+            prev_pmm=None,
+        )
+        assert result is None
+
+    def test_entity_scoped_threshold_matches_exact_entity(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("10.0")},
+            mda_thresholds=[
+                _threshold(
+                    "reserve_coverage_months",
+                    "2.5",
+                    "0.20",
+                    "lte",
+                    entity_scope="GRC",  # exact match
+                )
+            ],
+            prev_pmm=None,
+        )
+        assert result is not None
+        assert Decimal(result.value) == Decimal("1")
+
+    def test_entity_scoped_threshold_skipped_for_other_entity(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("10.0")},
+            mda_thresholds=[
+                _threshold(
+                    "reserve_coverage_months",
+                    "2.5",
+                    "0.20",
+                    "lte",
+                    entity_scope="ARG",  # different entity — skipped
+                )
+            ],
+            prev_pmm=None,
+        )
+        assert result is None
+
+    def test_pmm_value_serialized_as_string(self) -> None:
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={"reserve_coverage_months": _qty("3.0")},
+            mda_thresholds=[_threshold("reserve_coverage_months", "2.5", "0.20", "lte")],
+            prev_pmm=None,
+        )
+        assert result is not None
+        assert isinstance(result.value, str)
+        assert isinstance(result.direction, str)

--- a/backend/tests/unit/test_trajectory_endpoint.py
+++ b/backend/tests/unit/test_trajectory_endpoint.py
@@ -234,6 +234,7 @@ async def test_step_significance_absent_key_is_routine() -> None:
     conn2.fetch = AsyncMock(side_effect=[
         [snap],    # snapshot_rows
         [],        # policy_rows
+        [],        # mda_threshold_rows (PMM computation — Issue #496)
         [],        # boundary constants for step 1 ecological
     ])
 

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -15,9 +15,10 @@
  * output yet). Mapping from MDAAlert → Zone1BAlert derives framework from
  * the output record key and confidence_tier from the indicator record.
  *
- * PMM: pmm_value and pmm_direction remain null in M9 (no PMM endpoint
- * exists yet; the PMM widget renders "—"). This is correct per ADR-008
- * Decision 6: null renders as "—" (instrument in validation).
+ * PMM: pmm_value and pmm_direction are populated from per-step PMM data
+ * embedded in the trajectory response (Issue #496). Synced via useEffect
+ * on currentStep + store.trajectory. Null at step 0 or when no MDA
+ * thresholds have matching indicator data for the step.
  */
 import React, { useEffect, useState } from "react";
 import { InstrumentCluster } from "./InstrumentCluster";
@@ -48,6 +49,7 @@ interface RawTrajectoryStep {
   step_event_label: string | null;
   step_significance: "SIGNIFICANT" | "ROUTINE";
   frameworks: RawFrameworkPoint[];
+  pmm: { value: string; direction: string } | null;
 }
 
 interface RawTrajectoryResponse {
@@ -89,12 +91,21 @@ function parseTrajectoryResponse(raw: RawTrajectoryResponse): TrajectoryResponse
               : fw.scoring_basis,
         };
       }
+      const pmm =
+        step.pmm !== null && step.pmm !== undefined
+          ? {
+              value: parseFloat(step.pmm.value),
+              direction: step.pmm.direction as "up" | "down" | "flat",
+            }
+          : null;
+
       return {
         step_index: step.step_index,
         effective_from: step.effective_from,
         step_event_label: step.step_event_label,
         step_significance: step.step_significance,
         frameworks: frameworkMap,
+        pmm,
       };
     }),
   };
@@ -217,6 +228,22 @@ export function ScenarioInstrumentCluster({
       cancelled = true;
     };
   }, [scenarioId]);
+
+  // Sync PMM from trajectory step data when current step changes (Issue #496).
+  // PMM is pre-computed per step by the backend; no additional fetch needed.
+  useEffect(() => {
+    const traj = store.trajectory;
+    if (!traj || currentStep === 0) {
+      store.setPmmState(null, null);
+      return;
+    }
+    const step = traj.steps.find((s) => s.step_index === currentStep);
+    if (step?.pmm != null) {
+      store.setPmmState(step.pmm.value, step.pmm.direction);
+    } else {
+      store.setPmmState(null, null);
+    }
+  }, [currentStep, store.trajectory]);
 
   // Fetch MDA alerts from measurement-output after each step advance (IR-001).
   // Entity ID comes from the trajectory response already fetched above.

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -21,6 +21,7 @@ export interface TrajectoryStep {
   step_event_label: string | null;
   step_significance: "SIGNIFICANT" | "ROUTINE";
   frameworks: Record<string, TrajectoryFrameworkPoint>;
+  pmm: { value: number; direction: "up" | "down" | "flat" } | null;
 }
 
 export interface MDAFloor {


### PR DESCRIPTION
## Summary

- **PMMRecord schema** — `value` (Decimal-as-str, [0,1]) + `direction` ("up"/"down"/"flat"); added to `TrajectoryStep.pmm` (null when no threshold data matches the step)
- **PMM computation** — `_pmm_indicator_margin()` computes [0,1] margin for one indicator vs its MDA threshold (both `lte` and `gte` operators, approach-window normalized); `_compute_pmm_for_step()` takes min across all 'all'-scoped thresholds with matching indicator data; direction derived from prev-step delta vs 0.01 threshold; MDA thresholds fetched once per trajectory request
- **Frontend wiring** — `parseTrajectoryResponse()` parses per-step PMM from trajectory API; `useEffect([currentStep, store.trajectory])` syncs `pmm_value`/`pmm_direction` to Zustand store; `TrajectoryStep` store type extended with `pmm` field
- **29 new unit tests** — full coverage of `_pmm_indicator_margin` (lte, gte, degenerate) and `_compute_pmm_for_step` (no match → null, approach zone, min-of-margins, direction tracking, cohort scope skipped, entity scope matching)

## Test plan

- [ ] `pytest tests/unit/test_pmm_computation.py -v` — 29 tests pass
- [ ] `pytest tests/unit/` — 839 tests pass, no regressions
- [ ] `ruff check . && mypy app/` — both exit 0
- [ ] `tsc --noEmit` — no TypeScript errors
- [ ] CI green (unit, playwright-e2e, backtesting)
- [ ] Zone 1C PMM widget shows live value (not "—") when Greece demo is run and indicators include `reserve_coverage_months` or `debt_gdp_ratio`

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)