### PR TITLE
fix(frontend): Zone 1D ecological boundary annotation + AttributeSelector display names (closes #616, closes #617)

### DIFF
--- a/frontend/src/components/AttributeSelector.tsx
+++ b/frontend/src/components/AttributeSelector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { AttributeSummary } from "../types";
+import { getIndicatorDisplayNameAny } from "../lib/indicatorDisplayNames";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
@@ -57,7 +58,7 @@ export default function AttributeSelector({ value, onChange }: Props) {
     >
       {options.map((a) => (
         <option key={a.attribute_key} value={a.attribute_key}>
-          {a.attribute_key} ({a.unit}, {a.variable_type})
+          {getIndicatorDisplayNameAny(a.attribute_key)} ({a.unit}, {a.variable_type})
         </option>
       ))}
     </select>

--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -183,6 +183,14 @@ export function FourFrameworkZone1D({
               }}
             >
               {displayLabel}
+              {key === "ecological" && (
+                <span
+                  data-testid="ecological-boundary-note"
+                  style={{ display: "block", fontSize: 9, color: "#888", fontWeight: 400 }}
+                >
+                  1.0 = boundary
+                </span>
+              )}
             </span>
 
             <span

--- a/frontend/src/lib/indicatorDisplayNames.ts
+++ b/frontend/src/lib/indicatorDisplayNames.ts
@@ -78,3 +78,13 @@ function formatFallback(key: string): string {
 export function getIndicatorDisplayName(framework: string, key: string): string {
   return INDICATOR_DISPLAY_NAMES[framework]?.[key] ?? formatFallback(key);
 }
+
+/** Framework-agnostic lookup — returns the first matching display name across all
+ *  framework blocks, falling back to title-cased key. Used by surfaces that have
+ *  the attribute key but not the framework (e.g. AttributeSelector). */
+export function getIndicatorDisplayNameAny(key: string): string {
+  for (const block of Object.values(INDICATOR_DISPLAY_NAMES)) {
+    if (key in block) return block[key];
+  }
+  return formatFallback(key);
+}


### PR DESCRIPTION
## Summary

Two Demo 3 readiness gate fixes — both are pure frontend, no backend changes.

**#616 — Zone 1D ecological boundary annotation (`FourFrameworkZone1D.tsx`)**

The ecological composite uses a [0.0, 2.0] scale where 1.0 = the planetary boundary. All other frameworks use [0, 1]. A score of 1.07 reads as unremarkable without context.

Fix: a `"1.0 = boundary"` sub-label (9px, muted) below the "Ecological" row label — ecological row only. Carries `data-testid="ecological-boundary-note"` for future E2E assertion.

**#617 — AttributeSelector human-readable display names (`indicatorDisplayNames.ts` + `AttributeSelector.tsx`)**

Dropdown options were rendering raw API field names: `gdp_growth (%, FLOW)`. The `indicatorDisplayNames.ts` registry existed but was not reachable from AttributeSelector because it required a `(framework, key)` pair and AttributeSelector only has `key`.

Fix: `getIndicatorDisplayNameAny(key)` iterates all framework blocks and returns the first match (falling back to title-cased key). Wired into AttributeSelector in place of `a.attribute_key`. Unit and variable_type parenthetical retained for disambiguation.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 122/122 passing
- [ ] Manual: open Demo 3, confirm Zone 1D ecological row shows "1.0 = boundary" sub-label
- [ ] Manual: open choropleth attribute selector, confirm dropdown shows "GDP Growth (%, FLOW)" not "gdp_growth (%, FLOW)"

## Cross-references

Closes #616, closes #617. IR finding: `docs/demo/m10/reviews/2026-06-02-v0.10-demo3-ir.md` §IR-M10-002 and §IR-M10-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)