### PR TITLE
docs(adr): M10 exit license renewals — ADR-001/002/005/007/008/010

### DIFF
--- a/docs/adr/ADR-001-simulation-core-data-model.md
+++ b/docs/adr/ADR-001-simulation-core-data-model.md
@@ -6,16 +6,30 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-05-23 — M9 exit review. No renewal triggers fired during
+**Last Reviewed:** 2026-06-02 — M10 exit review (SCAN-024). No renewal triggers fired
+during Milestone 10. GovernanceModule promotion (`"governance"` removed from
+`_UNIMPLEMENTED_FRAMEWORKS`) is within the existing `MeasurementFramework` taxonomy
+(GOVERNANCE enum value existed since M6) and uses the existing Quantity-delta Event
+contract. Argentina 2000–2002 fixture uses existing `initial_attributes` wire format.
+PMM endpoint adds `pmm_value`/`pmm_direction` to the trajectory API response — these
+are application-layer fields, not `SimulationEntity.attributes` or `Quantity` type
+changes. Phase 1 benchmark script is a read-only measurement tool with no schema
+changes. No `MeasurementFramework` taxonomy modifications, no `DATA_STANDARDS.md` unit
+standard changes affecting attribute store design, no backtesting integrity rule changes
+requiring state representation changes. License Status confirmed CURRENT. License
+renewed through Milestone 11 — Engine Investigation and Political Economy. Next
+scheduled review at Milestone 11 close.
+
+**Previously reviewed:** 2026-05-23 — M9 exit review. No renewal triggers fired during
 Milestone 9. M9 was a documentation, standards, and process milestone — no simulation
 core data model changes, no `MeasurementFramework` taxonomy changes, no
 `DATA_STANDARDS.md` unit standard changes affecting attribute store design, no
 backtesting integrity rule changes requiring state representation changes. License
 Status confirmed CURRENT. License renewed through Milestone 10 — Engine Integrity and
-Instrument Delivery. Next scheduled review at Milestone 10 close.
+Instrument Delivery.
 
 **Previously reviewed:** 2026-05-19 — M8 exit review (SCAN-022). No renewal triggers
 fired during Milestone 8. M8 EcologicalModule boundary proximity normalization

--- a/docs/adr/ADR-002-input-orchestration-layer.md
+++ b/docs/adr/ADR-002-input-orchestration-layer.md
@@ -6,10 +6,25 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-05-23 — M9 exit review. No renewal triggers fired during
+**Last Reviewed:** 2026-06-02 — M10 exit review (SCAN-024). No renewal triggers fired
+during Milestone 10. GovernanceModule promotion uses existing `ControlInput` types and
+Quantity-delta Event contract — no new input channel types. `EMERGENCY_DECLARATION`
+added to the GovernanceModule's internal `EmergencyInstrument` enum; this is a module-
+internal simulation parameter, not a `ControlInput` type taxonomy addition (the
+orchestration layer's EmergencyPolicyInput already accommodates this via its `instruments`
+field). Argentina 2000–2002 fixture uses existing `EmergencyPolicyInput` and
+`FiscalPolicyInput` types — additive and backward-compatible. PMM endpoint and
+trajectory API extensions are read-path outputs, not input orchestration changes.
+Phase 1 benchmark script introduces no input contract changes. No `ControlInput` type
+taxonomy changes, no audit trail schema requirement changes, no uncertainty
+quantification standard additions affecting how events carry uncertainty metadata.
+License Status confirmed CURRENT. License renewed through Milestone 11 — Engine
+Investigation and Political Economy. Next scheduled review at Milestone 11 close.
+
+**Previously reviewed:** 2026-05-23 — M9 exit review. No renewal triggers fired during
 Milestone 9. M9 was a documentation, standards, and process milestone — no
 `ControlInput` type taxonomy changes, no audit trail schema requirement changes, no
 uncertainty quantification standard additions affecting how events carry uncertainty
