### PR TITLE
docs(ux): NARRATION-RULING-1 — institutionalize three-layer narration structure

### DIFF
--- a/docs/process/demo-preparation-standard.md
+++ b/docs/process/demo-preparation-standard.md
@@ -1,7 +1,7 @@
 # Demo Preparation Standard
 
 **Established:** 2026-05-18
-**Last revised:** 2026-06-02 (M10 — screenshot naming, legibility gate, narration instrument check; closes #379)
+**Last revised:** 2026-06-02 (M10 — screenshot naming, legibility gate, narration instrument check, NARRATION-RULING-1 self-check; closes #379)
 **Cadence:** Every two milestones (M6, M8, M10, M12...)
 **Reference cases:** Issue #220 (M6), Issue #333 (M8), Issue #261 (M10)
 
@@ -140,6 +140,27 @@ npx playwright test tests/e2e/demo-advancement-flow.spec.ts --project=chromium
 All tests must pass before screenshots are captured. A legibility failure means a
 frame will be illegible in the review — the same defect class as DEMO-002, DEMO-003,
 DEMO-005. Fix the failing assertion before proceeding to Step 6.
+
+### Step 5c — Narration structure self-check (M10 forward — NARRATION-RULING-1)
+
+Before the Independent Review Agent sees the script, apply a self-check to every
+live-application step in Section 2 of `docs/demo/stakeholder-walkthrough.md`.
+For each step, verify all three of:
+
+- [ ] **Umbrella present.** One to two sentences orient the audience before any
+  instrument reading is stated. The step does not open with a fact.
+- [ ] **Synthesis present.** After the instrument output, one to two sentences
+  draw the implication for the decision context (negotiating room, ministry brief,
+  policy headroom).
+- [ ] **Transitions present where required.** If the step's argument depends on
+  the prior step's finding, a connective sentence bridges them. Steps in a causal
+  chain are not self-contained.
+
+Authority: NARRATION-RULING-1 (`docs/ux/standards.md §16`).
+
+This check gates against the class of defect documented in Issue #652: narration
+that presents instrument output without framing or implication, introducing
+presenter-skill dependency for the "so what" the audience needs.
 
 ### Step 6 — Run the demo and capture screenshots
 

--- a/docs/ux/standards.md
+++ b/docs/ux/standards.md
@@ -256,3 +256,45 @@ scenario curves render at 100% opacity, 2px stroke. A divergence fill region (5�
 appears where they separate.
 
 This is not a user-toggled feature. The comparison is always live once a control input exists.
+
+---
+
+## 16. Live-Application Narration Structure (NARRATION-RULING-1)
+
+**Authority:** EL ruling 2026-06-02 (Issue #652, Issue #654).
+
+Every live-application narration block in Section 2 of the stakeholder walkthrough
+follows a mandatory three-layer structure:
+
+1. **Umbrella** — what is happening and why it matters now, before any facts are
+   stated. One to two sentences that orient the audience to the cognitive task of the
+   current step. Answers: "What am I looking at and why does it matter at this moment
+   in the presentation arc?"
+
+2. **Facts** — the instrument output, exactly as readable on screen. No interpretation
+   yet. "The PMM widget reads 0.29." "Zone 1B shows a CRITICAL threshold breach on
+   `reserve_coverage_months` at step 2."
+
+3. **Synthesis** — so what. The implication for the audience's decision context: the
+   negotiating room, the ministry brief, the policy lever that no longer exists. One to
+   two sentences that connect the fact to the use case.
+
+**Transitions:** Where the presentation arc demands connective tissue between steps
+(e.g. "that is what Zone 1A showed — Zone 1B now puts a specific number on it"), a
+transition sentence is required. Transitions are not optional when a step's argument
+depends on the previous step's finding.
+
+**Edge case:** When existing narration already embeds a strong synthesis within the
+fact statement itself, a separate synthesis sentence is redundant. The test: can a
+listener who looked away during the fact statement understand the implication from the
+synthesis sentence alone? If yes, the synthesis is present whether or not it is
+structurally separate.
+
+**Violation:** A narration block that opens with an instrument reading before the
+umbrella is in place violates this standard. "The PMM widget shows 0.29" as an opener
+is a violation; "This is the frame that tells us how much headroom remains — the PMM
+widget reads 0.29" is not.
+
+**Check cadence:** Applied at Step 5c of the Demo Preparation Standard for each
+milestone cycle (M10 forward). Authority reference in prep standard:
+`docs/process/demo-preparation-standard.md §Step 5c`.


### PR DESCRIPTION
## Summary

- Adds **NARRATION-RULING-1** (§16) to `docs/ux/standards.md`: umbrella → facts → synthesis required in every live-application narration block, with transitions where the arc demands connective tissue. Edge case documented (embedded synthesis is sufficient; test: can a listener who missed the fact statement understand the implication alone?).
- Adds **Step 5c** to `docs/process/demo-preparation-standard.md`: self-check checklist (umbrella present / synthesis present / transitions present) gates each milestone's walkthrough before the Independent Review Agent sees it. References NARRATION-RULING-1 explicitly.

## Context

Issue #652 found that Section 2 narration opened with instrument readings before orienting the audience — the "so what" was carried by the presenter's domain knowledge, not the script. PR #654 fixed the current walkthrough. This PR closes the process gap so the fix doesn't need to be rediscovered each cycle.

## Test plan

- [ ] `docs/ux/standards.md §16` follows the format of all 15 existing settled decisions (authority line, rule body, edge cases, check cadence)
- [ ] `docs/process/demo-preparation-standard.md §Step 5c` is positioned after Step 5b and before Step 6 — narration check runs before screenshots are captured
- [ ] Step 5c checkbox format matches the atomic action format used in Step 5a and 5b
- [ ] Cross-reference: standards.md cites demo-preparation-standard.md §Step 5c; demo-preparation-standard.md cites standards.md §16

Closes part of M10 process hardening work initiated by Issue #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)