### PR TITLE
docs(demo): Step 4 narration — honest scope framing replaces false recovery claim

### DIFF
--- a/docs/demo/stakeholder-walkthrough.md
+++ b/docs/demo/stakeholder-walkthrough.md
@@ -313,11 +313,16 @@ Governance composite healing slowly — not yet at full recovery.
 
 **What the presenter says:**
 
-> Step 4 is 2004. GDP growing at plus 9 percent. The Kirchner recovery is entrenched.
+> Step 4 is 2004. The GDP numbers — which you can see in the indicator panel —
+> are growing at plus 9 percent. The Kirchner recovery is real.
 >
-> Now look at the trajectory arc as a whole: four steps, all four frameworks.
-> The financial arc has recovered. The governance arc is healing — but slowly.
+> But look at the governance composite: it's healing slowly, not yet restored.
 > Institutional recovery lags financial recovery, sometimes by years.
+>
+> And this points to something the current fixture doesn't yet model: the full
+> Kirchner recovery arc. That's a scope limitation we're honest about — the
+> simulation captures the crisis, the default, and the governance deterioration.
+> The recovery phase is M11 scope.
 >
 > And this is the platform principle made concrete: the same engine, the same
 > instruments, the same analytical discipline that modelled Greece in 2010 to 2015


### PR DESCRIPTION
## Summary

- Replaces "the financial arc has recovered" with narration that directs the audience to the indicator panel, acknowledges the Kirchner recovery is real, and is transparent that the full recovery arc is M11 scope
- EL decision: Option (a) remove false claim + Option (b) add honest scope disclosure (no new fixture data needed)
- Resolves the financial narration gap identified during Demo 3 review (Issue #634)

## Change

**Before:**
> The financial arc has recovered. The governance arc is healing — but slowly.

**After:**
> Step 4 is 2004. The GDP numbers — which you can see in the indicator panel — are growing at plus 9 percent. The Kirchner recovery is real.
>
> But look at the governance composite: it's healing slowly, not yet restored. Institutional recovery lags financial recovery, sometimes by years.
>
> And this points to something the current fixture doesn't yet model: the full Kirchner recovery arc. That's a scope limitation we're honest about — the simulation captures the crisis, the default, and the governance deterioration. The recovery phase is M11 scope.

## Test plan

- [ ] Read the full Step 7 narration block in context — flow from Step 6 into Platform Principle close
- [ ] Confirm "financial arc has recovered" no longer appears anywhere in the walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)