### PR TITLE
fix(fixture): Argentina Demo 3 — emergency_declaration at step 2 triggers governance MDA (closes #615)

### DIFF
--- a/backend/tests/fixtures/argentina_2001_2002_scenario.py
+++ b/backend/tests/fixtures/argentina_2001_2002_scenario.py
@@ -24,7 +24,11 @@ Simulation structure:
 
   build_argentina_demo_scenario(): n_steps=4 (annual: 2001→2004).
     Demo 3 variant. Extends the base with EcologicalModule, GovernanceModule,
-    step_metadata event labels, and recovery-phase steps (Issue #553).
+    step_metadata event labels, recovery-phase steps, and an emergency_declaration
+    at step 2 (state of siege, December 19 2001 — concurrent with sovereign default).
+    The emergency_declaration drives democratic_quality_score below the 0.70 MDA
+    floor at step 3, producing a governance WARNING during the Kirchner recovery
+    period (Issue #553, #615).
 
 Scheduled inputs:
   Step 1: IMF program acceptance (Blindaje) + fiscal spending cut (Zero Deficit Plan)
@@ -156,8 +160,8 @@ def build_argentina_demo_scenario() -> ScenarioCreateRequest:
       - co2_concentration_ppm initial seed (369.5 ppm — NOAA Mauna Loa 2000 mean)
       - rule_of_law_percentile initial seed (33.2 — WGI Rule of Law ARG 2000)
       - democratic_quality_score initial seed (0.71 — V-Dem LDI ARG 2000)
-      - step_metadata with SIGNIFICANT labels for crisis steps 1 and 2,
-        and SIGNIFICANT label for the Kirchner recovery at step 3
+      - step_metadata with SIGNIFICANT labels for crisis steps 1–3
+      - emergency_declaration at step 2 (state of siege, December 19 2001)
 
     Composite score status (M10):
       Ecological      — live (boundary proximity; CO2 active)
@@ -245,21 +249,37 @@ def build_argentina_demo_scenario() -> ScenarioCreateRequest:
         }
     )
 
-    # emergency_declaration at step 1 is already in base.scheduled_inputs.
-    # No additional inputs needed for steps 3–4 (recovery driven by prior-shock
-    # unwind and endogenous state dynamics). Steps 3 and 4 are ROUTINE in
-    # scheduled_inputs — the GovernanceModule will read the emergency_declaration
-    # one-step lag at step 2 (default) to reduce democratic_quality_score.
+    # Add emergency_declaration at step 2: Argentina's state of siege was declared
+    # December 19, 2001 — the same step as the sovereign default. GovernanceModule
+    # applies a one-step lag, so this event is processed at step 3. The elasticity
+    # is -0.05 on democratic_quality_score (Bermeo 2016). Starting at 0.715 after
+    # the imf_program_acceptance effect (+0.005 at step 2), the score drops to
+    # 0.665 at step 3 — below the MDA-GOV-DEMOCRACY-FLOOR threshold of 0.70.
+    # MDA WARNING fires at step 3 (the Kirchner recovery), showing that governance
+    # damage persists even as the economy begins to recover.
+    demo_scheduled_inputs = list(base.scheduled_inputs) + [
+        ScheduledInputSchema(
+            step=2,
+            input_type="EmergencyPolicyInput",
+            input_data={
+                "instrument": "emergency_declaration",
+                "target_entity": "ARG",
+                "expected_duration": 1,
+            },
+        ),
+    ]
 
     return base.model_copy(update={
         "name": "Argentina 2001-2002 Demo 3 — Crisis Arc and Kirchner Recovery",
         "description": (
             "Demo 3 scenario (Issue #553). "
             "EcologicalModule and GovernanceModule enabled — all four framework axes live. "
-            "Crisis arc: Zero Deficit Plan (2001) → sovereign default (2002) → "
+            "Crisis arc: Zero Deficit Plan (2001) → sovereign default + state of siege (2002) → "
             "Kirchner recovery (2003–2004). "
             "Governance composite uses normalized_absolute strategy "
             "(WGI/V-Dem; ADR-005 Amendment 4). "
+            "MDA-GOV-DEMOCRACY-FLOOR breached at step 3: emergency_declaration (step 2) "
+            "drives democratic_quality_score to 0.665 via GovernanceModule one-step lag. "
             "Financial and human_development composites are null "
             "(percentile rank requires ≥2 entities, Issue #193). "
             "Initial state: IMF WEO April 2001 + INDEC EPH October 2000 "
@@ -268,4 +288,5 @@ def build_argentina_demo_scenario() -> ScenarioCreateRequest:
             "+ V-Dem v13 (democratic_quality_score=0.71)."
         ),
         "configuration": demo_config,
+        "scheduled_inputs": demo_scheduled_inputs,
     })

--- a/backend/tests/unit/test_argentina_backtesting_fixtures.py
+++ b/backend/tests/unit/test_argentina_backtesting_fixtures.py
@@ -465,3 +465,77 @@ def test_build_argentina_demo_scenario_serializes_to_json() -> None:
     cfg = dumped["configuration"]
     assert "step_metadata" in cfg
     assert cfg["step_metadata"]["1"]["significance"] == "SIGNIFICANT"
+
+
+def test_build_argentina_demo_scenario_has_emergency_declaration_at_step2() -> None:
+    """Demo scenario must include emergency_declaration at step 2 (state of siege,
+    December 19 2001 — concurrent with sovereign default).
+
+    This is the instrument that drives democratic_quality_score below the 0.70
+    MDA-GOV-DEMOCRACY-FLOOR at step 3 via GovernanceModule one-step lag (#615).
+    """
+    demo = build_argentina_demo_scenario()
+    emergency_at_step2 = [
+        si for si in demo.scheduled_inputs
+        if si.step == 2
+        and si.input_type == "EmergencyPolicyInput"
+        and si.input_data.get("instrument") == "emergency_declaration"
+    ]
+    assert len(emergency_at_step2) == 1, (
+        "Demo scenario must have exactly one emergency_declaration at step 2 "
+        f"(found {len(emergency_at_step2)})"
+    )
+
+
+def test_build_argentina_demo_scenario_emergency_declaration_step_in_range() -> None:
+    """emergency_declaration step must be within [0, n_steps]."""
+    demo = build_argentina_demo_scenario()
+    n = demo.configuration.n_steps
+    for si in demo.scheduled_inputs:
+        assert 0 <= si.step <= n, (
+            f"Scheduled input step {si.step} outside valid range [0, {n}]"
+        )
+
+
+def test_build_argentina_demo_scenario_governance_mda_breach_math() -> None:
+    """Verify democratic_quality_score drops below 0.70 at step 3.
+
+    GovernanceModule one-step lag applies elasticities from the prior step:
+      Step 2 reads step 1: imf_program_acceptance × +0.005 = +0.005
+        → score: 0.71 + 0.005 = 0.715 (above 0.70 — no breach)
+      Step 3 reads step 2: emergency_declaration × -0.05 = -0.05
+        → score: 0.715 - 0.05 = 0.665 ≤ 0.70 — MDA WARNING fires
+
+    This test encodes the expected score trajectory as a regression gate.
+    If the elasticity values or initial seed change, this test will catch it.
+    """
+    from decimal import Decimal
+
+    from app.simulation.modules.governance.elasticities import GOVERNANCE_ELASTICITY_REGISTRY
+
+    initial_dqs = Decimal("0.71")
+    mda_floor = Decimal("0.70")
+
+    imf_elasticity = next(
+        r.elasticity for r in GOVERNANCE_ELASTICITY_REGISTRY
+        if r.event_type == "imf_program_acceptance"
+        and r.indicator_key == "democratic_quality_score"
+    )
+    emergency_elasticity = next(
+        r.elasticity for r in GOVERNANCE_ELASTICITY_REGISTRY
+        if r.event_type == "emergency_declaration" and r.indicator_key == "democratic_quality_score"
+    )
+
+    # Step 2 effect: imf_program_acceptance fires at step 1 → processed at step 2
+    score_after_step2 = initial_dqs + (Decimal("1") * imf_elasticity)
+    assert score_after_step2 > mda_floor, (
+        f"Score after step 2 ({score_after_step2}) must be above MDA floor — "
+        "breach should not fire until step 3"
+    )
+
+    # Step 3 effect: emergency_declaration fires at step 2 → processed at step 3
+    score_after_step3 = score_after_step2 + (Decimal("1") * emergency_elasticity)
+    assert score_after_step3 <= mda_floor, (
+        f"Score after step 3 ({score_after_step3}) must be ≤ MDA floor {mda_floor} — "
+        "MDA-GOV-DEMOCRACY-FLOOR WARNING must fire at step 3"
+    )


### PR DESCRIPTION
## Problem

The Argentina Demo 3 fixture (`build_argentina_demo_scenario()`) never fired a governance MDA alert. The `MDA-GOV-DEMOCRACY-FLOOR` threshold requires `democratic_quality_score ≤ 0.70 → WARNING`. The initial seed is 0.71 (V-Dem LDI ARG 2000), and with only `imf_program_acceptance` at step 1 (elasticity +0.005 on democratic_quality_score), the score _rose_ to 0.715 and never breached the floor.

A wrong comment in the fixture falsely claimed `emergency_declaration` was already present in the base scheduled inputs — it was not.

## Fix

Add `emergency_declaration` at step 2 in `build_argentina_demo_scenario()` (not in the base backtesting scenario). This is historically accurate: Argentina's state of siege was declared December 19, 2001, concurrent with the sovereign default declaration.

**Score trajectory with fix:**

| Step | Event processed (one-step lag) | `democratic_quality_score` | MDA status |
|---|---|---|---|
| 1 | (none) | 0.71 | — |
| 2 | `imf_program_acceptance` × +0.005 | 0.715 | approach window (0.70–0.735) |
| 3 | `emergency_declaration` × −0.05 | **0.665** | ⚠ WARNING fires |
| 4 | (none) | 0.665 | ⚠ WARNING persists |

The governance WARNING fires at step 3 (the Kirchner recovery period), showing that democratic damage persists even as the economy begins to recover. This is historically accurate and narratively compelling for Demo 3.

## Tests

Three new tests added:
- `test_build_argentina_demo_scenario_has_emergency_declaration_at_step2` — fixture gate
- `test_build_argentina_demo_scenario_emergency_declaration_step_in_range` — step bounds check
- `test_build_argentina_demo_scenario_governance_mda_breach_math` — encodes the elasticity math as a regression gate; will catch any future change to the elasticity values or initial seed

## Verification

- `ruff check .` — clean
- `mypy app/` — clean  
- 887 passed, 73 skipped (full backend suite, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)