### PR TITLE
docs(g5): demo narration gaps, viewport fix, screenshot sequence manifests

### DIFF
--- a/docs/demo/m10/screenshots/SEQUENCE.md
+++ b/docs/demo/m10/screenshots/SEQUENCE.md
@@ -1,0 +1,44 @@
+# M10 Screenshot Sequence — Presentation Order Manifest and Capture Attestation
+
+**Milestone:** 10 (v0.10.0)
+**Scenario:** Argentina 2001–2004 sovereign default and Kirchner recovery, four steps
+**Filing issues:** #667 (DEMO-010), #668 (DEMO-011)
+
+## Presentation Order
+
+| Presentation order | Filename | Caption |
+|---|---|---|
+| 1 (THESIS) | `frame-c-step3-divergence.png` | Step 3 — financial recovery vs. governance lag — thesis frame |
+| 2 | `frame-a-step1-instrument.png` | Step 1 — Zone 1 instrument cluster — scenario loaded |
+| 3 | `frame-b-step2-crisis.png` | Step 2 — financial floor — Zero Deficit Plan impact |
+| 4 | `frame-d-step3-evidence.png` | Step 3 — MDA alert panel — governance WARNING citeable evidence |
+| 5 | `frame-e-step4-recovery.png` | Step 4 — recovery arc — GDP growth vs. governance lag |
+
+## Capture State Attestation — DEMO-010 / DEMO-011
+
+**Finding:** These screenshots are present locally but were never committed to the
+repository. Capture provenance (date, branch, commit SHA) cannot be verified from
+git history — the files are untracked.
+
+**Consequence:** Post-fix state for DEMO-003 (axis label overflow, PRs #337) and
+DEMO-005 (Zone 1A legend overlap, PR #345) cannot be confirmed without pixel
+comparison against those fix commits. Frame D specifically (DEMO-011) was the
+primary frame affected by DEMO-005 and cannot be attested as post-fix.
+
+**Status:** UNATTESTED — capture provenance unknown.
+
+**Required action:** Re-capture this screenshot set before the next stakeholder
+presentation or review cycle. Use the updated `demo-narrated.spec.ts` (viewport
+fixed to 1440×900 per Issue #675) to produce a committed, traceable capture.
+After re-capture, update this file with:
+- Capture date
+- Branch / commit SHA at time of capture
+- Confirmation that DEMO-003 and DEMO-005 fixes are visible in all frames
+- Frame D attestation: legend area legible, no overlap
+
+## Capture Viewport Note
+
+The M10 screenshots were captured at an undocumented viewport. The legibility
+gate (Step 5b) runs at 1440×900. The `demo-narrated.spec.ts` defaulted to
+1280×720 (playwright.config.ts) during M10 — this mismatch is the root cause
+documented in NM-032. The viewport was corrected in Issue #675.

--- a/docs/demo/m8/screenshots/SEQUENCE.md
+++ b/docs/demo/m8/screenshots/SEQUENCE.md
@@ -1,0 +1,31 @@
+# M8 Screenshot Sequence — Presentation Order Manifest
+
+**Milestone:** 8 (v0.8.0)
+**Scenario:** Greece 2010–2015 IMF programme, six steps
+**Capture date:** 2026-05-18 (pre-M9)
+**Filing issue:** #349 (DEMO-008 retroactive fix)
+
+## Capture-to-Presentation Order Mapping
+
+Files are named in capture order (A–E). The UX Agent brief (Issue #233) specified
+presentation order **C → A → B → D → E** (thesis-first sequence). Use this manifest
+when presenting or reviewing these artifacts.
+
+| Presentation order | Filename | Caption |
+|---|---|---|
+| 1 (THESIS) | `frame-c-step5-divergence.png` | Step 5 — HD tab — divergence frame (thesis visualization) |
+| 2 | `frame-a-step1-instrument.png` | Step 1 — full Zone 1 — instrument cluster setup |
+| 3 | `frame-b-step3-collapse.png` | Step 3 — Financial tab — maximum fiscal stress |
+| 4 | `frame-d-step3-evidence.png` | Step 3 — MDA alert panel prominent — citeable evidence |
+| 5 | `frame-e-step3-ecological.png` | Step 3 — Ecological tab + note expanded |
+
+## Why This File Exists
+
+DEMO-008 (M8 stakeholder review, 2026-05-18): screenshot filenames were assigned
+alphabetically in capture order, not in the presentation order specified by the
+UX Agent brief. A reviewer reading frame-a before frame-c encounters the instrument
+view before the thesis, which changes the quality of the review analysis.
+
+`docs/process/demo-preparation-standard.md §Step 6` now requires either
+presentation-order filenames or a SEQUENCE.md for all future milestones.
+This file is the retroactive SEQUENCE.md for M8.

--- a/docs/demo/stakeholder-walkthrough.md
+++ b/docs/demo/stakeholder-walkthrough.md
@@ -213,6 +213,12 @@ The Zone 1 instruments load with Argentina data.
 > What you are about to see is not a chart of history — it is the instrument
 > cluster reading that scenario forward, one step at a time.
 
+**Curve convention (DEMO-013 — required before any quantitative reading):** When Zone 1A loads, point briefly to the curve style:
+
+> The dashed curves are projected — model output from the scenario. The solid portion, where it appears, is the historical basis for the calibration you are seeing. You are looking at both at once: what happened, and what the model says would follow from the inputs we gave it.
+
+Do not skip this sentence even if the audience seems technically sophisticated. It prevents the audience from treating forward projection as historical fact.
+
 **Cognitive purpose:** Establish that scenarios are structured, not arbitrary.
 The historical events — the programme conditions, the default, the emergency
 declaration — are the inputs. What the simulation does with them is the output.
@@ -268,6 +274,18 @@ while the governance curve remains flat near the breach floor.
 >
 > Financial recovery and institutional recovery are not the same event. No
 > single-axis measurement tool can show you both simultaneously. This one does.
+>
+> Now look at the human development curve. It is tracking below its pre-crisis
+> level and has not recovered with GDP. That curve represents what the adjustment
+> period did to the capabilities of Argentina's population — health access,
+> education enrollment, the social mobility of the cohorts who were children in
+> 2001 and 2002. Those cohorts absorbed the cost of the convertibility collapse.
+> They are visible in this instrument as a trajectory that lags the financial
+> recovery by years.
+>
+> A negotiation that optimises for the financial curve alone is not seeing the
+> full picture. This tool shows all four simultaneously. That is the capability
+> gap we are closing.
 >
 > And the next panel puts a specific, citeable number on what you just saw.
 

--- a/docs/process/demo-preparation-standard.md
+++ b/docs/process/demo-preparation-standard.md
@@ -127,6 +127,7 @@ Update `demo-narrated.spec.ts` for the current milestone:
 - Key frame capture points (per UX Agent brief)
 - Narration strings for new features (ecological axis, governance null, PMM widget state)
 - Screenshot output paths pointing to `docs/demo/m{N}/screenshots/`
+- **Capture viewport — mandatory:** At the top of the test body, add `await page.setViewportSize({ width: 1440, height: 900 })` before `page.goto()`. Do NOT rely on the `playwright.config.ts` default (1280×720). The capture viewport must match the legibility gate (1440×900) and the presenter display. Root cause of NM-032 (DEMO-020 invisible to review chain at 1280×720). Issue #675.
 
 ### Step 5 — Update `docs/demo/stakeholder-walkthrough.md`
 
@@ -196,6 +197,9 @@ that presents instrument output without framing or implication, introducing
 presenter-skill dependency for the "so what" the audience needs.
 
 ### Step 6 — Run the demo and capture screenshots
+
+**Pre-capture gate — viewport confirmation (M10 forward — Issue #675):**
+Before running, confirm that `demo-narrated.spec.ts` contains `page.setViewportSize({ width: 1440, height: 900 })` before the first `page.goto()`. If absent, add it (Step 4 requirement). Capturing at 1280×720 (the playwright.config.ts default) means the review chain sees a rendering the stakeholder will not — viewport-dependent defects are invisible. This gate exists because NM-032 was not caught by either the internal panel or the IR Agent because of this mismatch.
 
 ```bash
 ./scripts/demo.sh          # Start stack, run migrations, seed data

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -39,7 +39,7 @@ import { test, expect } from "@playwright/test";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SPEAK_SCRIPT = path.resolve(__dirname, "../../../scripts/speak.sh");
-const SCREENSHOT_DIR = path.resolve(__dirname, "../../../docs/demo/m8/screenshots/");
+const SCREENSHOT_DIR = path.resolve(__dirname, "../../../docs/demo/m10/screenshots/");
 
 // Ensure screenshot directory exists (created by PR #334; guard against clean clones).
 fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
@@ -97,6 +97,10 @@ test(
   { tag: ["@demo"] },
   async ({ page }) => {
     test.setTimeout(20 * 60 * 1000);
+
+    // Match legibility gate and live demo viewport — NM-032 / Issue #675.
+    // Do NOT rely on playwright.config.ts default (1280×720).
+    await page.setViewportSize({ width: 1440, height: 900 });
 
     // ── STEP 1: Map loads ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Six documentation issues closed in one commit — all identified from the M10 Step 6b internal review (NM-032 root cause: screenshot viewport mismatch made several findings invisible to the review chain).

- **Closes #669 (DEMO-013)** — dashed/solid curve disambiguation added to walkthrough Step 2
- **Closes #670 (DEMO-017)** — Human Development trajectory narration beat added to Step 4 (Thesis Frame); names capability domains and affected cohorts — CLAUDE.md §Human Cost Ledger is Primary
- **Closes #675** — `demo-narrated.spec.ts`: SCREENSHOT_DIR updated m8→m10; `page.setViewportSize(1440, 900)` added before `page.goto()`. `demo-preparation-standard.md` Step 4 and Step 6 updated with mandatory viewport gate
- **Closes #349 (DEMO-008)** — `docs/demo/m8/screenshots/SEQUENCE.md` created; retroactive presentation-order manifest (C → A → B → D → E per UX Agent brief #233)
- **Closes #667 (DEMO-010)** — `docs/demo/m10/screenshots/SEQUENCE.md` created with honest attestation: screenshots untracked in git, capture provenance unverifiable, post-fix state for DEMO-003/005 unconfirmed
- **Closes #668 (DEMO-011)** — Frame D capture state attested as UNATTESTED; re-capture required before next review cycle using updated spec at 1440×900

## Files changed

- `frontend/tests/e2e/demo-narrated.spec.ts` — viewport + SCREENSHOT_DIR fix
- `docs/process/demo-preparation-standard.md` — Steps 4 and 6 viewport gates
- `docs/demo/stakeholder-walkthrough.md` — DEMO-013 + DEMO-017 narration
- `docs/demo/m8/screenshots/SEQUENCE.md` — new (retroactive M8 manifest)
- `docs/demo/m10/screenshots/SEQUENCE.md` — new (M10 attestation + sequence)

## NARRATION-RULING-1 self-check

Both walkthrough additions (Step 2 curve convention, Step 4 HD beat) pass the self-check: umbrella framing present, instrument reading present, synthesis/implication present, transition to next step present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)