### PR TITLE
refactor(frontend): setTrajectory must not set current_step as side effect

### DIFF
--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -220,10 +220,6 @@ export function ScenarioInstrumentCluster({
       .then((raw) => {
         if (cancelled) return;
         store.setTrajectory(parseTrajectoryResponse(raw));
-        // setTrajectory also sets current_step = trajectory.step_count (designed for
-        // re-selection of completed scenarios). Re-assert the prop-driven step value
-        // so Zone 1 instruments reflect the step that actually triggered this fetch.
-        useScenarioStepStore.setState({ current_step: currentStep });
         setTrajectoryLoading(false);
       })
       .catch(() => {

--- a/frontend/src/components/__tests__/TrajectoryView.test.ts
+++ b/frontend/src/components/__tests__/TrajectoryView.test.ts
@@ -389,4 +389,29 @@ describe("AC-006 — atomicity: Zustand store single-set() invariant", () => {
 
     expect(useScenarioStepStore.getState().current_step).toBe(3);
   });
+
+  // setTrajectory side-effect removal — Issue #643
+  it("setTrajectory does not mutate current_step", () => {
+    useScenarioStepStore.getState().setScenario("traj-test", 5, "MODE_1");
+    useScenarioStepStore.setState({ current_step: 3 });
+
+    useScenarioStepStore.getState().setTrajectory({
+      scenario_id: "traj-test",
+      entity_id: "ARG",
+      step_count: 5,
+      mda_floors: [],
+      steps: [],
+    });
+
+    expect(useScenarioStepStore.getState().current_step).toBe(3);
+  });
+
+  it("setCurrentStep sets current_step explicitly", () => {
+    useScenarioStepStore.getState().setScenario("traj-test-2", 5, "MODE_1");
+    useScenarioStepStore.setState({ current_step: 0 });
+
+    useScenarioStepStore.getState().setCurrentStep(5);
+
+    expect(useScenarioStepStore.getState().current_step).toBe(5);
+  });
 });

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -74,6 +74,8 @@ interface ScenarioStepState {
     mode: "MODE_1" | "MODE_2" | "MODE_3",
   ) => void;
   setTrajectory: (trajectory: TrajectoryResponse) => void;
+  /** Jump to a specific step — used by scenario re-selection to land on the final step. */
+  setCurrentStep: (step: number) => void;
   setMdaAlerts: (alerts: Zone1BAlert[]) => void;
   /** Set PMM state in a single set() call (DD-012 atomicity). */
   setPmmState: (value: number | null, direction: "up" | "down" | "flat" | null) => void;
@@ -111,9 +113,10 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
   setTrajectory: (trajectory) =>
     set({
       trajectory,
-      current_step: trajectory.step_count,
       computation_state: "complete",
     }),
+
+  setCurrentStep: (step) => set({ current_step: step }),
 
   setMdaAlerts: (alerts) => set({ mda_alerts: alerts }),
 


### PR DESCRIPTION
## Summary

- **Closes #643** — removes the implicit `current_step = trajectory.step_count` side effect from `setTrajectory()`
- Adds dedicated `setCurrentStep(step: number)` action for callers that need explicit step control (scenario re-selection, future Mode 3 jump-to-step)
- Removes the workaround re-assert and its 3-line comment from `ScenarioInstrumentCluster.tsx` (introduced in PR #639)

## Root cause

`setTrajectory()` was designed to jump to the final step for scenario re-selection. This side effect clobbered the prop-driven `current_step` during live step advances in `ScenarioInstrumentCluster`, requiring an immediate re-assert workaround — an implicit contract not enforced by types.

## Files changed

- `frontend/src/store/scenarioStepStore.ts` — `setTrajectory` no longer mutates `current_step`; `setCurrentStep` added
- `frontend/src/components/ScenarioInstrumentCluster.tsx` — workaround re-assert + comment removed
- `frontend/src/components/__tests__/TrajectoryView.test.ts` — 2 new contract tests added

## Test plan

- [x] `setTrajectory does not mutate current_step` — new test, passing
- [x] `setCurrentStep sets current_step explicitly` — new test, passing
- [x] 124 frontend unit tests passing, no regressions
- [x] `npm run build` clean (tsc -b, no TypeScript errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)