### PR TITLE
test(g1): STOCK/FLOW delta path, EmergencyPolicy contract, MDA threshold integration

### DIFF
--- a/backend/tests/unit/test_apply_delta_contract.py
+++ b/backend/tests/unit/test_apply_delta_contract.py
@@ -1,0 +1,224 @@
+"""
+STOCK/FLOW delta path contract tests — Issue #374.
+
+apply_delta() is the single boundary where VariableType semantics are
+enforced. Misclassification between STOCK and FLOW produces silent
+accumulation errors that are only visible after several simulation steps.
+These tests are required before any simulation module with STOCK variables
+ships (DATA_STANDARDS.md §STOCK/FLOW delta path gate).
+
+Contract under test (SimulationEntity.apply_delta):
+  STOCK       — replaces existing value unconditionally (delta is absolute level)
+  FLOW        — adds delta to existing; initialises from delta if absent
+  RATIO       — same additive semantics as FLOW
+  DIMENSIONLESS — same additive semantics as FLOW
+  confidence_tier — max(existing, delta) on accumulation (lower-of-two-quality rule)
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.engine.models import MeasurementFramework, SimulationEntity
+from app.simulation.engine.quantity import Quantity, VariableType
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _entity(attrs: dict[str, tuple[Decimal, VariableType]] | None = None) -> SimulationEntity:
+    """Return a minimal country entity with optional pre-seeded attributes."""
+    attribute_map: dict[str, Quantity] = {}
+    for key, (val, vtype) in (attrs or {}).items():
+        attribute_map[key] = Quantity(
+            value=val,
+            unit="dimensionless",
+            variable_type=vtype,
+            measurement_framework=MeasurementFramework.FINANCIAL,
+            confidence_tier=1,
+        )
+    return SimulationEntity(
+        id="TST",
+        entity_type="country",
+        attributes=attribute_map,
+        metadata={},
+    )
+
+
+def _qty(
+    value: float,
+    variable_type: VariableType,
+    confidence_tier: int = 1,
+) -> Quantity:
+    return Quantity(
+        value=Decimal(str(value)),
+        unit="dimensionless",
+        variable_type=variable_type,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=confidence_tier,
+    )
+
+
+# ---------------------------------------------------------------------------
+# STOCK semantics — replacement
+# ---------------------------------------------------------------------------
+
+
+def test_stock_replaces_existing_value() -> None:
+    entity = _entity({"debt_outstanding": (Decimal("500"), VariableType.STOCK)})
+    entity.apply_delta("debt_outstanding", _qty(600.0, VariableType.STOCK))
+    result = entity.get_attribute_value("debt_outstanding")
+    assert result == Decimal("600")
+
+
+def test_stock_replaces_with_lower_value() -> None:
+    entity = _entity({"debt_outstanding": (Decimal("500"), VariableType.STOCK)})
+    entity.apply_delta("debt_outstanding", _qty(100.0, VariableType.STOCK))
+    assert entity.get_attribute_value("debt_outstanding") == Decimal("100")
+
+
+def test_stock_initialises_absent_attribute() -> None:
+    entity = _entity()
+    entity.apply_delta("reserves", _qty(8.5, VariableType.STOCK))
+    assert entity.get_attribute_value("reserves") == Decimal("8.5")
+
+
+def test_stock_second_delta_replaces_first() -> None:
+    """Two STOCK deltas on the same key: last one wins, no accumulation."""
+    entity = _entity()
+    entity.apply_delta("reserves", _qty(10.0, VariableType.STOCK))
+    entity.apply_delta("reserves", _qty(20.0, VariableType.STOCK))
+    assert entity.get_attribute_value("reserves") == Decimal("20")
+
+
+# ---------------------------------------------------------------------------
+# FLOW semantics — additive accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_flow_accumulates_on_existing() -> None:
+    entity = _entity({"gdp_growth": (Decimal("0.03"), VariableType.FLOW)})
+    entity.apply_delta("gdp_growth", _qty(-0.05, VariableType.FLOW))
+    result = entity.get_attribute_value("gdp_growth")
+    assert result == Decimal("0.03") + Decimal("-0.05")
+
+
+def test_flow_initialises_absent_attribute() -> None:
+    entity = _entity()
+    entity.apply_delta("gdp_growth", _qty(0.02, VariableType.FLOW))
+    assert entity.get_attribute_value("gdp_growth") == Decimal("0.02")
+
+
+def test_flow_multiple_deltas_accumulate() -> None:
+    entity = _entity()
+    entity.apply_delta("exports", _qty(10.0, VariableType.FLOW))
+    entity.apply_delta("exports", _qty(5.0, VariableType.FLOW))
+    entity.apply_delta("exports", _qty(-3.0, VariableType.FLOW))
+    assert entity.get_attribute_value("exports") == Decimal("12")
+
+
+# ---------------------------------------------------------------------------
+# RATIO semantics — same additive semantics as FLOW
+# ---------------------------------------------------------------------------
+
+
+def test_ratio_accumulates_on_existing() -> None:
+    entity = _entity({"debt_gdp_ratio": (Decimal("1.2"), VariableType.RATIO)})
+    entity.apply_delta("debt_gdp_ratio", _qty(0.1, VariableType.RATIO))
+    assert entity.get_attribute_value("debt_gdp_ratio") == Decimal("1.3")
+
+
+def test_ratio_initialises_absent_attribute() -> None:
+    entity = _entity()
+    entity.apply_delta("debt_gdp_ratio", _qty(0.8, VariableType.RATIO))
+    assert entity.get_attribute_value("debt_gdp_ratio") == Decimal("0.8")
+
+
+# ---------------------------------------------------------------------------
+# DIMENSIONLESS semantics — same additive semantics as FLOW
+# ---------------------------------------------------------------------------
+
+
+def test_dimensionless_accumulates_on_existing() -> None:
+    entity = _entity({"democratic_quality_score": (Decimal("0.72"), VariableType.DIMENSIONLESS)})
+    entity.apply_delta("democratic_quality_score", _qty(-0.05, VariableType.DIMENSIONLESS))
+    result = entity.get_attribute_value("democratic_quality_score")
+    assert result == pytest.approx(Decimal("0.67"), abs=Decimal("0.000001"))
+
+
+def test_dimensionless_initialises_absent_attribute() -> None:
+    entity = _entity()
+    entity.apply_delta("rule_of_law_percentile", _qty(45.0, VariableType.DIMENSIONLESS))
+    assert entity.get_attribute_value("rule_of_law_percentile") == Decimal("45")
+
+
+# ---------------------------------------------------------------------------
+# Confidence tier — lower-of-two-quality rule (max of tier numbers)
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_tier_uses_max_on_accumulation() -> None:
+    """Lower-of-two-quality rule: result confidence_tier = max(existing, delta)."""
+    entity = _entity()
+    # Seed with tier-1 (highest quality)
+    entity.attributes["gdp_growth"] = Quantity(
+        value=Decimal("0.03"),
+        unit="dimensionless",
+        variable_type=VariableType.FLOW,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=1,
+    )
+    # Accumulate a tier-3 delta (lower quality)
+    delta = Quantity(
+        value=Decimal("-0.01"),
+        unit="dimensionless",
+        variable_type=VariableType.FLOW,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=3,
+    )
+    entity.apply_delta("gdp_growth", delta)
+    assert entity.attributes["gdp_growth"].confidence_tier == 3
+
+
+def test_confidence_tier_unchanged_when_delta_is_higher_quality() -> None:
+    """If delta tier < existing tier, result keeps the lower quality (higher number)."""
+    entity = _entity()
+    entity.attributes["gdp_growth"] = Quantity(
+        value=Decimal("0.03"),
+        unit="dimensionless",
+        variable_type=VariableType.FLOW,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=4,
+    )
+    delta = Quantity(
+        value=Decimal("0.01"),
+        unit="dimensionless",
+        variable_type=VariableType.FLOW,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=1,
+    )
+    entity.apply_delta("gdp_growth", delta)
+    assert entity.attributes["gdp_growth"].confidence_tier == 4
+
+
+def test_stock_replacement_takes_delta_confidence_tier() -> None:
+    """STOCK replace: result tier comes from the delta, not the prior value."""
+    entity = _entity()
+    entity.attributes["reserves"] = Quantity(
+        value=Decimal("10"),
+        unit="dimensionless",
+        variable_type=VariableType.STOCK,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=1,
+    )
+    delta = Quantity(
+        value=Decimal("15"),
+        unit="dimensionless",
+        variable_type=VariableType.STOCK,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=3,
+    )
+    entity.apply_delta("reserves", delta)
+    assert entity.attributes["reserves"].confidence_tier == 3

--- a/backend/tests/unit/test_emergency_policy_integration.py
+++ b/backend/tests/unit/test_emergency_policy_integration.py
@@ -1,0 +1,196 @@
+"""
+EmergencyPolicyInput → GovernanceModule event_type contract — Issue #642.
+
+Root cause of NM-029: EmergencyPolicyInput.to_events() emits
+  event_type = "emergency_policy_{instrument.value}"
+GovernanceModule._SUBSCRIBED_EVENTS must contain the exact same strings.
+25 unit tests passed with wrong synthetic event_type strings because no
+test verified the adapter → subscriber contract end-to-end.
+
+These tests cross the boundary: EmergencyPolicyInput produces an Event;
+GovernanceModule receives it. The contract is structural — if the string
+in to_events() diverges from _SUBSCRIBED_EVENTS, governance effects
+silently disappear. This is the highest-severity near-miss class in the
+engine: silent wrong result, not a crash.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.engine.models import (
+    MeasurementFramework,
+    ResolutionConfig,
+    ScenarioConfig,
+    SimulationEntity,
+    SimulationState,
+)
+from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.modules.governance.module import _SUBSCRIBED_EVENTS, GovernanceModule
+from app.simulation.orchestration.inputs import EmergencyInstrument, EmergencyPolicyInput
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_TIMESTEP = datetime(2001, 12, 19, tzinfo=UTC)
+
+
+def _input(instrument: EmergencyInstrument) -> EmergencyPolicyInput:
+    return EmergencyPolicyInput(
+        target_entity="ARG",
+        actor_id="test-actor",
+        instrument=instrument,
+        parameters={},
+        expected_duration=1,
+    )
+
+
+def _state_with_events(events: list) -> SimulationState:  # type: ignore[type-arg]
+    entity = SimulationEntity(
+        id="ARG",
+        entity_type="country",
+        attributes={
+            "democratic_quality_score": Quantity(
+                value=Decimal("0.71"),
+                unit="ratio_0_1",
+                variable_type=VariableType.DIMENSIONLESS,
+                measurement_framework=MeasurementFramework.GOVERNANCE,
+                confidence_tier=1,
+            ),
+        },
+        metadata={},
+    )
+    ts = _TIMESTEP
+    return SimulationState(
+        timestep=ts,
+        resolution=ResolutionConfig(),
+        entities={"ARG": entity},
+        relationships=[],
+        events=events,
+        scenario_config=ScenarioConfig(
+            scenario_id="test-sid",
+            name="Test",
+            description="",
+            start_date=ts,
+            end_date=ts,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — event_type strings produced by to_events()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("instrument,expected_event_type", [
+    (
+        EmergencyInstrument.EMERGENCY_DECLARATION,
+        "emergency_policy_emergency_declaration",
+    ),
+    (
+        EmergencyInstrument.IMF_PROGRAM_ACCEPTANCE,
+        "emergency_policy_imf_program_acceptance",
+    ),
+    (
+        EmergencyInstrument.CAPITAL_CONTROLS,
+        "emergency_policy_capital_controls",
+    ),
+])
+def test_to_events_produces_correct_event_type(
+    instrument: EmergencyInstrument,
+    expected_event_type: str,
+) -> None:
+    """to_events() must produce event_type matching the documented pattern."""
+    events = _input(instrument).to_events(_TIMESTEP)
+    assert len(events) == 1
+    assert events[0].event_type == expected_event_type
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — event_types in _SUBSCRIBED_EVENTS match what to_events() emits
+# ---------------------------------------------------------------------------
+
+
+def test_emergency_declaration_event_type_is_in_subscribed_events() -> None:
+    """The event_type emitted for EMERGENCY_DECLARATION is subscribed by GovernanceModule."""
+    events = _input(EmergencyInstrument.EMERGENCY_DECLARATION).to_events(_TIMESTEP)
+    assert events[0].event_type in _SUBSCRIBED_EVENTS
+
+
+def test_imf_program_acceptance_event_type_is_in_subscribed_events() -> None:
+    """The event_type emitted for IMF_PROGRAM_ACCEPTANCE is subscribed by GovernanceModule."""
+    events = _input(EmergencyInstrument.IMF_PROGRAM_ACCEPTANCE).to_events(_TIMESTEP)
+    assert events[0].event_type in _SUBSCRIBED_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — GovernanceModule processes the event end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_governance_module_processes_emergency_declaration() -> None:
+    """End-to-end: EmergencyPolicyInput event is processed by GovernanceModule.
+
+    GovernanceModule.compute() must return a non-empty list of governance
+    events when an emergency_declaration event is present in state.events.
+    If the event_type contract breaks, compute() silently returns [].
+    """
+    emergency_events = _input(EmergencyInstrument.EMERGENCY_DECLARATION).to_events(_TIMESTEP)
+    state = _state_with_events(emergency_events)
+    entity = state.entities["ARG"]
+
+    result = GovernanceModule().compute(entity, state, _TIMESTEP)
+
+    assert result, (
+        "GovernanceModule.compute() returned [] for an emergency_declaration event. "
+        "Check that EmergencyPolicyInput.to_events() event_type matches "
+        "_SUBSCRIBED_EVENTS in GovernanceModule."
+    )
+
+
+def test_governance_module_processes_imf_program_acceptance() -> None:
+    """End-to-end: IMF_PROGRAM_ACCEPTANCE event is processed by GovernanceModule."""
+    imf_events = _input(EmergencyInstrument.IMF_PROGRAM_ACCEPTANCE).to_events(_TIMESTEP)
+    state = _state_with_events(imf_events)
+    entity = state.entities["ARG"]
+
+    result = GovernanceModule().compute(entity, state, _TIMESTEP)
+
+    assert result, (
+        "GovernanceModule.compute() returned [] for an imf_program_acceptance event. "
+        "Check that EmergencyPolicyInput.to_events() event_type matches "
+        "_SUBSCRIBED_EVENTS in GovernanceModule."
+    )
+
+
+def test_governance_module_ignores_unknown_event_type() -> None:
+    """GovernanceModule must return [] for events not in _SUBSCRIBED_EVENTS.
+
+    This is the inverse guard: if the subscription filter is broken and
+    processes everything, this test will fail.
+    """
+    emergency_events = _input(EmergencyInstrument.EMERGENCY_DECLARATION).to_events(_TIMESTEP)
+    # Corrupt the event_type to simulate the pre-NM-029 bug pattern
+    broken_event = emergency_events[0]
+    # bare name, not prefixed — simulates the pre-NM-029 bug pattern
+    object.__setattr__(broken_event, "event_type", "emergency_declaration")
+
+    state = _state_with_events([broken_event])
+    entity = state.entities["ARG"]
+
+    result = GovernanceModule().compute(entity, state, _TIMESTEP)
+
+    assert result == [], (
+        "GovernanceModule processed a bare 'emergency_declaration' event_type that is not "
+        "in _SUBSCRIBED_EVENTS. The subscription filter is not enforced correctly."
+    )
+
+
+def test_get_subscribed_events_returns_all_emergency_types() -> None:
+    """get_subscribed_events() must include all emergency event_types."""
+    subscribed = GovernanceModule().get_subscribed_events()
+    assert "emergency_policy_emergency_declaration" in subscribed
+    assert "emergency_policy_imf_program_acceptance" in subscribed

--- a/backend/tests/unit/test_mda_threshold_integration.py
+++ b/backend/tests/unit/test_mda_threshold_integration.py
@@ -1,0 +1,300 @@
+"""
+MDA threshold integration scenarios — Issue #184.
+
+Deliberately constructed scenarios that verify MDAChecker fires the
+correct severity at the correct threshold boundary. Tests are scenario-level
+(entity + threshold + checker) rather than unit-level (one method call).
+
+Thresholds used here mirror production thresholds from the Argentina and
+Greece fixtures so that backtesting regressions are caught immediately.
+
+Severity contract (MDAChecker docstring):
+  WARNING  — within approach_pct of floor, not yet breached
+  CRITICAL — breached for exactly one consecutive step
+  TERMINAL — breached for two or more consecutive steps
+
+comparison_operator contract:
+  "lte" — breach when current ≤ floor_value (lower-bound threshold)
+  "gte" — breach when current ≥ floor_value (upper-bound threshold)
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from app.schemas import MDASeverity, MDAThresholdRecord
+from app.simulation.engine.models import (
+    ResolutionConfig,
+    ScenarioConfig,
+    SimulationEntity,
+    SimulationState,
+)
+from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.mda_checker import MDAChecker, alerts_to_events_snapshot
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_TS = datetime(2001, 12, 1, tzinfo=UTC)
+
+_DEMOCRACY_FLOOR = MDAThresholdRecord(
+    mda_id="MDA-GOV-DEMOCRACY-FLOOR",
+    indicator_key="democratic_quality_score",
+    entity_scope="all",
+    measurement_framework="governance",
+    floor_value="0.70",
+    floor_unit="ratio_0_1",
+    approach_pct="0.10",
+    comparison_operator="lte",
+    severity_at_breach="CRITICAL",
+    description="V-Dem LDI democracy floor — minimum threshold for governance viability.",
+    historical_basis="V-Dem dataset, autocratization thresholds.",
+    recovery_horizon_years=None,
+    irreversibility_note="Democratic backsliding requires years to reverse.",
+)
+
+_ECOLOGICAL_BOUNDARY = MDAThresholdRecord(
+    mda_id="MDA-ECO-CO2-BOUNDARY",
+    indicator_key="co2_proximity_score",
+    entity_scope="all",
+    measurement_framework="ecological",
+    floor_value="1.0",
+    floor_unit="ratio",
+    approach_pct="0.05",
+    comparison_operator="gte",
+    severity_at_breach="CRITICAL",
+    description="CO2 planetary boundary — breach when normalized proximity ≥ 1.0.",
+    historical_basis="NOAA MLO CO2 series, IPCC boundary.",
+    recovery_horizon_years=None,
+    irreversibility_note="CO2 concentration is effectively irreversible on human timescales.",
+)
+
+_DEBT_CEILING = MDAThresholdRecord(
+    mda_id="MDA-FIN-DEBT-GDP",
+    indicator_key="debt_gdp_ratio",
+    entity_scope="all",
+    measurement_framework="financial",
+    floor_value="1.40",
+    floor_unit="ratio",
+    approach_pct="0.20",
+    comparison_operator="gte",
+    severity_at_breach="CRITICAL",
+    description="Debt-to-GDP ceiling — breach when ratio ≥ 1.40.",
+    historical_basis="Greece 2012 sovereign debt crisis threshold.",
+    recovery_horizon_years=None,
+    irreversibility_note="",
+)
+
+
+def _state(entity_id: str, attrs: dict[str, Decimal]) -> SimulationState:
+    attribute_map: dict[str, Quantity] = {
+        key: Quantity(
+            value=val,
+            unit="dimensionless",
+            variable_type=VariableType.DIMENSIONLESS,
+            measurement_framework=None,
+            confidence_tier=1,
+        )
+        for key, val in attrs.items()
+    }
+    entity = SimulationEntity(
+        id=entity_id,
+        entity_type="country",
+        attributes=attribute_map,
+        metadata={},
+    )
+    return SimulationState(
+        timestep=_TS,
+        resolution=ResolutionConfig(),
+        entities={entity_id: entity},
+        relationships=[],
+        events=[],
+        scenario_config=ScenarioConfig(
+            scenario_id="test-sid",
+            name="Integration test",
+            description="",
+            start_date=_TS,
+            end_date=_TS,
+        ),
+    )
+
+
+def _prior_breach_events(
+    mda_id: str,
+    entity_id: str,
+    consecutive_steps: int = 1,
+) -> list[dict[str, Any]]:
+    """Build the events_snapshot format that encodes a prior breach."""
+    return [
+        {
+            "event_type": "mda_breach",
+            "event_id": f"{mda_id}--{entity_id}--0",
+            "mda_id": mda_id,
+            "entity_id": entity_id,
+            "consecutive_breach_steps": consecutive_steps,
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Democracy floor — lte threshold
+# ---------------------------------------------------------------------------
+
+
+def test_democracy_floor_safe_zone_produces_no_alert() -> None:
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.90")})
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert alerts == []
+
+
+def test_democracy_floor_approach_zone_produces_warning() -> None:
+    # floor=0.70, approach_pct=0.10 → warning when value ≤ 0.70 * 1.10 = 0.77
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.73")})
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.WARNING
+    assert alerts[0].mda_id == "MDA-GOV-DEMOCRACY-FLOOR"
+
+
+def test_democracy_floor_breach_produces_critical() -> None:
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.665")})
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.CRITICAL
+    assert alerts[0].entity_id == "ARG"
+
+
+def test_democracy_floor_second_consecutive_breach_produces_terminal() -> None:
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.65")})
+    prior = _prior_breach_events("MDA-GOV-DEMOCRACY-FLOOR", "ARG", consecutive_steps=1)
+    alerts = MDAChecker().check(state, prior, [_DEMOCRACY_FLOOR])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.TERMINAL
+    assert alerts[0].consecutive_breach_steps == 2
+
+
+def test_democracy_floor_boundary_exact_value_is_breach() -> None:
+    """exact floor value triggers CRITICAL, not WARNING (≤ semantics)."""
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.70")})
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# Ecological boundary — gte threshold
+# ---------------------------------------------------------------------------
+
+
+def test_ecological_boundary_safe_zone_produces_no_alert() -> None:
+    state = _state("GRC", {"co2_proximity_score": Decimal("0.90")})
+    alerts = MDAChecker().check(state, [], [_ECOLOGICAL_BOUNDARY])
+    assert alerts == []
+
+
+def test_ecological_boundary_breach_produces_critical() -> None:
+    # Argentina Argentina seed: 369.5 ppm → proximity ≈ 1.056 (above 1.0 boundary)
+    state = _state("ARG", {"co2_proximity_score": Decimal("1.056")})
+    alerts = MDAChecker().check(state, [], [_ECOLOGICAL_BOUNDARY])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.CRITICAL
+    assert alerts[0].mda_id == "MDA-ECO-CO2-BOUNDARY"
+
+
+def test_ecological_boundary_approach_produces_warning() -> None:
+    # floor=1.0, approach_pct=0.05 → warning when value ≥ 1.0 * (1 - 0.05) = 0.95
+    state = _state("ARG", {"co2_proximity_score": Decimal("0.97")})
+    alerts = MDAChecker().check(state, [], [_ECOLOGICAL_BOUNDARY])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# Multiple thresholds simultaneously
+# ---------------------------------------------------------------------------
+
+
+def test_two_thresholds_both_breached_produce_two_alerts() -> None:
+    """A single entity breaching both democracy and ecological floors → two alerts."""
+    state = _state("ARG", {
+        "democratic_quality_score": Decimal("0.65"),  # below 0.70 → CRITICAL
+        "co2_proximity_score": Decimal("1.056"),       # above 1.0 → CRITICAL
+    })
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR, _ECOLOGICAL_BOUNDARY])
+    assert len(alerts) == 2
+    alert_ids = {a.mda_id for a in alerts}
+    assert "MDA-GOV-DEMOCRACY-FLOOR" in alert_ids
+    assert "MDA-ECO-CO2-BOUNDARY" in alert_ids
+    assert all(a.severity == MDASeverity.CRITICAL for a in alerts)
+
+
+def test_threshold_does_not_match_absent_indicator() -> None:
+    """No alert when the entity has no attribute for the threshold's indicator_key."""
+    state = _state("GRC", {"gdp_growth": Decimal("-0.08")})  # no democratic_quality_score
+    alerts = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert alerts == []
+
+
+def test_entity_scope_filters_non_matching_entity() -> None:
+    """entity_scope='GRC' threshold does not fire for 'ARG'."""
+    scoped_threshold = MDAThresholdRecord(
+        mda_id="MDA-GRC-ONLY",
+        indicator_key="democratic_quality_score",
+        entity_scope="GRC",
+        measurement_framework="governance",
+        floor_value="0.70",
+        floor_unit="ratio_0_1",
+        approach_pct="0.10",
+        comparison_operator="lte",
+        severity_at_breach="CRITICAL",
+        description="GRC-scoped threshold.",
+        historical_basis="",
+        recovery_horizon_years=None,
+        irreversibility_note="",
+    )
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.60")})
+    alerts = MDAChecker().check(state, [], [scoped_threshold])
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Debt ceiling — gte threshold (Issue #236 regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_debt_gdp_ceiling_breach_produces_critical() -> None:
+    # Greece 2012: debt/GDP ≈ 1.483 — well above 1.40 ceiling
+    state = _state("GRC", {"debt_gdp_ratio": Decimal("1.483")})
+    alerts = MDAChecker().check(state, [], [_DEBT_CEILING])
+    assert len(alerts) == 1
+    assert alerts[0].severity == MDASeverity.CRITICAL
+
+
+def test_debt_gdp_ceiling_safe_zone() -> None:
+    state = _state("GRC", {"debt_gdp_ratio": Decimal("0.90")})
+    alerts = MDAChecker().check(state, [], [_DEBT_CEILING])
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Snapshot round-trip — alerts_to_events_snapshot → prior_breach_events
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_round_trip_produces_correct_consecutive_count() -> None:
+    """alerts_to_events_snapshot output can be fed back as prior_breach_events."""
+    state = _state("ARG", {"democratic_quality_score": Decimal("0.65")})
+
+    # Step 1: first breach
+    alerts_step1 = MDAChecker().check(state, [], [_DEMOCRACY_FLOOR])
+    assert alerts_step1[0].severity == MDASeverity.CRITICAL
+
+    # Serialise to snapshot format
+    snapshot = alerts_to_events_snapshot(alerts_step1, step_index=1)
+
+    # Step 2: second breach using step 1 snapshot as prior
+    alerts_step2 = MDAChecker().check(state, snapshot, [_DEMOCRACY_FLOOR])
+    assert alerts_step2[0].severity == MDASeverity.TERMINAL
+    assert alerts_step2[0].consecutive_breach_steps == 2


### PR DESCRIPTION
## Summary

- **37 new integration-level tests** across three files, guarding silent-wrong-result failure classes that prior unit tests missed because they did not cross module boundaries
- **Closes #374** — STOCK/FLOW/RATIO/DIMENSIONLESS delta path contract + confidence-tier lower-of-two-quality rule (DATA_STANDARDS.md §STOCK/FLOW delta path gate)
- **Closes #642** — EmergencyPolicyInput → GovernanceModule event_type string contract end-to-end (NM-029 root cause: 25 prior tests passed with wrong synthetic strings)
- **Closes #184** — MDA threshold integration: WARNING/CRITICAL/TERMINAL severity boundaries, lte/gte operator semantics, entity_scope filtering, snapshot round-trip

## Files changed

- `backend/tests/unit/test_apply_delta_contract.py` (new, 14 tests)
- `backend/tests/unit/test_emergency_policy_integration.py` (new, 9 tests)
- `backend/tests/unit/test_mda_threshold_integration.py` (new, 15 tests)

No app code changes. Test-only PR.

## Test plan

- [x] All 37 new tests pass locally
- [x] Full suite: 926 passing, 73 skipped — no regressions
- [x] `ruff check backend/` clean
- [x] Production threshold values from Argentina and Greece fixtures used in MDA tests (backtesting regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)