### PR TITLE
docs(demo): add issue numbers to M10 stakeholder review findings

### DIFF
--- a/docs/demo/m10/reviews/2026-06-02-v0.10.0-stakeholder-review.md
+++ b/docs/demo/m10/reviews/2026-06-02-v0.10.0-stakeholder-review.md
@@ -160,7 +160,7 @@ legible. See IR-S7-003, IR-S7-004.
 
 ---
 
-### IR-S7-001 — Frame D does not deliver the "Evidence" compositional frame
+### IR-S7-001 — Frame D does not deliver the "Evidence" compositional frame — [#647](https://github.com/PublicEnemage/worldsim/issues/647)
 
 - **Severity:** 🔴 CRITICAL (blocks demo Step 5)
 - **Instrument:** Zone 1B — MDA Alert Panel
@@ -179,10 +179,13 @@ legible. See IR-S7-003, IR-S7-004.
   severity, indicator, step index, framework.
 - **Precedent:** The UX Agent brief §Frame D explicitly required Zone 1B as compositional
   focus. The walkthrough Step 5 narration depends on this frame's legibility.
+- **GitHub Issue:** #647 ✅ Closed — Zone 1B responsive columnWidth fix (PR #651) resolved
+  the root cause (hardcoded 240px → 400px at 1440×900). Frame D confirmed legible at live
+  session.
 
 ---
 
-### IR-S7-002 — Zone 1B MDA alerts not visible in any screenshot
+### IR-S7-002 — Zone 1B MDA alerts not visible in any screenshot — [#647](https://github.com/PublicEnemage/worldsim/issues/647)
 
 - **Severity:** 🔴 CRITICAL (blocks demo Steps 4 and 5)
 - **Instrument:** Zone 1B — MDA Alert Panel
@@ -203,10 +206,13 @@ legible. See IR-S7-003, IR-S7-004.
   card does not render: this is a data issue — investigate the MDA alert pipeline from the
   measurement-output endpoint.
 - **Priority:** Resolve before demo session. The walkthrough Steps 4 and 5 depend on this.
+- **GitHub Issue:** #647 ✅ Closed — root cause was hardcoded `columnWidth={240}` in
+  `ScenarioInstrumentCluster` (compact mode always; full-density mode never triggered at
+  1440×900). Fixed by PR #651; Zone 1B confirmed rendering at live session.
 
 ---
 
-### IR-S7-003 — Zone 1D Four-Framework scorecard not legible in screenshots
+### IR-S7-003 — Zone 1D Four-Framework scorecard not legible in screenshots — [#634](https://github.com/PublicEnemage/worldsim/issues/634)
 
 - **Severity:** 🟠 Significant
 - **Instrument:** Zone 1D — Four-Framework Current Position
@@ -229,10 +235,13 @@ legible. See IR-S7-003, IR-S7-004.
 - **Note:** The `demo-legibility.spec.ts` Playwright tests (PR #626) gate on Zone 1D
   framework labels ≥ 10px and non-overflow-clipped. If those tests pass, Zone 1D is
   technically legible — the screenshot resolution may simply not resolve it.
+- **GitHub Issue:** #634 (demo prep umbrella — no dedicated issue filed for this finding).
+  Zone 1D confirmed rendering at live session; legibility limitation is screenshot-resolution
+  only. No implementation fix required before Demo 3.
 
 ---
 
-### IR-S7-004 — PMM = 0.00 across all four steps
+### IR-S7-004 — PMM = 0.00 across all four steps — [#648](https://github.com/PublicEnemage/worldsim/issues/648)
 
 - **Severity:** 🟠 Significant
 - **Instrument:** Zone 1C — PMM Widget
@@ -267,10 +276,15 @@ legible. See IR-S7-003, IR-S7-004.
   presenter should say "PMM activates once at least one threshold is breached and we advance
   one step — it is null at step 0." The current "0.00 ↑" display is the worst of both: it
   implies a computed value that is analytically meaningless.
+- **GitHub Issue:** #648 ✅ Closed — root cause was ecological CO2 breach (score ≈ 1.056 ≥
+  1.0 floor from step 0) driving `min(margins)` to zero and masking governance headroom.
+  Fixed by PR #650: `_compute_pmm_for_step` now skips breached thresholds (margin == 0).
+  Confirmed PMM trajectory: steps 0–1 ≈ 0.2857 (flat), step 2 ≈ 0.4286 (↑), steps 3–4
+  = None / "—" (governance threshold breached by `emergency_declaration`).
 
 ---
 
-### IR-S7-005 — Choropleth visual dominance relative to Zone 1 instruments
+### IR-S7-005 — Choropleth visual dominance relative to Zone 1 instruments — [#342](https://github.com/PublicEnemage/worldsim/issues/342)
 
 - **Severity:** 🟡 Minor
 - **Surface:** Zone 2 / Zone 1 viewport balance
