### PR TITLE
fix(pmm): skip breached thresholds — PMM measures remaining headroom

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -626,7 +626,12 @@ def _compute_pmm_for_step(
             floor_value = Decimal(str(row["floor_value"]))
             approach_pct = Decimal(str(row["approach_pct"]))
             op = str(row.get("comparison_operator", "lte"))
-            margins.append(_pmm_indicator_margin(current, floor_value, approach_pct, op))
+            margin = _pmm_indicator_margin(current, floor_value, approach_pct, op)
+            # Skip thresholds already in breach (margin == 0). Breached thresholds
+            # are captured by MDA alerts; PMM measures remaining headroom on
+            # thresholds not yet crossed. If all thresholds are breached, return None.
+            if margin > Decimal("0"):
+                margins.append(margin)
 
     if not margins:
         return None

--- a/backend/tests/unit/test_pmm_computation.py
+++ b/backend/tests/unit/test_pmm_computation.py
@@ -194,13 +194,16 @@ class TestComputePmmForStep:
         assert result is not None
         assert Decimal(result.value) == Decimal("0.5")
 
-    def test_min_across_thresholds(self) -> None:
-        # reserves margin = 1.0 (well above), debt margin = 0 (at breach)
+    def test_breached_threshold_excluded_non_breached_contributes(self) -> None:
+        # debt_gdp_ratio is at breach (margin=0) — excluded from PMM.
+        # reserve_coverage_months is well outside approach zone (margin=1.0).
+        # PMM = 1.0 (only the non-breached threshold contributes).
+        # Breached thresholds are MDA-alert territory; PMM measures remaining headroom.
         result = _compute_pmm_for_step(
             entity_id="GRC",
             entity_attrs={
                 "reserve_coverage_months": _qty("10.0"),
-                "debt_gdp_ratio": _qty("1.20"),  # at floor for gte
+                "debt_gdp_ratio": _qty("1.20"),  # at floor for gte — breach
             },
             mda_thresholds=[
                 _threshold("reserve_coverage_months", "2.5", "0.20", "lte"),
@@ -209,7 +212,46 @@ class TestComputePmmForStep:
             prev_pmm=None,
         )
         assert result is not None
-        assert Decimal(result.value) == Decimal("0")
+        assert Decimal(result.value) == Decimal("1")
+
+    def test_all_thresholds_breached_returns_none(self) -> None:
+        # All thresholds at breach — PMM is None (shown as "—" in UI).
+        # MDA alerts carry the breach signal; PMM has nothing to measure.
+        result = _compute_pmm_for_step(
+            entity_id="GRC",
+            entity_attrs={
+                "reserve_coverage_months": _qty("2.0"),  # below floor 2.5 — breach
+                "debt_gdp_ratio": _qty("1.20"),          # at floor 1.20 — breach
+            },
+            mda_thresholds=[
+                _threshold("reserve_coverage_months", "2.5", "0.20", "lte"),
+                _threshold("debt_gdp_ratio", "1.20", "0.10", "gte"),
+            ],
+            prev_pmm=None,
+        )
+        assert result is None
+
+    def test_ecological_breach_excluded_governance_margin_survives(self) -> None:
+        # Argentina Demo 3 pattern: CO2 proximity already breached (>=1.0),
+        # governance score not yet breached (0.71 > 0.70 floor).
+        # PMM = governance margin only; ecological breach is excluded.
+        # governance margin = (0.71 - 0.70) / (0.70 * 0.05) = 0.01/0.035 ≈ 0.2857
+        result = _compute_pmm_for_step(
+            entity_id="ARG",
+            entity_attrs={
+                "planetary_boundary_co2_proximity": _qty("1.056"),  # breach
+                "democratic_quality_score": _qty("0.71"),           # not breached
+            },
+            mda_thresholds=[
+                _threshold("planetary_boundary_co2_proximity", "1.0", "0.05", "gte"),
+                _threshold("democratic_quality_score", "0.70", "0.05", "lte"),
+            ],
+            prev_pmm=None,
+        )
+        assert result is not None
+        expected = (Decimal("0.71") - Decimal("0.70")) / (Decimal("0.70") * Decimal("0.05"))
+        assert abs(Decimal(result.value) - expected) < Decimal("0.0001")
+        assert result.direction == "flat"  # prev_pmm is None
 
     def test_direction_up_when_pmm_improves(self) -> None:
         result = _compute_pmm_for_step(


### PR DESCRIPTION
## Summary

- **Root cause of #648 (PMM = 0.00)**: Ecological CO2 boundary threshold (`planetary_boundary_co2_proximity ≥ 1.0`) is breached from step 1 in Argentina Demo 3 (seed ≈ 1.056 × boundary). The old `min(margins)` collapsed to 0 even though the governance score (0.71 > 0.70 floor) still had ~0.29 headroom.
- **Fix**: `_compute_pmm_for_step` now skips thresholds with `margin == 0` (already breached). MDA alerts carry the breach signal; PMM reports the minimum margin on thresholds *not yet crossed*. Returns `None` (shown as "—") when all applicable thresholds are breached.
- **Expected Argentina Demo 3 behaviour after fix**: Steps 1–2 show PMM ≈ 0.29 (governance headroom); step 3+ show "—" once governance threshold also breaches via emergency declaration.

## Tests

- Replaced `test_min_across_thresholds` (encoded old wrong contract — asserted PMM=0 when one threshold breached) with three new tests:
  - `test_breached_threshold_excluded_non_breached_contributes`
  - `test_all_thresholds_breached_returns_none`
  - `test_ecological_breach_excluded_governance_margin_survives` (Argentina Demo 3 pattern)
- All 31 unit tests pass.

## Closes

Closes #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)