### PR TITLE
docs(roadmap): M11 primary/stretch-goal reframe — matrix engine primary, political economy stretch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — WorldSim Project Context
 
 > Last significant revision: 2026-05-30
-> Updated against: M10 kickoff — M9 closed (v0.9.0); M10 current; M11 next; ADR-007 accepted; GovernanceModule #556 in M10; Argentina #553 confirmed; GitHub milestone titles/descriptions corrected
+> Updated against: M11 active — M10 closed (v0.10.0); M11 current; M12 next; ADR-007 accepted; matrix engine investigation is primary M11 objective; political economy module is M11 stretch goal (EL decision 2026-06-03)
 > Previous version context: M9 exit (2026-05-23) — M9 Standards Foundation current, M10 next, ADR-007 forthcoming
 
 ## What This Project Is:
@@ -270,15 +270,22 @@ Detailed domain profiles: `docs/agents/domain-intelligence-council.md`
 
 ## What We Are Building First
 
-M0–M9 complete (v0.1.0–v0.9.0). ADRs 001–007 current.
+M0–M10 complete (v0.1.0–v0.10.0). ADRs 001–007 current.
 See GitHub Releases for full delivery history.
 
-**Milestone 10 — Engine Integrity and Instrument Delivery (Current)**
-- Instrument cluster redesign — all four Zone 1 axes live with real data
-- GovernanceModule promoted — governance axis live (five ADR-005 criteria; Issue #556)
-- PMM (Policy Manoeuvre Margin) live computation
-- Argentina 2000–2002 second country fixture (Demo 3; Issue #553)
-- Phase 1 engine baseline benchmarks — prerequisite for ADR-009 (Issue #514)
+**Milestone 11 — Engine Investigation and Political Economy (Current)**
+
+*Primary objective (M11 exit gate):*
+- ADR-009 authored and accepted — simulation engine computation model
+- Sparse matrix proof-of-concept — matrix engine running alongside iterative engine
+- Phase 2 A/B validation — output equivalence, performance comparison, full backtesting suite
+- Matrix interpretability tooling — contribution tracing, transformation visualization
+
+*Stretch goal (ships if primary is complete with capacity remaining):*
+- Political economy module — political feasibility constraints, conditionality modelling, elite capture dynamics
+- Carries to M12 if not started in M11
+
+M11 closes when the matrix engine investigation track is complete. The political economy module does not block M11 closure. EL decision 2026-06-03.
 
 Each milestone is a vertical slice — working software at every stage,
 not infrastructure waiting for features.
@@ -287,15 +294,16 @@ not infrastructure waiting for features.
 
 ## Milestone Roadmap
 
-M0–M9 complete (v0.1.0–v0.9.0). M10 current. See GitHub Releases for full delivery history.
+M0–M10 complete (v0.1.0–v0.10.0). M11 current. See GitHub Releases for full delivery history.
 
-The full roadmap covering M10 through M13 — milestone deliverables, demo anchors, canonical users served, and the long-term resolution spectrum direction — is maintained at `docs/roadmap/worldsim-roadmap.md`. That document is the canonical reference. The summary below reflects current and next milestone only.
+The full roadmap covering M11 through M13 — milestone deliverables, demo anchors, canonical users served, and the long-term resolution spectrum direction — is maintained at `docs/roadmap/worldsim-roadmap.md`. That document is the canonical reference. The summary below reflects current and next milestone only.
 
-**Milestone 10 — Engine Integrity and Instrument Delivery (Current)**
-Core deliverable: Instrument cluster redesign implemented, all four radar axes live with real data, GovernanceModule promoted, Argentina 2000–2002 second country fixture. Demo 3.
+**Milestone 11 — Engine Investigation and Political Economy (Current)**
+Primary objective: ADR-009 (simulation engine computation model), sparse matrix proof-of-concept, Phase 2 A/B validation, matrix interpretability tooling. No demo. M11 closes when the matrix engine investigation track is complete.
+Stretch goal: Political economy module (conditionality, political feasibility, elite capture) — ships if primary objective is complete with capacity remaining; otherwise carries to M12. EL decision 2026-06-03.
 
-**Milestone 11 — Engine Investigation and Political Economy (Next)**
-Core deliverable: ADR-009 (simulation engine computation model), sparse matrix proof-of-concept, political economy module (conditionality, political feasibility, elite capture). No demo.
+**Milestone 12 — Active Control and External Sector (Next)**
+Core deliverable: Matrix computation engine in production, external sector module, Mode 3 (Active Control). Demo 4.
 
 Full roadmap: `docs/roadmap/worldsim-roadmap.md`
 

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -110,9 +110,13 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 
 ### Milestone 11 — Engine Investigation and Political Economy *(no demo)*
 
-**Core deliverable:** A complete empirical understanding of the simulation engine's performance characteristics, a proof-of-concept matrix engine running in parallel with the iterative engine, and the political economy module that serves the Argentina and Ukraine/Pakistan marquee cases.
+**Primary objective:** A complete empirical understanding of the simulation engine's performance characteristics and a validated proof-of-concept matrix engine running in parallel with the iterative engine. M11 closes when the matrix engine investigation track is complete — the political economy module does not block M11 closure.
 
-**What ships:**
+**Stretch goal:** Political economy module — political feasibility constraints, conditionality modelling, elite capture dynamics, coalition stability. Ships in M11 if the primary objective is complete with milestone capacity remaining. If not started in M11, carries to M12.
+
+**Rationale (EL decision 2026-06-03):** Both tracks were originally listed as co-equal M11 deliverables. The PM Agent flagged the risk that both cannot realistically ship in the same milestone alongside ADR-009 authoring, which is itself time-intensive research work. The sparse matrix investigation is the foundational architectural decision; the political economy module is additive domain coverage. When scope must be reduced, reduce analytical sophistication before reducing architectural integrity.
+
+**What ships — Primary (M11 exit gate):**
 
 *Matrix engine investigation (Chief Engineer owned):*
 - Phase 1 baseline benchmarks — [moved to M10, Issue #514 (horizon:immediate), per NM-020 2026-05-25; ADR-009 authoring depends on M10 benchmark results before matrix investigation begins]
@@ -121,6 +125,8 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 - Phase 2 A/B validation — output equivalence to Decimal precision, performance comparison on identical hardware, full backtesting suite passing identically on both engines
 - Matrix interpretability tooling — contribution tracing, transformation visualization, computation anomaly detection (separate alert channel from MDA threshold system)
 - Phase 3 stress test suite — load levels 1x through 1000x on target hardware. Permanent test infrastructure artifact.
+
+**What ships — Stretch goal (ships if primary is complete):**
 
 *Political economy module:*
 - Political feasibility constraints as scenario inputs
@@ -132,7 +138,7 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 
 **Canonical user primarily served:** The Chief Engineer and Architect Agent — M11 is primarily an internal architectural milestone whose outputs enable M12.
 
-**What M11 does not do:** M11 does not migrate the production engine. The iterative engine remains in production at M11 close. The matrix engine is a validated proof-of-concept, not a replacement. Production migration is M12.
+**What M11 does not do:** M11 does not migrate the production engine. The iterative engine remains in production at M11 close. The matrix engine is a validated proof-of-concept, not a replacement. Production migration is M12. M11 does not guarantee political economy module delivery — that delivery depends on capacity remaining after the primary objective is complete.
 
 ---
 


### PR DESCRIPTION
## Summary

EL decision (2026-06-03): the sparse matrix engine investigation is the primary M11 objective. The political economy module is the M11 stretch goal. M11 closes when the matrix engine track is complete — political economy does not block M11 closure and carries to M12 if not started.

## Files changed

- **`CLAUDE.md`**: Header updated (M10 → M11 active), `§What We Are Building First` rewritten with primary/stretch structure, `§Milestone Roadmap` updated, M12 summary added
- **`docs/roadmap/worldsim-roadmap.md`**: §Milestone 11 fully rewritten — `Primary objective` section, `Stretch goal` section, explicit `Rationale` block (EL decision, PM Agent risk flag, guiding principle: architectural integrity before analytical sophistication), `What M11 does not do` extended
- **GitHub milestone #12** (Milestone 11): description updated via API — same primary/stretch framing, visible to all contributors on the Issues board

## Rationale

PM Agent flagged that both tracks — matrix engine investigation and political economy module — cannot realistically ship alongside ADR-009 authoring in the same milestone. ADR-009 is itself time-intensive research work. The sparse matrix investigation is the foundational architectural decision that gates M12. The political economy module is additive domain coverage that can start whenever matrix track is done or carry to M12 intact.

When scope must be reduced: reduce analytical sophistication before architectural integrity.

## ADRs affected

None. This is scope prioritization, not an architectural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)