### PR TITLE
docs(demo): Demo 3 M10 IR review — DEMO issue triage against M10 architecture

### DIFF
--- a/docs/demo/m10/reviews/2026-06-02-v0.10-demo3-ir.md
+++ b/docs/demo/m10/reviews/2026-06-02-v0.10-demo3-ir.md
@@ -1,0 +1,361 @@
+# Independent Review — 2026-06-02 — v0.10 / Milestone 10 Demo 3
+
+## Review Context
+
+- **Version reviewed:** v0.10 (Milestone 10 — Engine Integrity and Instrument Delivery)
+- **Review date:** 2026-06-02
+- **Reviewer role:** Domain expert stakeholder — senior fiscal policy analyst, experience on both
+  sides of multilateral programme negotiations. Evaluation from the cognitive task perspective
+  of the intended users. No knowledge of implementation details.
+- **Review purpose:** Demo 3 readiness assessment against the nine open M10 DEMO issues
+  (#342, #343, #345, #346, #347, #348, #350, #376, #377). Triages each issue against
+  the M10 architecture: M9 instrument cluster live in primary viewport, all four Zone 1 axes
+  wired with real data, GovernanceModule promoted to live, Argentina 2001–2002 fixture complete.
+- **Input from PM Agent FOCUS:** Four issues (#342, #343, #346, #347) were "transformed" at
+  M9 exit due to architecture changes. No re-triage had been done against the M10 state before
+  this review.
+- **Artifacts reviewed:**
+  - Demo 3 script: `backend/scripts/demo_argentina_2001_2002.py`
+  - `frontend/src/components/TrajectoryView.tsx` — Zone 1A curve rendering, Path A handling
+  - `frontend/src/components/MDAAlertPanelZone1B.tsx` — Zone 1B step-aware rendering
+  - `frontend/src/components/FourFrameworkZone1D.tsx` — Zone 1D null/numeric rendering
+  - `frontend/src/components/AttributeSelector.tsx` — DEMO-009 status
+  - `frontend/src/lib/indicatorDisplayNames.ts` — display name registry
+  - M9 IR review: `docs/demo/m9/reviews/2026-05-23-v0.9-instrument-cluster-ir.md`
+  - Open DEMO issues: #342, #343, #345, #346, #347, #348, #350
+
+---
+
+## Opening Assessment
+
+The M10 instrument cluster delivers on the M9 IR's primary commitment: all four Zone 1
+instruments are wired with real data. Zone 1B (MDA Alert Panel) receives live mda_alerts
+from the trajectory response; Zone 1C (PMM Widget) computes live Policy Manoeuvre Margin;
+Zone 1D (Four-Framework) shows live composite scores for all four frameworks including
+governance, which is now promoted from null-placeholder to live axis. The Argentina fixture
+adds a second country, demonstrating the Platform Principle with real IMF programme data
+from a structurally distinct crisis arc.
+
+The M9 IR's two root causes are resolved:
+- **Root Cause A** (data layer not wired to Zone 1B and 1C): closed — mda_alerts wired
+  (PR #495), PMM endpoint live (PR #587).
+- **Root Cause B** (session state and entry-state architecture not implemented): closed —
+  persistent scenario state via localStorage (PR #584), default step labels from start year
+  (PR #583).
+
+Three of the nine open DEMO issues can be closed immediately. Three require implementation
+before Demo 3 is presentation-ready. Two new findings emerge from the Argentina fixture
+specifically. Two test infrastructure issues remain out of scope for Demo 3 readiness but
+are M10 exit gates.
+
+---
+
+## DEMO Issue Re-Triage
+
+---
+
+### #347 — DEMO-006: Governance honest-null distinction (CLOSE)
+
+- **Original finding:** Governance axis not distinguishable from other axes at drawer scale;
+  dashed rendering and "(in validation)" label not visible.
+- **M10 verdict:** **Resolved — close this issue.**
+- **Reason:** GovernanceModule was promoted to live in M10 (PR #585, ADR-005 Amendment 4).
+  The governance composite score is now a live normalized_absolute value derived from WGI
+  and V-Dem data. Zone 1D renders it as a numeric score with a solid left border — the null
+  treatment (DD-011) is no longer invoked. There is no longer a governance null to distinguish.
+  The "(in validation)" annotation was correctly removed (IR-005, PR #585). The original
+  concern — that the honest-null pattern was invisible — is moot because governance is live.
+- **Action:** Close #347 with a comment referencing PR #585 (GovernanceModule promotion).
+  No implementation required.
+
+---
+
+### #343 — DEMO-002: Thesis frame legibility (SCOPE UPDATED — reduce severity)
+
+- **Original finding:** Radar chart asymmetric deformation not legible at projection scale
+  without narration.
+- **M9 re-scope:** "Zone 1A trajectory view legibility as thesis visualization."
+- **M10 verdict:** **Substantially resolved; minor gap remains. Reduce severity to Minor.**
+- **Reasoning:** Zone 1A now carries the primary thesis visualization (trajectory view with
+  four composite curves on a shared step axis). For the Argentina Demo 3:
+  - Financial curve (dashed, Path A) rises at step 3 (Kirchner recovery begins)
+  - Governance curve (solid) remains relatively flat through recovery
+  - The divergence between financial recovery and governance stagnation IS readable in
+    Zone 1A without narration — the curve shapes tell the story
+  - The ecological WARNING ReferenceLine at y=1.0 provides a reference threshold in-frame
+  - Step annotations (event labels from step_metadata: "Default / Peso devaluation",
+    "Kirchner recovery begins") anchor steps to historical events
+- **Remaining gap:** The dashed treatment for financial and HD curves (Path A,
+  single-entity normalized_absolute scoring) is correct per spec but is unexplained in the
+  primary viewport. Two of four Zone 1A curves are dashed; a user watching the demo will
+  notice the difference and may not understand it. The methodology note is Zone 3 (drawer).
+  This is a demo walkthrough narration gap, not an architecture failure.
+- **Action:** Update #343 scope to "Zone 1A dashed-curve methodology note — in-viewport
+  clarification for demo context." Reduce severity to Minor. No implementation required
+  before demo; address in demo walkthrough script narration.
+
+---
+
+### #342 — DEMO-001: Choropleth no visible change for single-entity (SCOPE UPDATED — reduce severity)
+
+- **Original finding:** Choropleth map visually indistinguishable across steps for
+  single-entity scenario.
+- **M9 re-scope:** "Single-entity context choropleth color scaling."
+- **M10 verdict:** **Reduced severity (Critical → Minor). Persists but de-prioritized.**
+- **Reasoning:** Zone 1A now carries the primary temporal signal. The choropleth (Zone 2A,
+  geographic context) is a navigable secondary surface — it is no longer the instrument the
+  user is watching to understand trajectory change. For Demo 3, the Argentina fixture is
+  a single entity (ARG); only ARG is colored on the choropleth. If the composite score that
+  drives choropleth color changes across steps, ARG's color will shift — but the shift is
+  subtle on a full world map for a single country. The primary demo visual argument is now
+  in Zone 1A, not the choropleth.
+- **Structural note:** The choropleth is designed as context, not instrument. For a demo
+  presenter, the correct narration is "the trajectory view shows the four-framework arc;
+  the choropleth shows where Argentina sits geographically — this is how you would extend
+  the analysis to multiple countries." DEMO-001 framed the choropleth as a primary thesis
+  visualization because that was its M8 role. That role has changed.
+- **Action:** Update #342 scope to "choropleth single-entity color scaling — minor visual
+  polish for multi-entity comparison demos." Reduce severity to Minor. Not a blocker for
+  Demo 3.
+
+---
+
+### #345 — DEMO-004: MDA alerts appear identical across steps (VERIFY)
+
+- **Original finding:** Same two alerts fire at Step 1 and appear visually identical at
+  Step 3 — no accumulation or deepening visible.
+- **M10 verdict:** **Architecture resolved. Visual verification required.**
+- **Architecture finding:** Zone 1B (`MDAAlertPanelZone1B.tsx`) sorts alerts by severity
+  (TERMINAL → CRITICAL → WARNING) then by `step_index` ascending. Each alert card carries
+  `data-step={alert.step_index}` and displays `Step {alert.step_index}` as visible text.
+  Multiple alerts from different steps are rendered in order. `consecutive_breach_steps`
+  is available in the alert data structure. The step-differentiation architecture IS
+  correct and complete.
+- **Remaining question:** Does the Argentina fixture produce step-differentiated MDA alerts?
+  The governance MDA floor (`democratic_quality_score ≤ 0.70 → WARNING`) requires the
+  democratic_quality_score to drop below 0.70. Argentina starts at 0.71 (V-Dem LDI 2000).
+  Without an `emergency_declaration` instrument in the Argentina fixture, the score may not
+  breach the floor. If no MDA alerts fire across the Argentina 4-step fixture, Zone 1B will
+  show "No active threshold breaches" throughout Demo 3 — a weaker demo narrative than
+  Greece (which fires governance WARNING at step 6).
+- **Action:** Run the Argentina fixture against the live backend and confirm whether any
+  MDA thresholds are breached across steps 1–4. If none fire, seed an Argentina-specific
+  MDA threshold for `unemployment_rate` or configure the fixture so the governance floor is
+  reached. This is a data/fixture decision, not a frontend issue.
+
+**→ File as IR-M10-001.**
+
+---
+
+### #346 — DEMO-005: Radar axis labels not legible at drawer scale (SCOPE UPDATED)
+
+- **Original finding:** Radar chart axis labels and scores unreadable at screenshot resolution.
+- **M9 re-scope:** "Zone 2 radar legibility at EntityDetailDrawer scale."
+- **M10 verdict:** **Reduced severity (Significant → Minor). Persists but secondary.**
+- **Reasoning:** Zone 1D (FourFrameworkZone1D) is now the primary four-framework readout
+  at primary viewport scale. Framework names ("Financial", "Human Development", "Ecological",
+  "Governance") and numeric scores render at 11px label / 13px value in the co-primary
+  column — readable at 1024×768 without magnification. The radar chart in Zone 2 (EntityDetail-
+  Drawer) is a secondary visualization. If axis labels remain unreadable in the drawer, it
+  degrades the radar as a detailed exploration surface but does not block the primary demo
+  narrative, which now lives in Zone 1A and Zone 1D.
+- **Action:** Update #346 scope to "Zone 2 EntityDetailDrawer radar legibility — secondary
+  polish." Reduce severity to Minor. Not a blocker for Demo 3.
+
+---
+
+### #348 — DEMO-007: Ecological score reference annotation absent (OPEN — DEMO BLOCKER)
+
+- **Original finding:** CO2 boundary proximity value (1.8) not self-interpreting — no
+  reference point showing 1.0 = at boundary.
+- **M10 verdict:** **Open and unresolved. Severity: Minor (but demo-blocking at Demo 3 scale).**
+- **Architecture state:** Zone 1D's ecological row shows the composite score (a boundary
+  proximity value, e.g., 1.07 for Argentina at step 1) as a raw number. The ecological
+  WARNING ReferenceLine in Zone 1A at y=1.0 provides a reference threshold in the trajectory
+  chart, labeled per the floor record. But Zone 1D's score readout — the most prominent
+  numerical display of the ecological composite — has no annotation indicating what the
+  scale means.
+- **User impact:** A demo viewer who sees "Ecological: 1.07" in Zone 1D has no context for
+  whether 1.07 is good, bad, or near a threshold. The value 1.07 means "7% beyond the safe
+  CO2 planetary boundary" — but nothing in Zone 1D says so. The ecological framework is the
+  only framework with a boundary-normalized score; all others are [0,1]. Zone 1D does not
+  communicate this difference.
+- **Fix:** Add a reference annotation to the ecological row in Zone 1D. Two options:
+  - A tooltip on the ecological score: "1.0 = at planetary boundary; >1.0 = boundary exceeded"
+  - An inline sub-label beneath the score: "(1.0 = boundary)"
+  Both are one-to-three line changes in `FourFrameworkZone1D.tsx`.
+- **Action:** Implement the reference annotation before Demo 3 presentation. **File as
+  IR-M10-002.**
+
+---
+
+### #350 — DEMO-009: Attribute selector shows raw variable names (OPEN — DEMO BLOCKER)
+
+- **Original finding:** Attribute selector reads `gdp_growth [...]` — programmatic variable
+  name, not human-readable label.
+- **M10 verdict:** **Open and unresolved. Severity: Minor (but visible to any demo observer).**
+- **Architecture state:** `AttributeSelector.tsx` renders
+  `{a.attribute_key} ({a.unit}, {a.variable_type})` — the raw `attribute_key` from the API.
+  `indicatorDisplayNames.ts` (`getIndicatorDisplayName()`) exists and maps `gdp_growth` →
+  "GDP Growth", but `AttributeSelector.tsx` does not use it.
+- **Root cause:** `AttributeSelector` renders attributes from `/api/v1/attributes/available`.
+  This API returns `attribute_key`, `unit`, and `variable_type` — no `display_name` field.
+  `getIndicatorDisplayName(framework, key)` requires a framework argument that AttributeSelector
+  does not have per-attribute. Two fix paths:
+  - **Path A (backend):** Add a `display_name` field to the `AttributeSummary` API response,
+    computed from `indicatorDisplayNames.ts` logic server-side (or a backend equivalent).
+  - **Path B (frontend):** Add a framework-agnostic lookup function to `indicatorDisplayNames.ts`
+    that tries all frameworks and returns the first match; use it in AttributeSelector.
+  Path B is a one-file frontend change. Path A requires an API schema change.
+- **Action:** Implement Path B (framework-agnostic lookup) before Demo 3 presentation.
+  **File as IR-M10-003.**
+
+---
+
+### #376 — Playwright demo advancement flow test (TEST INFRASTRUCTURE — not Demo 3 blocker)
+
+- **M10 verdict:** Not a Demo 3 presentation blocker. Is a M10 exit gate.
+- **Note:** This test must exist before M10 exits — it gates regression detection for the
+  demo flow. File with appropriate M10 horizon:near-term priority. Not a dependency for Demo 3
+  readiness, but creates technical debt if deferred past M10.
+
+---
+
+### #377 — Legibility assertions (TEST INFRASTRUCTURE — not Demo 3 blocker)
+
+- **M10 verdict:** Not a Demo 3 presentation blocker. Is a M10 exit gate.
+- **Note:** Same disposition as #376. Both test infrastructure issues should be filed for
+  M10 near-term implementation after Demo 3 runs.
+
+---
+
+## New Findings
+
+---
+
+### IR-M10-001 — Argentina fixture MDA accumulation unknown
+
+- **Severity:** 🟠 Significant
+- **Instrument:** Zone 1B — MDA Alert Panel
+- **Observation:** The Greece fixture produces step-differentiated MDA alerts (financial
+  reserve warnings accumulating across steps; governance WARNING at step 6). This demonstrates
+  Zone 1B's step-aware rendering: each alert shows its step number, consecutive breach count,
+  and severity ordering. The Argentina fixture's MDA behavior is unverified. The governance
+  MDA floor (`democratic_quality_score ≤ 0.70 → WARNING`) may not fire: Argentina's democratic
+  quality score starts at 0.71, and without an `emergency_declaration` instrument event in the
+  fixture, it may not breach the floor across 4 steps. If no alerts fire, Zone 1B shows
+  "No active threshold breaches" throughout Demo 3.
+- **Demo narrative impact:** Demo 3's "divergence between financial recovery and institutional
+  resilience" argument is strengthened if the governance MDA threshold breaches at the default
+  (step 2: the peso devaluation and political crisis) and persists through the financial
+  recovery. A Zone 1B that shows no alerts produces a weaker demo — it demonstrates instrument
+  presence but not instrument value.
+- **Action:** Run the Argentina fixture with the live backend. If governance floor does not
+  breach: (a) lower the initial `democratic_quality_score` seed to 0.68 (still historically
+  defensible for 2000 — V-Dem LDI for Argentina 2000 was 0.71, but WGI Rule of Law at step 2
+  should drive a governance deterioration), or (b) add an unemployment_rate MDA threshold for
+  Argentina that fires at step 2 (unemployment_rate > 0.20 → WARNING).
+
+---
+
+### IR-M10-002 — Ecological score reference annotation in Zone 1D
+
+*See #348 re-triage above — filed here as a new GitHub issue target.*
+
+- **Severity:** 🟡 Minor
+- **Instrument:** Zone 1D — Four-Framework Current Position, ecological row
+- **Fix:** One-to-three line change in `FourFrameworkZone1D.tsx` — tooltip or inline
+  sub-label on the ecological score displaying "1.0 = planetary boundary."
+
+---
+
+### IR-M10-003 — Attribute selector raw variable names
+
+*See #350 re-triage above — filed here as a new GitHub issue target.*
+
+- **Severity:** 🟡 Minor
+- **Component:** AttributeSelector — choropleth attribute chooser
+- **Fix:** Framework-agnostic lookup in `indicatorDisplayNames.ts`; use in `AttributeSelector.tsx`.
+
+---
+
+## Summary Table
+
+### DEMO Issue Verdicts
+
+| Issue | Title | M10 Verdict | Action |
+|---|---|---|---|
+| #347 | Governance honest-null (DEMO-006) | ✅ **CLOSE** — governance is live | Close with PR #585 reference |
+| #343 | Thesis frame legibility (DEMO-002) | ✅ Minor gap — reduce severity | Update scope to Zone 1A dashed-curve narration; not a blocker |
+| #342 | Choropleth no visible change (DEMO-001) | ✅ Reduce severity Critical→Minor | Update scope; not a Demo 3 blocker |
+| #346 | Radar axis labels (DEMO-005) | ✅ Reduce severity to Minor | Update scope to EntityDetailDrawer; not a Demo 3 blocker |
+| #345 | MDA accumulation visual (DEMO-004) | ⚠️ Verify — architecture correct | Run Argentina fixture; confirm alerts fire — see IR-M10-001 |
+| #348 | Ecological score reference (DEMO-007) | 🔴 **Open — Demo 3 blocker** | Fix Zone 1D annotation — see IR-M10-002 |
+| #350 | Attribute selector labels (DEMO-009) | 🔴 **Open — Demo 3 blocker** | Fix AttributeSelector display — see IR-M10-003 |
+| #376 | Playwright demo flow test | ⚙️ Test infrastructure — M10 exit gate | Not a Demo 3 blocker |
+| #377 | Legibility assertions | ⚙️ Test infrastructure — M10 exit gate | Not a Demo 3 blocker |
+
+### New Issues to File
+
+| ID | Severity | Title |
+|---|---|---|
+| IR-M10-001 | 🟠 Significant | Argentina fixture MDA accumulation — verify governance/unemployment floor fires at step 2 |
+| IR-M10-002 | 🟡 Minor | Zone 1D ecological score reference annotation — "1.0 = planetary boundary" |
+| IR-M10-003 | 🟡 Minor | AttributeSelector human-readable labels — framework-agnostic display name lookup |
+
+### Demo 3 Readiness Gate
+
+Before Demo 3 can be presented:
+
+1. **Verify #345 / IR-M10-001** — run Argentina fixture; confirm MDA alerts fire at step 2+
+2. **Fix IR-M10-002** — ecological score annotation in Zone 1D (~3 lines of JSX)
+3. **Fix IR-M10-003** — attribute selector display names (~5 lines in indicatorDisplayNames.ts + AttributeSelector)
+
+Items 2 and 3 are single-engineer, sub-hour fixes. Item 1 is a fixture verification that may
+require a seed data adjustment if the governance floor does not breach.
+
+---
+
+## M9 IR Findings Closure Confirmation
+
+All six M9 IR findings are confirmed closed in M10:
+
+| ID | Title | Closed by |
+|---|---|---|
+| IR-001 | Zone 1B MDA Panel always empty | PR #495 — mda_alerts wired from trajectory response |
+| IR-002 | Zone 1C PMM always "—" | PR #587 — PMM live computation endpoint |
+| IR-003 | Landing screen shows choropleth | PR #584 — persistent scenario state + demonstrative entry |
+| IR-004 | Step axis annotations absent | PR #583 — default step labels from start year; `step_metadata` Pydantic fix |
+| IR-005 | Governance "—" ambiguous | PR #585 — governance promoted; annotation removed |
+| IR-006 | No loading state | PR #582 — Zone 1D loading state skeleton |
+
+---
+
+## Positive Findings — What M10 Delivers
+
+1. **All four Zone 1 instruments carry live analytical content** — the M9 IR's primary
+   concern (Zone 1B and 1C always empty) is resolved. For the first time, a demo observer
+   can watch all four instruments update simultaneously as steps advance: trajectory curves
+   shift, MDA alerts accumulate, PMM updates directionally, and four-framework scores advance.
+   This is the Demo 3 primary demo surface — it exists and it works.
+
+2. **Governance live — the fourth axis is no longer dashed** — Zone 1D shows four real
+   numbers. The governance row carries a live normalized_absolute score derived from WGI Rule
+   of Law and V-Dem LDI data. For the Argentina fixture, the Kirchner recovery period shows
+   governance stagnation alongside financial rebound — the divergence thesis is visible in
+   Zone 1D without opening any drawer.
+
+3. **Argentina fixture complete with step event labels** — the `step_metadata` Pydantic
+   bug is fixed. The Zone 1A step axis shows "Default / Peso devaluation" at step 2 and
+   "Kirchner recovery begins" at step 3. A demo observer without any narration can read the
+   historical arc from the step axis alone.
+
+4. **Platform Principle demonstrated** — Demo 3 makes the platform claim concrete: the same
+   engine, instruments, and UX run the Argentina 2001–2002 arc as ran the Greece 2010–2015
+   arc. The demo script explicitly names this. For the intended audience (finance ministries
+   considering adoption), this is the most important claim Demo 3 makes.
+
+5. **PMM provides a directional signal for the Kirchner recovery** — at step 3, the PMM
+   should show an upward direction as fiscal consolidation pressure eases and the threshold
+   margin widens. A live PMM that changes direction at the recovery step makes Zone 1C
+   analytically meaningful for the first time.


### PR DESCRIPTION
## Summary

- Produces `docs/demo/m10/reviews/2026-06-02-v0.10-demo3-ir.md` — IR review of Demo 3 (Argentina 2001–2002 + M10 instrument cluster) against all nine open DEMO issues
- Closes #347 (DEMO-006 — governance now live in M10; null annotation moot)
- Reduces severity on #342 (DEMO-001), #343 (DEMO-002), #346 (DEMO-005) — architecture changed, Zone 1A now carries the primary thesis
- Confirms all 6 M9 IR findings closed (IR-001 through IR-006)
- Files 3 new GitHub issues: #615 (Argentina MDA accumulation seed), #616 (ecological boundary annotation in Zone 1D), #617 (attribute selector human-readable labels)

## Demo 3 Readiness Gate

3 items before Demo 3 can be presented:
1. **#615** — Verify Argentina fixture produces step-differentiated MDA alerts; seed if needed
2. **#616** — Add ecological score reference annotation in Zone 1D (~3 lines of JSX)
3. **#617** — Fix attribute selector display names (~5 lines)

## Test plan

- [ ] IR review document present at `docs/demo/m10/reviews/2026-06-02-v0.10-demo3-ir.md`
- [ ] #347 closed
- [ ] Comments posted on #342, #343, #346 with M10 re-triage verdicts
- [ ] Issues #615, #616, #617 filed as M10 Immediate

🤖 Generated with [Claude Code](https://claude.com/claude-code)