### PR TITLE
fix(frontend): DEMO-018/019/020 — legend raw names, PMM None label, y-axis clip

### DIFF
--- a/frontend/src/components/PMMWidgetZone1C.tsx
+++ b/frontend/src/components/PMMWidgetZone1C.tsx
@@ -46,6 +46,15 @@ export function getPmmArrow(direction: "up" | "down" | "flat" | null): string {
 }
 
 /**
+ * Returns the plain-language note shown when PMM is None due to all thresholds breached.
+ * Empty string when PMM has a value — note is suppressed.
+ * DEMO-019: distinguishes "margin fully exhausted" from "not computed" / "not applicable".
+ */
+export function getPmmBreachedNote(pmmValue: number | null): string {
+  return pmmValue === null ? "All thresholds breached — see alerts" : "";
+}
+
+/**
  * Returns the CSS color for the direction arrow.
  * Green-family avoided (CVD constraint from MV-001 — teal only for ecological).
  */
@@ -72,6 +81,7 @@ export function PMMWidgetZone1C({
   const label = getPmmLabel(mode);
   const arrow = getPmmArrow(pmm_direction);
   const arrowColor = getPmmArrowColor(pmm_direction);
+  const breachedNote = getPmmBreachedNote(pmm_value);
   const isPending = computation_state === "computing";
 
   const formattedValue =
@@ -135,6 +145,16 @@ export function PMMWidgetZone1C({
           {arrow}
         </span>
       </div>
+
+      {/* Contextual note when all thresholds are breached (pmm_value === null) */}
+      {breachedNote && !isPending && (
+        <div
+          data-testid="pmm-breached-note"
+          style={{ fontSize: 10, color: "#cc0000", marginTop: 4, lineHeight: 1.3 }}
+        >
+          {breachedNote}
+        </div>
+      )}
 
       {/* Pending label — Mode 3 computation in flight */}
       {isPending && (

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -328,7 +328,12 @@ export function TrajectoryView({
             height={60}
           />
 
-          <YAxis domain={[0, 1]} tick={{ fontSize: 11 }} width={32} />
+          <YAxis
+            domain={[0, "auto"]}
+            tick={{ fontSize: 11 }}
+            width={44}
+            tickFormatter={(v: number) => v.toFixed(2)}
+          />
 
           <Tooltip
             formatter={(value, name) => {
@@ -356,6 +361,7 @@ export function TrajectoryView({
               stroke="none"
               isAnimationActive={false}
               connectNulls={CONNECT_NULLS}
+              legendType="none"
             />
           ))}
 
@@ -370,6 +376,7 @@ export function TrajectoryView({
               stroke="none"
               isAnimationActive={false}
               connectNulls={CONNECT_NULLS}
+              legendType="none"
             />
           ))}
 
@@ -403,6 +410,7 @@ export function TrajectoryView({
                   connectNulls={CONNECT_NULLS}
                   name={`${legendFormatter(fw, "percentile_rank")} (baseline)` as never}
                   isAnimationActive={false}
+                  legendType="none"
                 />
               );
             })}

--- a/frontend/src/components/__tests__/PMMWidgetZone1C.test.ts
+++ b/frontend/src/components/__tests__/PMMWidgetZone1C.test.ts
@@ -14,6 +14,7 @@ import {
   getPmmLabel,
   getPmmArrow,
   getPmmArrowColor,
+  getPmmBreachedNote,
   PMM_LABELS,
 } from "../PMMWidgetZone1C";
 
@@ -125,5 +126,27 @@ describe("getPmmArrowColor: direction to color", () => {
     // null direction carries no directional meaning so it must not imply improvement
     expect(color).not.toBe("#1A8FA0");
     expect(color).not.toBe("#2271B3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPmmBreachedNote — DEMO-019 contextual note for None state
+// ---------------------------------------------------------------------------
+
+describe("getPmmBreachedNote: None-state intelligibility", () => {
+  it("returns plain-language note when pmm_value is null", () => {
+    const note = getPmmBreachedNote(null);
+    expect(note).toBeTruthy();
+    expect(note).toContain("breached");
+  });
+
+  it("returns empty string when pmm_value is a number", () => {
+    expect(getPmmBreachedNote(0.42)).toBe("");
+    expect(getPmmBreachedNote(0)).toBe("");
+  });
+
+  it("note does not contain raw field names or internal identifiers", () => {
+    const note = getPmmBreachedNote(null);
+    expect(note).not.toMatch(/pmm_value|policy_margin|null|undefined/);
   });
 });


### PR DESCRIPTION
## Summary

Three DEMO-finding fixes identified from the M10 Step 6b live application review (NM-032 root cause — all were invisible at the 1280×720 screenshot capture viewport).

- **Closes #672 (DEMO-018)** — Zone 1A legend showing raw variable names (`ecological_ci_upper`, `financial_active`, etc.): `legendType="none"` added to all CI band, divergence fill, and baseline ghost series
- **Closes #673 (DEMO-019)** — PMM "—" state unintelligible to non-specialists: `getPmmBreachedNote()` pure function + "All thresholds breached — see alerts" sub-label in critical red when `pmm_value` is null
- **Closes #674 (DEMO-020)** — Zone 1A y-axis tick labels clipped at ≥1440px: `YAxis width` 32→44, `tickFormatter` to 2 decimal places, `domain` changed to `[0, "auto"]` for ecological scores above 1.0

## Files changed

- `frontend/src/components/TrajectoryView.tsx` — DEMO-018 legend fix + DEMO-020 y-axis fix
- `frontend/src/components/PMMWidgetZone1C.tsx` — DEMO-019: `getPmmBreachedNote()` exported function + render
- `frontend/src/components/__tests__/PMMWidgetZone1C.test.ts` — 3 new tests for `getPmmBreachedNote`

## Test plan

- [x] 127 frontend unit tests passing, no regressions
- [x] `npm run build` clean (tsc -b)
- [x] `getPmmBreachedNote(null)` returns plain-language note containing "breached"
- [x] `getPmmBreachedNote(0.42)` returns `""` — note suppressed when value exists
- [x] Note contains no raw field names or internal identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)