@@ -293,6 +307,9 @@ legible. See IR-S7-003, IR-S7-004.
   the panel on the left — the map provides geographic context") — the walkthrough Step 1
   already includes this orientation. No implementation required before Demo 3. File as M11
   layout enhancement if the live session confirms the imbalance matters to observers.
+- **GitHub Issue:** #342 (DEMO-001 root cause — choropleth as context surface vs. change
+  instrument). M11 layout enhancement (scenario-relative color scale, Option B) will
+  address the underlying visual weight issue when implemented.
 
 ---
 
@@ -322,13 +339,13 @@ note assumes IR-S7-002 is resolved — Zone 1B must show the governance WARNING 
 
 ## Summary Table
 
-| ID | Severity | Finding | Action |
-|---|---|---|---|
-| IR-S7-001 | 🔴 CRITICAL | Frame D is indistinct from Frame C — Zone 1B not compositional focus | Re-capture Frame D with governance WARNING card foregrounded |
-| IR-S7-002 | 🔴 CRITICAL | Zone 1B MDA alerts not visible in any screenshot | Verify live rendering at 1440×900; investigate if alert pipeline issue |
-| IR-S7-003 | 🟠 Significant | Zone 1D Four-Framework scorecard not legible at screenshot resolution | Verify live rendering; crop Zone 1D if full-viewport screenshots don't resolve it |
-| IR-S7-004 | 🟠 Significant | PMM = 0.00 across all steps — analytically meaningless | Investigate trajectory API `pmm` field for Argentina; fix null rendering or computation |
-| IR-S7-005 | 🟡 Minor | Choropleth visual dominance relative to Zone 1 — visual weight imbalance | No blocker; strong presenter orientation at Step 1; M11 layout enhancement if confirmed by live session |
+| ID | Severity | Finding | Issue | Resolution |
+|---|---|---|---|---|
+| IR-S7-001 | 🔴 CRITICAL | Frame D is indistinct from Frame C — Zone 1B not compositional focus | [#647](https://github.com/PublicEnemage/worldsim/issues/647) | ✅ Closed — PR #651 (Zone 1B responsive width) |
+| IR-S7-002 | 🔴 CRITICAL | Zone 1B MDA alerts not visible in any screenshot | [#647](https://github.com/PublicEnemage/worldsim/issues/647) | ✅ Closed — PR #651 |
+| IR-S7-003 | 🟠 Significant | Zone 1D Four-Framework scorecard not legible at screenshot resolution | [#634](https://github.com/PublicEnemage/worldsim/issues/634) | ✅ Screenshot-resolution only; renders live |
+| IR-S7-004 | 🟠 Significant | PMM = 0.00 across all steps — analytically meaningless | [#648](https://github.com/PublicEnemage/worldsim/issues/648) | ✅ Closed — PR #650 (breach-exclusion fix) |
+| IR-S7-005 | 🟡 Minor | Choropleth visual dominance relative to Zone 1 — visual weight imbalance | [#342](https://github.com/PublicEnemage/worldsim/issues/342) | Open — M11 Option B (scenario-relative color scale) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds GitHub issue references to all five IR-S7 findings in the M10 stakeholder review, matching the M8 convention (`2026-05-18-v0.8.0-stakeholder-review.md`) of linking issues in both the finding header and body.

| Finding | Issue | Status |
|---|---|---|
| IR-S7-001 — Frame D compositional gap | [#647](https://github.com/PublicEnemage/worldsim/issues/647) | ✅ Closed — PR #651 |
| IR-S7-002 — Zone 1B alerts not visible | [#647](https://github.com/PublicEnemage/worldsim/issues/647) | ✅ Closed — PR #651 |
| IR-S7-003 — Zone 1D not legible at screenshot resolution | [#634](https://github.com/PublicEnemage/worldsim/issues/634) | ✅ Screenshot-resolution only; renders live |
| IR-S7-004 — PMM = 0.00 | [#648](https://github.com/PublicEnemage/worldsim/issues/648) | ✅ Closed — PR #650 |
| IR-S7-005 — Choropleth visual dominance | [#342](https://github.com/PublicEnemage/worldsim/issues/342) | Open — M11 Option B |

Also adds resolution notes for closed findings and updates the summary table to include Issue and Resolution columns (replacing the old Action column).

## Context

Raised by EL after noticing M10 review had no issue numbers, unlike the M8 review where every DEMO-NNN finding linked directly to a GitHub issue. Step 8 (file DEMO-NNN issues from review output) was skipped for M10 because the CRITICAL items were hotfixed directly. IR-S7-003 and IR-S7-005 had no dedicated issues filed — referenced to the demo prep umbrella (#634) and DEMO-001 root cause (#342) respectively.

## Test plan

- [ ] Each IR-S7 finding header ends with `— [#NNN](...)`
- [ ] Each IR-S7 finding body has a `- **GitHub Issue:**` line
- [ ] Summary table has Issue and Resolution columns
- [ ] All issue links resolve to real GitHub issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)