### PR TITLE
process(agents): pre-escalation domain routing in working agreements (closes #633)

### DIFF
--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -110,6 +110,14 @@ PM Agent: EXECUTE — [task]
 
 **Where I will offer help:** Mid-session discoveries. Any agent that has found something — a bug, a gap, a new requirement — and is uncertain whether to act now or file it: bring it to me. One sentence describing the finding, I return one word.
 
+**Before escalating to EL — domain routing (Issue #633):**
+When a recommendation or question falls outside the current agent's domain, route to the domain owner before surfacing to the EL. These triggers are self-activating — no EL prompt required to initiate them:
+
+1. **Zone 1 layout** (zone assignment, hierarchy, instrument placement) → `Frontend Architect: REVIEW — [scope]` then `UX Designer: REVIEW — [scope]` before EL
+2. **Confidence tier or methodology** (data quality, uncertainty quantification, statistical integrity) → `Chief Methodologist: VALIDATE — [question]` before EL
+3. **Demo script or demo preparation** → `UX Designer: REVIEW — [scope]` before EL (PM Agent is already in the loop for demo scope)
+4. **Agent working agreements or RACI** → `Process Integrity Agent: REVIEW — [scope]` before EL
+
 ### Issue Hierarchy
 
 WorldSim uses a strict three-level issue hierarchy. The spawning rule is
@@ -313,6 +321,14 @@ Exempt from issue requirement: purely mechanical commits such as lint fixes, imp
 Every commit that resolves a tracked issue must close that issue in the same session using `gh issue close N --comment "..."` with a one-sentence summary of what was done and the commit SHA. An issue that is not explicitly closed remains open in the tracker regardless of whether the work is done in the codebase.
 
 **Relationships:** Downstream of Architect Agent (executes ADR contracts). Coordinates with QA Lead Agent (tests required alongside code). Reports to Engineering Lead via PRs and issue closure.
+
+**Before escalating to EL — domain routing (Issue #633):**
+When an implementation question or finding touches a cross-domain concern, route to the domain owner before escalating:
+
+1. **Zone 1 layout** (zone assignment, hierarchy, instrument placement) → `Frontend Architect: REVIEW — [scope]` then `UX Designer: REVIEW — [scope]` before EL
+2. **Confidence tier or methodology** → `Chief Methodologist: VALIDATE — [question]` before EL
+3. **Demo script or demo preparation** → `PM Agent: TRIAGE — [scope]` + `UX Designer: REVIEW — [scope]` before EL
+4. **Agent working agreements or RACI** → `Process Integrity Agent: REVIEW — [scope]` before EL
 
 ---
 
@@ -542,6 +558,14 @@ Frontend Architect: UPDATE — [what changed]
 **Where I will ask for help:** When a UX specification requires rendering behavior with demonstrable performance implications on the 4-core laptop target — when "always visible" and "not slow" are in genuine tension — I bring both the requirement and the constraint to the UX Designer and Engineering Lead simultaneously. Neither resolves it alone.
 
 **Where I will offer help:** UX Designer — before a ruling commits to an interaction that requires a specific technical implementation, tell me. I'll tell you in five minutes whether it's feasible on the target hardware. That conversation belongs at design time, not after the layout is published.
+
+**Before escalating to EL — domain routing (Issue #633):**
+When an architectural recommendation crosses into another domain, route to the domain owner before escalating:
+
+1. **Zone 1 layout** (final zone assignment, hierarchy ruling) → `UX Designer: REVIEW — [scope]` before EL — Frontend Architect recommends; UX Designer rules; EL confirms only if UX Designer and FA disagree
+2. **Confidence tier or methodology** → `Chief Methodologist: VALIDATE — [question]` before EL
+3. **Demo script or demo preparation** → `PM Agent: TRIAGE — [scope]` + `UX Designer: REVIEW — [scope]` before EL
+4. **Agent working agreements or RACI** → `Process Integrity Agent: REVIEW — [scope]` before EL
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a "Before escalating to EL — domain routing" section to three agent working agreements: PM Agent, Implementation Agents, Frontend Architect Agent
- Four self-activating triggers make existing RACI consultation obligations fire without EL quarterback
- One file changed: `docs/process/agents.md` — 24 lines inserted

## Changes

**PM Agent working agreement** (after "Where I will offer help"):
Four triggers. Trigger 3 notes PM is already in the loop for demo prep — route to UX Designer, not PM→PM.

**Implementation Agents section** (after "Relationships"):
Four triggers, identically framed. Implementation agents make the widest range of domain-crossing recommendations.

**Frontend Architect Agent working agreement** (after "Where I will offer help"):
Four triggers. Trigger 1 clarifies the Zone 1 boundary explicitly: FA recommends, UX Designer rules, EL confirms only if they disagree.

## Root case

UX-RULING-4 (2026-06-02): PM Agent scoping comment recommended Option A (~30 LOC) for DEMO-001. Recommendation had Zone 1 layout implications (UX Designer R, FA Agent C). EL recognized the domain and routed manually. Correct resolution was zero code. Without EL recognition, the wrong fix would have shipped.

## ADRs Affected

| ADR | Decision(s) touched | Compliant? |
|---|---|---|
| None | Process doc only — no ADR scope | N/A |

## Test plan

- [ ] `grep "Before escalating to EL" docs/process/agents.md` returns three results (PM, FA, Implementation)
- [ ] Each trigger specifies the correct activation prompt format from agents.md §Activation prompt reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)