### PR TITLE
docs(demo): NM-032 + DEMO-018/019/020 — screenshot viewport mismatch and live application findings

### DIFF
--- a/docs/demo/m10/reviews/2026-06-03-v0.10.0-internal-review.md
+++ b/docs/demo/m10/reviews/2026-06-03-v0.10.0-internal-review.md
@@ -3,9 +3,15 @@
 ## Review Context
 
 - **Version reviewed:** v0.10.0 (Milestone 10 — Engine Integrity and Instrument Delivery)
-- **Review date:** 2026-06-03
+- **Review date:** 2026-06-03 (initial); supplemented 2026-06-03 after live application comparison
 - **Review type:** Step 6b — Internal Team Review (inaugural instance, Issue #663)
 - **Orchestrated by:** PM Agent
+- **Supplement note (2026-06-03):** Three additional findings (DEMO-018, DEMO-019, DEMO-020) were
+  identified by comparing a live application screenshot at Step 3/4 against the repository frame-c
+  artifact. This comparison revealed a process integrity gap: the Playwright screenshot spec captures
+  at 1280×720 while the live demo runs at 1440+ wide. DEMO-020 (y-axis glyph clipping) was visible
+  in the live application but invisible in both the repository artifact and the prior IR review.
+  Near-miss NM-032 filed. Fix tracked in Issue #675.
 - **Application note:** This review is being run retroactively for M10. The Step 6b process
   (Issue #663) was defined after the IR review (Step 7) and stakeholder session (Step 9)
   were already complete. Findings from this review cannot satisfy the pre-IR gate
@@ -466,22 +472,123 @@ Recommendation: Add to walkthrough Step 7 (or Step 6 narration): "The Human Deve
 
 ---
 
+---
+
+### Supplement — Live Application Comparison (2026-06-03)
+
+*Findings DEMO-018 through DEMO-020 were identified after comparing a live application
+screenshot (Step 3/4, Argentina scenario, captured at presenter display width >1440px) against
+the repository artifact frame-c-step3-divergence.png. All three findings were invisible in
+frame-c (captured at 1280×720 via Playwright default). See NM-032.*
+
+**Frontend Architect (supplement):**
+
+```
+[DEMO-018]: Zone 1A legend shows raw variable names for CI upper bound and active curves
+Severity: MEDIUM
+Screenshot ref: Live application Step 3/4 (frame-c artifact does not resolve this)
+What is shown: Zone 1A Recharts legend displays raw internal dataKey strings for ghost/CI
+  curves: "ecological_ci_upper", "financial_active", "financial_ci_upper",
+  "human_development_ci_upper". The four primary composite curves display correctly.
+  The getIndicatorDisplayNameAny() fix (PR #622, Issue #617) resolved the AttributeSelector
+  dropdown but did not cover Recharts legend entries for derived keys.
+What should be shown: CI upper bound curves should either be excluded from the legend
+  (legendType="none") or labeled with human-readable names ("[Framework] (upper bound)").
+  No raw underscore-delimited variable names should appear in any user-facing element.
+Recommendation: Pass legendType="none" on CI/ghost Line components, or pass explicit name
+  prop with plain-language labels. Regression: TrajectoryView Vitest tests must still pass.
+```
+
+**Customer Agent (supplement):**
+
+```
+[DEMO-019]: PMM None state ("—") has no explanation for non-specialist users
+Severity: MEDIUM
+Screenshot ref: Live application Step 3/4 (Zone 1C)
+What is shown: Zone 1C displays "—" with label "Policy Manoeuvre Margin — historical."
+  PMM is correctly None because all thresholds are breached (ecological TERMINAL + governance
+  CRITICAL per PR #650 breach-exclusion fix). No contextual text explains WHY the value
+  is absent.
+What should be shown: A non-specialist cannot distinguish "margin fully exhausted" from
+  "not computed," "data unavailable," or "rendering error." When PMM is None due to
+  all-thresholds-breached, Zone 1C should display a brief contextual label: "All thresholds
+  breached — see alerts" or equivalent.
+Recommendation: UX copy change only — no backend change. Add a conditional sub-label in
+  PMMWidgetZone1C.tsx that renders when pmm_value is null. Distinct from DEMO-016
+  (nonzero PMM precision); this is about intelligibility when the value is absent.
+```
+
+**Frontend Architect (supplement — y-axis clipping):**
+
+```
+[DEMO-020]: Zone 1A y-axis tick labels clipped at left component boundary
+Severity: MEDIUM
+Screenshot ref: Live application Step 3/4 (Zone 1A top-left)
+What is shown: The leftmost character of the top y-axis tick label is outside the Recharts
+  ComposedChart's paint boundary. The full value (approximately 1.0577 given the ecological
+  score of 1.06 at Step 3) renders as ".0577" — the leading "1" is clipped. This is a
+  Recharts margin.left configuration issue: the left margin is too narrow for 6-character
+  tick labels when the ecological composite exceeds 1.0.
+What should be shown: All y-axis tick labels fully visible within the Zone 1A component
+  boundary at 1440×900 and above.
+Recommendation: Increase margin.left on the ComposedChart in TrajectoryView.tsx to
+  48–56px, or format tick labels to fixed 4-character precision to reduce label width.
+  Confirm with demo-legibility.spec.ts at 1440×900 after fix.
+Why this was missed: Invisible at 1280×720 (Playwright default capture viewport). Both
+  the internal panel (Step 6b) and the IR Agent (Step 7) reviewed 1280×720 artifacts.
+  See NM-032.
+```
+
+---
+
 ## PM Agent — Consolidated Summary
 
 | Finding ID | Agent | Severity | One-line description | Status |
 |---|---|---|---|---|
-| DEMO-010 | Frontend Architect | MEDIUM | Repository screenshots unverified as post-fix state | Needs attestation or re-capture |
-| DEMO-011 | Frontend Architect | MEDIUM | Frame D not visually distinguishable from Frame C in repository artifacts | Needs re-capture before M12 |
+| DEMO-010 | Frontend Architect | MEDIUM | Repository screenshots unverified as post-fix state | Issue #667 filed |
+| DEMO-011 | Frontend Architect | MEDIUM | Frame D not visually distinguishable from Frame C in repository artifacts | Issue #668 filed |
 | DEMO-012 | UX Designer | LOW | Zone 1A legend text too small for projected-display legibility | Narration note required |
-| DEMO-013 | UX Design Thinking | MEDIUM | Dashed curve convention not narrated — screenshot brief requirement unimplemented | Walkthrough update required |
+| DEMO-013 | UX Design Thinking | MEDIUM | Dashed curve convention not narrated — screenshot brief requirement unimplemented | Issue #669 filed |
 | DEMO-014 | Customer Agent | LOW | Zone 1C PMM widget has no plain-language label visible at demo scale | Verify live; M11 enhancement if absent |
 | DEMO-015 | QA Lead | LOW | AC-013 "(exp)" confidence marker not verifiable at demo screenshot resolution | Verify live; M11 legibility enhancement if absent |
 | DEMO-016 | Chief Methodologist | LOW | PMM precision at tight governance margin may overstate certainty | Narration note required |
-| DEMO-017 | Development Economist | MEDIUM | Human Development composite trajectory not narrated — human cost arc absent from walkthrough | Walkthrough update required |
+| DEMO-017 | Development Economist | MEDIUM | Human Development composite trajectory not narrated — human cost arc absent from walkthrough | Issue #670 filed |
+| DEMO-018 | Frontend Architect (supplement) | MEDIUM | Zone 1A legend shows raw variable names for CI upper bound and active curves | Issue #672 filed |
+| DEMO-019 | Customer Agent (supplement) | MEDIUM | PMM None state ("—") has no explanation for non-specialist users | Issue #673 filed |
+| DEMO-020 | Frontend Architect (supplement) | MEDIUM | Zone 1A y-axis tick labels clipped at left component boundary | Issue #674 filed |
 
 **Acknowledged existing findings (not new):**
 - IR-S7-003 (Significant): Zone 1D not legible at screenshot resolution — confirmed renders live.
 - IR-S7-005 (Minor, open): Choropleth visual dominance — tracked in #342, M11 Option B.
+
+---
+
+## Process Integrity Note
+
+The three supplement findings (DEMO-018, DEMO-019, DEMO-020) were not found by either the
+internal panel or the IR Agent. The root cause is structural, not an oversight by any reviewer:
+
+**The screenshots reviewed by the panel and IR Agent were captured at 1280×720. The live
+application renders at 1440+ wide. These are different visual artifacts.**
+
+Specifically:
+- `demo-narrated.spec.ts` inherits the Playwright config default of 1280×720 and has no
+  `page.setViewportSize()` call.
+- `demo-legibility.spec.ts` runs every assertion at 1440×900 — but this spec does not produce
+  the screenshots that go to the review chain.
+- `demo-narrated.spec.ts` line 42 still references `docs/demo/m8/screenshots/` — the M10
+  screenshots were captured by an undocumented mechanism, not by running the current spec.
+
+The legibility gate (Step 5b) passed cleanly for M10. This means the application is legible
+at 1440×900. But the screenshots sent to reviewers were at 1280×720. The gate validated a
+viewport that no reviewer saw.
+
+**Near-miss filed:** NM-032. Fix tracked in Issue #675 (M11, near-term).
+
+The process improvement required: the demo spec must set `page.setViewportSize({ width: 1440,
+height: 900 })` before each capture, and the demo-preparation-standard must explicitly state
+that the capture viewport must match the legibility gate viewport. See NM-032 for the full
+process improvement specification.
 
 ---
 
@@ -494,18 +601,21 @@ inform M12 preparation.
 
 **CRITICAL findings:** None.
 
-**MEDIUM findings requiring GitHub issues (DEMO-010, DEMO-011, DEMO-013, DEMO-017):**
+**MEDIUM findings — all filed as GitHub issues:**
 
-| Finding | Action | Target |
-|---|---|---|
-| DEMO-010 | Attest screenshot state; re-capture if pre-fix | M10 remaining work |
-| DEMO-011 | Re-capture Frame D post-fix | Before M12 demo cycle |
-| DEMO-013 | Add dashed curve narration to walkthrough | Before M12 demo cycle |
-| DEMO-017 | Add HD composite narration to walkthrough | Before M12 demo cycle |
+| Finding | Issue | Action | Target |
+|---|---|---|---|
+| DEMO-010 | #667 | Attest screenshot state; re-capture if pre-fix | Before M12 demo cycle |
+| DEMO-011 | #668 | Re-capture Frame D post-fix | Before M12 demo cycle |
+| DEMO-013 | #669 | Add dashed curve narration to walkthrough | Before M12 demo cycle |
+| DEMO-017 | #670 | Add HD composite narration to walkthrough | Before M12 demo cycle |
+| DEMO-018 | #672 | Fix CI legend raw names in TrajectoryView | M11 |
+| DEMO-019 | #673 | Add PMM None state contextual label | M11 |
+| DEMO-020 | #674 | Fix Zone 1A y-axis glyph clipping (margin.left) | M11 |
 
 **LOW findings (DEMO-012, DEMO-014, DEMO-015, DEMO-016):**
-File at PM Agent discretion. Recommended: file DEMO-013 and DEMO-017 in the same PR as the
-walkthrough updates (they are both walkthrough changes). File DEMO-014 and DEMO-015 as M11
+File at PM Agent discretion. Narration notes for DEMO-012 and DEMO-016 should accompany
+the walkthrough update PRs for DEMO-013 and DEMO-017. DEMO-014 and DEMO-015 are M11
 investigation items.
 
 ---

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -1746,6 +1746,89 @@ was not captured in naming guidance at all.
 
 ---
 
+## NM-032 — Demo Screenshot Capture Viewport (1280×720) Mismatches Live Demo and Legibility Gate (1440×900) (Reactive)
+
+**Date:** 2026-06-03
+**Milestone:** M10 — Engine Integrity and Instrument Delivery
+**Detected by:** Engineering Lead — live application comparison against repository artifacts
+**Severity:** High
+
+### What happened
+
+`demo-narrated.spec.ts` captures screenshots at the Playwright config default viewport of
+**1280×720** (`playwright.config.ts` line 15: `viewport: { width: 1280, height: 720 }`).
+The spec has no `page.setViewportSize()` call — it inherits the global default.
+
+The legibility gate (`demo-legibility.spec.ts`) runs every assertion at **1440×900**
+via `page.setViewportSize({ width: 1440, height: 900 })`. The live demo presentation
+runs at the presenter's display width (typically ≥1440px).
+
+This produces a three-way mismatch:
+
+| Layer | Viewport |
+|---|---|
+| Demo screenshot capture (review artifacts) | 1280×720 |
+| Legibility gate (Step 5b) | 1440×900 |
+| Live demo / stakeholder presentation | Presenter display (≥1440px) |
+
+A second gap: `demo-narrated.spec.ts` line 42 still reads
+`SCREENSHOT_DIR = path.resolve(__dirname, "../../../docs/demo/m8/screenshots/")`.
+Step 4 of `demo-preparation-standard.md` requires updating screenshot output paths to
+`docs/demo/m{N}/screenshots/` each milestone. This was not done for M10. The M10
+screenshots in `docs/demo/m10/screenshots/` were captured by an undocumented mechanism,
+not by running the current spec.
+
+### What was at risk
+
+**Review chain integrity.** The IR Agent (Step 7) and the internal panel (Step 6b) reviewed
+1280×720 artifacts. The stakeholder saw a 1440+ wide rendering. Viewport-dependent rendering
+defects are invisible to the review chain. Three findings from this session confirm the
+consequence:
+
+- **DEMO-020** (y-axis glyph clipping, Issue #674): first digit of y-axis tick labels clipped
+  at left component boundary. Invisible at 1280×720; visible at 1440+. Neither the internal
+  panel nor the IR Agent could have found it.
+- **DEMO-018** (CI legend raw variable names, Issue #672): raw Recharts dataKey strings visible
+  in Zone 1A legend. Visibility affected by viewport — not clearly readable at 1280×720.
+- **DEMO-019** (PMM None state, Issue #673): identified only after viewing the live application.
+
+The legibility gate (Step 5b) validates that the application is legible — but the gate's
+1440×900 rendering is never stored as the screenshot artifact. The gate that validates
+quality and the process that produces review artifacts are structurally decoupled. A clean
+legibility gate does not guarantee the screenshots going to the IR are at the validated
+viewport.
+
+### What caught it
+
+Engineering Lead direct comparison of a live application screenshot (captured at presenter
+display width, >1440px) against the repository frame-c artifact. The y-axis clipping in the
+live screenshot was the precipitating observation — the finding was absent from all prior
+review outputs despite being visible and prominent in the live application.
+
+### Process improvement
+
+**Issue #675 filed** for the following required fixes (M11):
+
+1. Add `page.setViewportSize({ width: 1440, height: 900 })` at the start of each screenshot
+   capture block in `demo-narrated.spec.ts`. Do not rely on `playwright.config.ts` default.
+
+2. Update `SCREENSHOT_DIR` in `demo-narrated.spec.ts` to `docs/demo/m{N}/screenshots/` each
+   milestone — treat this as a mandatory Step 4 deliverable with its own checkbox.
+
+3. Update `demo-preparation-standard.md §Step 4` to state explicitly: "Set capture viewport
+   to 1440×900 via `page.setViewportSize()` — do not rely on the playwright.config.ts default."
+
+4. Update `demo-preparation-standard.md §Step 6` to add a pre-capture gate: "Confirm the
+   spec's capture viewport matches the legibility gate viewport (1440×900) before running
+   `./scripts/demo.sh --run`."
+
+**Root cause:** The demo preparation standard established the legibility gate (Step 5b) as a
+quality check but did not specify the capture viewport for Step 6. The implicit assumption was
+that the screenshot spec and the legibility spec used the same viewport. They did not. No
+gate existed to detect the mismatch.
+
+---
+
 ## Registry Maintenance
 
 ### How to add an entry


### PR DESCRIPTION
## Summary

- **NM-032** filed in near-miss registry: `demo-narrated.spec.ts` captures screenshots at 1280×720 (Playwright config default); legibility gate runs at 1440×900; live demo presents at ≥1440px. The review chain reviewed a different rendering than the stakeholder sees. `SCREENSHOT_DIR` also still references `m8/screenshots/` — M10 screenshots were captured by an undocumented mechanism. Fix tracked in Issue #675.
- **M10 internal review artifact** updated with three supplement findings and a Process Integrity Note documenting the structural root cause.

## New findings (from live application comparison)

| Finding | Issue | Agent | Severity | Description |
|---|---|---|---|---|
| DEMO-018 | #672 | Frontend Architect | MEDIUM | Zone 1A legend shows raw CI/active curve variable names — `getIndicatorDisplayNameAny()` fix (#617) covered AttributeSelector, not Recharts legend |
| DEMO-019 | #673 | Customer Agent | MEDIUM | PMM `"—"` (None state) has no contextual explanation — non-specialist cannot distinguish "margin exhausted" from "not computed" |
| DEMO-020 | #674 | Frontend Architect | MEDIUM | Zone 1A y-axis tick labels clipped at left boundary — `margin.left` too narrow for 6-char labels when ecological score >1.0; invisible at 1280×720 |

## What the discrepancy points to

DEMO-020 (y-axis glyph clipping) was visible and prominent in the live application. Neither the internal panel nor the IR Agent found it. The reason is structural: the review chain reviews 1280×720 Playwright captures; the stakeholder sees 1440+ wide. The legibility gate validates 1440×900 but its output is never stored as the screenshot artifact. These are two different visual artifacts being treated as one.

## Test plan

- [ ] NM-032 entry appears in near-miss registry after DEMO-031 — in sequence
- [ ] Internal review artifact header updated with supplement note and 2026-06-03 supplement date
- [ ] Summary table has all 11 findings (DEMO-010 through DEMO-020) with issue numbers
- [ ] Process Integrity Note section present in artifact
- [ ] Gate Status table updated with DEMO-018/019/020 issue references

🤖 Generated with [Claude Code](https://claude.com/claude-code)