### PR TITLE
fix(zone1b): pass responsive columnWidth to MDAAlertPanelZone1B

### DIFF
--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -12,12 +12,12 @@ import React, { useEffect, useState } from "react";
 import { TrajectoryView } from "./TrajectoryView";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 
-const LAYOUT = {
+export const LAYOUT = {
   1024: { trajectory: 480, coPrimary: 240, controlPlane: 280 },
   1280: { trajectory: 580, coPrimary: 400, controlPlane: 280 },
 } as const;
 
-function useViewportBreakpoint(): 1024 | 1280 {
+export function useViewportBreakpoint(): 1024 | 1280 {
   const [bp, setBp] = useState<1024 | 1280>(
     window.innerWidth >= 1280 ? 1280 : 1024,
   );

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -22,7 +22,7 @@
  * thresholds have matching indicator data for the step.
  */
 import React, { useEffect, useState } from "react";
-import { InstrumentCluster } from "./InstrumentCluster";
+import { InstrumentCluster, LAYOUT, useViewportBreakpoint } from "./InstrumentCluster";
 import { MDAAlertPanelZone1B } from "./MDAAlertPanelZone1B";
 import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
 import { FourFrameworkZone1D } from "./FourFrameworkZone1D";
@@ -183,6 +183,8 @@ export function ScenarioInstrumentCluster({
   entityIds,
 }: ScenarioInstrumentClusterProps) {
   const store = useScenarioStepStore();
+  const bp = useViewportBreakpoint();
+  const coPrimaryWidth = LAYOUT[bp].coPrimary;
 
   // Fetch lifecycle state for Zone 1D loading/error display (IR-006).
   // Local state — not Zustand — because this is fetch lifecycle, not simulation state.
@@ -279,7 +281,7 @@ export function ScenarioInstrumentCluster({
   return (
     <InstrumentCluster
       entityIds={entityIds}
-      mdaPanel={<MDAAlertPanelZone1B columnWidth={240} />}
+      mdaPanel={<MDAAlertPanelZone1B columnWidth={coPrimaryWidth} />}
       pmmWidget={<PMMWidgetZone1C />}
       fourFramework={
         <FourFrameworkZone1D


### PR DESCRIPTION
## Summary

- **Root cause of IR-S7-001 / #647**: `MDAAlertPanelZone1B` was instantiated with `columnWidth={240}` (hardcoded), so it always rendered in compact mode (11px font, abbreviated severity labels, truncated indicator names) even at 1440×900 where the co-primary column is 400px.
- **Fix**: Export `LAYOUT` and `useViewportBreakpoint` from `InstrumentCluster.tsx`. `ScenarioInstrumentCluster` now calls `useViewportBreakpoint()` and passes `LAYOUT[bp].coPrimary` as `columnWidth`. At ≥1280px viewports the Zone 1B panel renders in full-density mode: 12px font, full `WARNING`/`CRITICAL`/`TERMINAL` severity pills, untruncated indicator names.
- **Breakpoint behaviour**: 1024→240px compact (unchanged); 1280+→400px full-density (fixed).

## Tests

- `MDAAlertPanelZone1B.test.ts`: 31/31 pass (no changes to test logic)
- `tsc --noEmit`: clean

## Closes

Closes #647. Resolves IR-S7-001 (CRITICAL) from Demo 3 screenshot IR review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)