@@ -17,7 +32,7 @@ metadata. ADR-007 (Synthetic Data Framework, accepted 2026-05-23) adds `is_synth
 and related fields to `Quantity` — these are Quantity schema extensions, not
 `ControlInput` type additions, and do not trigger this ADR's renewal. License Status
 confirmed CURRENT. License renewed through Milestone 10 — Engine Integrity and
-Instrument Delivery. Next scheduled review at Milestone 10 close.
+Instrument Delivery.
 
 **Previously reviewed:** 2026-05-19 — M8 exit review (SCAN-022). No renewal triggers
 fired during Milestone 8. EcologicalModule and GovernanceModule outputs use the

--- a/docs/adr/ADR-005-human-cost-ledger.md
+++ b/docs/adr/ADR-005-human-cost-ledger.md
@@ -6,8 +6,14 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-04-15 (date standards documents were established)
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** CURRENT
+
+**Amendment 5 applied:** 2026-06-02 — M10 GovernanceModule Promotion Confirmed.
+GovernanceModule promoted in M10: all five Decision M8-4 criteria met. `"governance"`
+removed from `_UNIMPLEMENTED_FRAMEWORKS`. Normalization obligation satisfied (Decision
+M8-4 Criterion 2). Integration test asserting non-null governance composite score written.
+License renewed through Milestone 11. See Amendment 5 section at end of document.
 
 **Amendment 4 applied:** 2026-05-23 — M9 Exit GovernanceModule Deferral.
 Formal M9 exit assessment: all five GovernanceModule promotion criteria remain at 0/5
@@ -2574,3 +2580,56 @@ be updated in the same commit as the GovernanceModule implementation work begins
 
 No renewal triggers fired during Milestone 9. The ADR remains sound as written through M10.
 Scheduled review at M10 close.
+
+---
+
+## Amendment 5 — M10 GovernanceModule Promotion Confirmed
+
+**Applied:** 2026-06-02
+**Issue:** #556
+**Author:** Engineering Lead
+**Scope:** Validity Context header update; M10 GovernanceModule promotion assessment;
+Decision M8-4 criteria closure; M9 obligations discharged confirmation.
+
+### M10 Exit Assessment — GovernanceModule Promotion Criteria
+
+Decision M8-4 established five promotion criteria for GovernanceModule. At M10 close,
+all five criteria are met:
+
+| Criterion | Status at M10 exit |
+|---|---|
+| 1. Backtesting threshold: governance scores produce backtesting results within the per-indicator error tolerance defined in `docs/DATA_STANDARDS.md §Backtesting Integrity` | **Met** — Argentina 2000–2002 Demo 3 fixture (Issue #553) includes governance axis with live composite score; governance MDA triggered at step 2 via `emergency_declaration` (Issue #615) |
+| 2. ADR amendment accepted formalizing the normalization methodology for governance composite score | **Met** — Normalization methodology resolved in M10 implementation: absolute threshold audit completed per Decision M8-4 obligation; governance composite uses percentile rank (no natural boundary thresholds identified at the specificity required for boundary proximity approach — see Issue #556 implementation notes) |
+| 3. Source field populated for all five indicator keys with `source_registry` draft-certified entry | **Met** — Source registry entries filed as part of GovernanceModule promotion work (Issue #556) |
+| 4. `[SIM-INTEGRITY]` WARNING fires when `compute()` receives unexpected null for any of the five indicator keys | **Met** — Implemented in GovernanceModule M10 promotion (single-entity note exemption fix included; Issue #556) |
+| 5. Integration test asserting that a scenario with real governance data produces a non-null governance composite score | **Met** — Argentina Demo 3 backtesting suite asserts non-null governance composite score across all live steps (Issue #553, PR #553) |
+
+**Outcome:** GovernanceModule promotion complete. `"governance"` removed from
+`_UNIMPLEMENTED_FRAMEWORKS`. Governance axis live as of M10.
+
+### M9 Obligations Discharged
+
+**M9 Governance Normalization Obligation** (carried from Amendment 4): Satisfied.
+Per-indicator absolute threshold audit completed before normalization methodology was
+specified. No boundary-anchored thresholds were found at the precision required for the
+boundary proximity strategy — percentile rank is the correct normalization for governance
+composite at this stage. The audit is documented in Issue #556.
+
+**Decision M8-5 Tooltip Update Obligation** (carried from Amendment 4): Satisfied.
+`_GOVERNANCE_IN_VALIDATION_TOOLTIP` replaced by live composite score in Zone 1D
+`FourFrameworkZone1D.tsx` — the `(in validation)` annotation (IR-005, Issue #499) was
+the transitional form and was removed when the live score was wired in M10.
+
+### Renewal Triggers — No New Triggers Added
+
+No new renewal triggers beyond those established in Decision 6 and prior amendments.
+
+### License Renewal
+
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
+**License Status:** CURRENT (renewed at M10 exit, 2026-06-02)
+
+No additional renewal triggers fired during Milestone 10 beyond the GovernanceModule
+promotion formalized in this amendment. ADR-005's core decisions governing the HCL
+output model, MDA threshold architecture, and multi-framework radar chart contract
+remain sound. Scheduled review at M11 close.

--- a/docs/adr/ADR-007-synthetic-data-framework.md
+++ b/docs/adr/ADR-007-synthetic-data-framework.md
@@ -6,8 +6,20 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-05-23
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** ACCEPTED — 2026-05-23
+
+**M10 exit review:** 2026-06-02 (SCAN-024). No renewal triggers fired during Milestone
+10. The synthetic data framework was not implemented in M10 — no sixth method proposed,
+holdout validation gate unchanged, confidence tier max() arithmetic unchanged, no
+meaninglessness threshold adjustments, no anomaly detection governance changes, no
+`Quantity` schema field renames. The PMM endpoint and trajectory API extensions are
+application-layer outputs that do not alter the `Quantity` schema fields enumerated in
+the renewal triggers. License Status confirmed ACCEPTED. License renewed through
+Milestone 11 — Engine Investigation and Political Economy. M11 political economy module
+will be the first consumer of synthetic data framework contracts for politically sensitive
+indicators — full implementation pressure expected in M11. Next scheduled review at
+Milestone 11 close.
 
 **Panel review:** 2026-05-23 — `docs/adr/reviews/ADR-007-panel-review.md`. Panel:
 Chief Methodologist (consultation complete, PR #373), Data Architect (conditional ✓),

--- a/docs/adr/ADR-008-ux-architecture.md
+++ b/docs/adr/ADR-008-ux-architecture.md
@@ -6,8 +6,22 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-05-22
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery (Demo 3)
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** ACCEPTED — 2026-05-22
+
+**M10 exit review:** 2026-06-02 (SCAN-024). No renewal triggers fired during Milestone
+10. All four Zone 1 instruments implemented per ADR-008 spec — implementation of the
+spec is not a trigger. Zone boundaries unchanged. `step_event_label` fix (Issue #395)
+standardised fixture content format; the field name, type, and schema contract are
+unchanged — not a trigger. Column width responsive fix (Issue #647) is an implementation
+detail within the existing ADR-008 layout contract. Simultaneous instrument update
+contract (AC-006 RTL test confirms all Zone 1 instruments update in a single render
+cycle) remains in force and unchanged. No mode transition, A/B comparison, blue/orange
+color, confidence tier visual, or methodology access model changes. License Status
+confirmed ACCEPTED. License renewed through Milestone 11 — Engine Investigation and
+Political Economy. M11 political economy module will introduce new conditionality
+instruments; any control plane or mode 3 changes must be evaluated against ADR-008
+renewal triggers at M11 exit. Next scheduled review at Milestone 11 close.
 
 **Panel (accepted):**
 - UX Designer Agent (C — UX frame and component decisions)

--- a/docs/adr/ADR-010-trajectory-view.md
+++ b/docs/adr/ADR-010-trajectory-view.md
@@ -6,8 +6,23 @@ Accepted
 ## Validity Context
 
 **Standards Version:** 2026-05-22
-**Valid Until:** Milestone 10 — Engine Integrity and Instrument Delivery (Demo 3)
+**Valid Until:** Milestone 11 — Engine Investigation and Political Economy
 **License Status:** ACCEPTED — 2026-05-22
+
+**M10 exit review:** 2026-06-02 (SCAN-024). No renewal triggers fired during Milestone
+10. TrajectoryView was fully implemented in M10 per ADR-010 decisions — implementation
+of the spec is not a trigger. Recharts/SVG rendering technology unchanged. The
+trajectory API endpoint (`GET /scenarios/{id}/trajectory`) was extended with
+`pmm_value` and `pmm_direction` fields for Zone 1C — these fields are not consumed by
+TrajectoryView and do not change the Zone 1A data contract (trajectory curves,
+confidence tiers, step annotations). Shared Zustand atom state architecture unchanged.
+Confidence tier visual rules (strokeDasharray, strokeOpacity) unchanged. Governance
+null rendered as absent curve, unchanged. No MDA floor overlay, A/B comparison, or
+policy/shock marker changes introduced. Minimum trajectory view width constants
+unchanged. License Status confirmed ACCEPTED. License renewed through Milestone 11 —
+Engine Investigation and Political Economy. If ADR-009 (computation model) results in
+streaming trajectory updates, the shared state architecture trigger must be evaluated.
+Next scheduled review at Milestone 11 close.
 
 **Panel (required for acceptance):**
 - Frontend Architect Agent (C — implementing agent, required per panel composition rule)


### PR DESCRIPTION
## Summary

M10 exit Standards License Audit — six ADRs renewed per M10 exit checklist (#261).

- **ADR-001** (Simulation Core Data Model) — CURRENT. No triggers fired. GovernanceModule promotion within existing taxonomy; PMM API extension is application-layer; Argentina fixture uses existing wire format. Valid Until → M11.
- **ADR-002** (Input Orchestration Layer) — CURRENT. No triggers fired. `EMERGENCY_DECLARATION` is a module-internal enum, not a `ControlInput` type addition. Valid Until → M11.
- **ADR-005** (Human Cost Ledger) — **Amendment 5** appended. GovernanceModule M10 promotion confirmed: all five Decision M8-4 criteria met (backtesting validated via Argentina Demo 3, normalization methodology resolved, source registry entries filed, `[SIM-INTEGRITY]` WARNING implemented, integration test written). Both M9 carry-forward obligations discharged (normalization audit complete, tooltip superseded by live score in Zone 1D). Valid Until → M11.
- **ADR-007** (Synthetic Data Framework) — ACCEPTED. No triggers fired. Framework not yet implemented in M10; no `Quantity` schema changes. Valid Until → M11.
- **ADR-008** (UX Architecture) — ACCEPTED. No triggers fired. `step_event_label` content fix ≠ schema rename; Zone 1 implementation per spec is not a trigger; simultaneous update contract confirmed by AC-006 RTL test. Valid Until → M11.
- **ADR-010** (Trajectory View) — ACCEPTED. No triggers fired. PMM API extension fields (`pmm_value`, `pmm_direction`) not consumed by TrajectoryView; Zone 1A data contract unchanged. Valid Until → M11.

## Test plan

- [ ] All six ADR files have `Valid Until: Milestone 11` in their Validity Context
- [ ] ADR-005 has `Amendment 5` appended at end of document with GovernanceModule promotion criteria table (5/5 met)
- [ ] ADR-005 Validity Context header shows `Amendment 5 applied: 2026-06-02`
- [ ] ADR-001/002 have new `Last Reviewed: 2026-06-02` paragraph before previous review entries
- [ ] ADR-007/008/010 have new `M10 exit review: 2026-06-02` paragraph in Validity Context

Closes M10 exit checklist Standards License Audit gate (Issue #261).

🤖 Generated with [Claude Code](https://claude.com/claude-code)