### PR TITLE
ci: Docker Python 3.12 → 3.13 — version guard matches pyproject.toml (closes #375)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 12):  # noqa: UP036 — operational guard for stale Docker images
+if sys.version_info < (3, 13):  # noqa: UP036 — operational guard for stale Docker images
     raise RuntimeError(
-        f"Python 3.12+ required; running {sys.version}. "
+        f"Python 3.13+ required; running {sys.version}. "
         "Rebuild the Docker image: docker compose build api"
     )
 


### PR DESCRIPTION
## Summary

- `backend/Dockerfile`: `FROM python:3.12-slim` → `FROM python:3.13-slim`
- `backend/app/main.py`: startup version guard raised from `(3, 12)` to `(3, 13)`

## Root cause

PR #564 (2026-05-31) upgraded `pyproject.toml`, `.python-version`, and `ci.yml` to Python 3.13, but did not update `Dockerfile` or the `main.py` startup guard. The two sources of truth drifted — any contributor building the Docker image would get a 3.12 container while the project requires 3.13. The startup guard would not fire on the stale image since it only checked `< (3, 12)`.

## Test

- Ruff: clean
- Existing backend unit tests unchanged (no logic change)
- Closes #375

## ADRs affected

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)