### PR TITLE
docs(g6): SA standards — 8 long-open gaps in CODING_STANDARDS, DATA_STANDARDS, POLICY

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1843,3 +1843,168 @@ The compliance scan is a secondary enforcement layer, not the primary one. The
 primary gate lives in `Quantity.__init__` or a module-level validator that checks
 the unit string against the canonical vocabulary before the `Quantity` is
 constructed.
+
+---
+
+## Simulation Lifecycle State Machine (SA-04)
+
+**Source:** STD-REVIEW-002 T1-F4 / T2-F2 — convergent finding. Issue #119.
+
+Every scenario has a lifecycle status field. Valid statuses and valid transitions are
+defined here and must not be implemented ad hoc in individual modules.
+
+### Valid Statuses
+
+| Status | Meaning |
+|---|---|
+| `pending` | Created, not yet executed |
+| `running` | Execution in progress |
+| `completed` | Execution finished without error |
+| `failed` | Execution raised an unhandled exception or pre-execution validation failed |
+
+### Valid Transitions
+
+- `pending → running` — execution begins
+- `running → completed` — execution finishes without error
+- `running → failed` — execution raises an unhandled exception
+- `pending → failed` — pre-execution validation fails at runtime
+
+Any transition not in this list is invalid and must raise a `StateTransitionError`.
+
+### Immutability Rule
+
+Scenario configuration (entities, n_steps, timestep_label, initial_attributes,
+scheduled_inputs) is frozen when status transitions from `pending` to `running`.
+Any PATCH that attempts to modify configuration fields when status is not `pending`
+must return HTTP 422.
+
+### Required Tests
+
+```python
+def test_scenario_create_starts_as_pending() -> None: ...
+def test_scenario_run_transitions_to_running() -> None: ...
+def test_scenario_complete_transitions_to_completed() -> None: ...
+def test_scenario_patch_rejected_when_running() -> None: ...
+def test_scenario_pending_to_failed_on_runtime_validation() -> None: ...
+```
+
+These five tests are required for any implementation of the scenario execution path.
+They gate Issue #111 (WebScenarioRunner) and any future execution engine changes.
+
+---
+
+## Human Cost Indicator Backtesting Requirement (SA-07)
+
+**Source:** STD-REVIEW-002 T1-F7. Issue #122. Extends `§Backtesting Tests` rule 5.
+
+Every backtesting case must include at least one human development indicator with
+a defined DIRECTION_ONLY or MAGNITUDE threshold. A backtesting suite that validates
+only macroeconomic indicators (GDP, inflation, exchange rate) without any human
+cost indicator is incomplete and must not be marked as passing.
+
+### Required Human Cost Indicators by Case
+
+**Greece 2010–2015:**
+- Life expectancy at birth — direction: negative expected over 2010–2012
+- Unemployment rate — direction: positive expected
+- At least one distributional indicator (Gini coefficient or income quintile share) — direction: worsening expected
+
+**Argentina 2001–2004:**
+- Unemployment rate — direction: positive expected through 2002 crisis peak
+- Poverty headcount ratio — direction: positive expected 2001–2002
+- Child mortality rate — direction: negative expected (worsening) 2001–2002
+
+DIRECTION_ONLY is acceptable for initial backtesting runs. MAGNITUDE thresholds are
+required when historical data with sub-annual resolution is available.
+
+A case that passes GDP contraction thresholds but carries zero human cost thresholds
+is architecturally incomplete (ARCH-REVIEW-002 BI2-I-02, Issue #87). Human cost
+indicators are not optional validation surface — they are the primary purpose of the tool.
+
+---
+
+## Snapshot Serialization Standard (SA-12)
+
+**Source:** STD-REVIEW-002 T2-F7. Issue #127.
+
+Every `Quantity` stored as JSONB in a `scenario_state_snapshots.state_data` record
+must round-trip without data loss through the following chain:
+
+```
+Quantity (Python) → json.dumps() → JSONB column → json.loads() → Quantity (Python)
+```
+
+### Required Round-Trip Test
+
+The following test is required for any implementation of the snapshot persistence path:
+
+```python
+def test_quantity_snapshot_round_trip() -> None:
+    original = Quantity(
+        value=Decimal("12345.67"),
+        unit="USD_2015",
+        variable_type="stock",
+        confidence_tier=3,
+    )
+    envelope = quantity_to_jsonb_envelope(original)
+    serialized = json.dumps(envelope)
+    deserialized = json.loads(serialized)
+    restored = quantity_from_jsonb(deserialized)
+    assert restored.value == original.value
+    assert restored.unit == original.unit
+    assert restored.confidence_tier == original.confidence_tier
+    assert restored.observation_date == original.observation_date
+```
+
+### Failure Modes This Test Must Catch
+
+- `observation_date` type: stored as ISO string, must restore as `date` object (not string)
+- `value` type: must restore as `Decimal` (not float, not string coercion artifact)
+- `variable_type`: must restore as the correct enum member, not raw string
+
+Any snapshot persistence implementation that does not include this test is non-compliant.
+
+---
+
+## JSONB Migration Validation Rule (SA-13)
+
+**Source:** STD-REVIEW-002 T2-F10. Issue #128.
+
+Migrations that modify JSONB column content — including `simulation_entities.attributes`,
+`scenario.configuration`, and `scenario_state_snapshots.state_data` — must include a
+validation step confirming all affected rows parse correctly after the migration.
+
+### Minimum Validation
+
+```sql
+SELECT COUNT(*) FROM <table> WHERE <jsonb_column> IS NOT NULL;
+```
+
+This must return the expected row count after the migration, confirming no rows were
+silently dropped or corrupted.
+
+### Structural Modification Validation
+
+For migrations that modify JSONB structure (field renames, type changes), the validation
+step must additionally confirm that the modified fields are present and correctly typed
+in a sample of rows:
+
+```python
+# Post-migration validation sample (required in migration test)
+rows = await conn.fetch("SELECT attributes FROM simulation_entities LIMIT 100")
+for row in rows:
+    attrs = row["attributes"]
+    assert isinstance(attrs, dict), f"attributes is not a dict: {type(attrs)}"
+    # Assert expected key structure here
+```
+
+### Entity Reference Integrity
+
+JSONB configuration columns that contain entity references must not be modified via
+direct SQL outside of the application layer. Migrations that modify JSONB entity
+references must include a validation step confirming all entity_id values in the
+modified column resolve to existing records in `simulation_entities`.
+
+This standard cannot prevent direct database access, but establishes a clear rule for
+migration authors. A migration that skips this validation is non-compliant regardless
+of whether the migration succeeds in testing.

--- a/docs/DATA_STANDARDS.md
+++ b/docs/DATA_STANDARDS.md
@@ -916,6 +916,110 @@ For sources that do not support vintage retrieval, use the following handling:
 
 ---
 
+## Backtesting Fidelity Threshold Registry (SA-08)
+
+**Source:** STD-REVIEW-002 T1-F8 / T2-F3 / T1-F11 — convergent finding. Issue #123.
+
+This section defines the canonical threshold types and their evaluation semantics.
+All backtesting cases must use these definitions — do not reimplement threshold
+evaluation logic in individual fixture files.
+
+### DIRECTION_ONLY
+
+Sign-of-change check only. A simulated value and actual value both negative (or both
+positive) constitutes a pass regardless of magnitude.
+
+**Canonical evaluator** (must be imported by all backtesting cases, not reimplemented):
+
+```python
+def evaluate_direction_only_threshold(
+    attribute: str,
+    simulated_values: list[Decimal],
+    actual_values: list[Decimal],
+) -> bool:
+    return all((s < 0) == (a < 0) for s, a in zip(simulated_values, actual_values))
+```
+
+**False-positive rate table (null model):**
+
+| Independent DIRECTION_ONLY indicators | Probability all pass by chance |
+|---|---|
+| 1 | 50% |
+| 2 | 25% |
+| 3 | 12.5% |
+| 4 | 6.25% |
+| 5 | 3.125% |
+
+**Minimum threshold:** A DIRECTION_ONLY suite must have at least 4 independent indicators
+for the false-positive rate to fall below 6.25%. Suites with fewer than 4 indicators must
+include the statistical power statement verbatim in `ia1_disclosure`.
+
+### MAGNITUDE_WITHIN_PCT
+
+Value within ±N% of historical outturn. N must be explicitly specified in the fixture
+and justified against the calibration tier of the model for that indicator.
+
+Requires parameter calibration to Tier A or B (Issue #44) before use. Do not use
+MAGNITUDE thresholds on uncalibrated indicators — a tight MAGNITUDE threshold on an
+uncalibrated model is more misleading than a DIRECTION_ONLY threshold.
+
+### DISTRIBUTION_COMBINED
+
+Simulated distribution overlaps with historical distribution. Requires uncertainty
+quantification to be validated before use. Not available until ADR-007 band outputs
+are in production.
+
+### Required `ia1_disclosure` Content
+
+Every fidelity report must include:
+1. The threshold type used for each indicator
+2. For DIRECTION_ONLY suites: the false-positive rate statement (see null model table)
+3. For MAGNITUDE suites: the calibration tier justification
+4. At least one human cost indicator threshold (CODING_STANDARDS.md §SA-07)
+
+---
+
+## MDA Threshold Tier Upgrade Evidence Criteria
+
+**Source:** ADR-005 Decision 3 gap — threshold upgrade criteria undefined. Issue #173.
+
+ADR-005 Decision 3 states that MDA thresholds ship at Tier 3 confidence and may be
+upgraded to Tier 2 "when backtesting cases provide enough historical breach evidence."
+This section defines what constitutes sufficient evidence.
+
+### Tier 3 → Tier 2 Upgrade Criteria
+
+A threshold may be upgraded from Tier 3 to Tier 2 when all four criteria are met:
+
+1. **Minimum backtesting case count:** At least 2 independent historical cases (different
+   countries or different crisis episodes) where the threshold was crossed and the
+   consequence the threshold describes was observed.
+
+2. **Breach sensitivity requirement:** The threshold correctly identifies ≥ 75% of
+   documented historical breaches in the backtesting corpus. A threshold that misses
+   more than 25% of known breach episodes is not validated.
+
+3. **False positive ceiling:** The threshold fires on ≤ 20% of non-breach historical
+   periods. A threshold with a false positive rate above 20% is generating noise, not
+   signal.
+
+4. **Review documentation:** The upgrade must be documented in
+   `docs/methodology/mda-calibration.md` (create if absent) with the specific cases
+   used, the sensitivity and false positive measurements, and the approval authority
+   (Engineering Lead or Chief Methodologist for domain-specific thresholds).
+
+### Tier 2 → Tier 1 Upgrade Criteria
+
+Not currently defined. Tier 1 MDA thresholds require external validation by domain
+experts outside the project (Technical Steering Committee scope, M13+).
+
+### Governance
+
+MDA threshold tier upgrades are logged in `docs/methodology/mda-calibration.md`.
+No threshold may be silently upgraded — the calibration document is the audit trail.
+
+---
+
 ## Scenario Fixture Step Annotation
 
 **Authority:** EL Decision 1 (2026-05-21, Premise 3); PR #390 Gap 1B; Issue #395.

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -532,6 +532,84 @@ would be the exact inversion of the mission.
 
 ---
 
+## Output Use in Live Decision Contexts (SA-10)
+
+**Source:** STD-REVIEW-002 T1-F10. Issue #125.
+
+WorldSim is intended for use in active negotiations, ministerial briefings, and
+policy analysis. Before outputs enter those contexts, the following disclosures are
+required.
+
+### Required Disclosures
+
+Any WorldSim output used in a live decision context — negotiation, ministerial
+briefing, parliamentary testimony, or media briefing — must carry:
+
+1. **Scenario analysis label:** "This is a scenario analysis, not a prediction."
+2. **Confidence basis:** The model confidence level (DIRECTION_ONLY / MAGNITUDE /
+   CALIBRATED) for each indicator presented.
+3. **DIRECTION_ONLY disclosure** where applicable: "A DIRECTION_ONLY result
+   validates the direction of change, not the magnitude. The probability that all
+   direction checks pass under an uncalibrated null model is 1-in-2^N, where N is
+   the number of steps checked."
+
+### What the Simulation Does Not Claim
+
+WorldSim outputs are structured reasoning aids. They do not predict outcomes. They
+do not constitute IMF or World Bank policy advice. They do not represent the position
+of any government or institution. The model's known limitations and blindspots are
+documented in `docs/POLICY.md §Declared Blindspots` and must be made available to
+any party using the outputs in a decision context.
+
+### Geopolitical Use Sensitivity
+
+Outputs related to currency attack vulnerability, sanctions exposure, and financial
+warfare modules carry an additional required disclosure: "This output describes
+defensive situational awareness. It must not be used to plan or execute financial
+attacks against third parties."
+
+This requirement is a permanent feature of the dual-use framework, not a temporary
+restriction. See `docs/POLICY.md §Dual-Use Position`.
+
+---
+
+## Scenario Data Retention (SA-06)
+
+**Source:** STD-REVIEW-002 T1-F6. Issue #121.
+
+### Retention Principles
+
+Scenario configurations (entities, n_steps, scheduled inputs) are treated as research
+artifacts, not transient session data. Scenario state snapshots carrying `ia1_disclosure`
+records represent a commitment to an epistemic position at a point in time. Their
+destruction removes the audit trail of what the model said and when.
+
+### Soft Delete as Default
+
+The public WorldSim API offers soft-delete (marking scenarios as archived) rather than
+hard delete as the default operation. A soft-deleted scenario is not visible in normal
+listings but its configuration and snapshot records remain recoverable.
+
+### Hard Delete
+
+Hard delete (permanent removal) requires operator-level authorization and is logged as
+an audit event. End users do not have hard-delete access through the public API.
+
+### Minimum Retention Period
+
+Scenario records are retained for a minimum of 30 days after soft-delete. Permanent
+retention is offered for scenarios explicitly archived by the user. This minimum may
+be extended by institutional agreements with finance ministries or partner organizations.
+
+### Rationale
+
+The STD-REVIEW-002 CONFLICT C-1 (DELETE CASCADE audit trail destruction) is resolved
+by Option A: soft delete as the default path. Hard delete removes the audit trail of
+what the model produced and when — in a tool used for consequential decision support,
+that audit trail is a methodological commitment, not an implementation detail.
+
+---
+
 ## Challenge and Correction Process
 
 ### How to Challenge Any Position in This Document


### PR DESCRIPTION
## Summary

Eight standards-gap amendments from STD-REVIEW-002 and STD-REVIEW-003, all open since M3–M5. Pure document additions — no code changes.

**Closes #119, #121, #122, #123, #125, #127, #128, #173**

### CODING_STANDARDS.md

- **SA-04 (#119)** — Simulation Lifecycle State Machine: valid statuses (`pending/running/completed/failed`), valid transitions, immutability rule (config frozen at `pending→running`), five required tests
- **SA-07 (#122)** — Human Cost Indicator Backtesting Requirement: explicit required HD indicators for Greece and Argentina; a suite passing GDP without HD indicators is architecturally incomplete
- **SA-12 (#127)** — Snapshot Serialization Standard: `Quantity` round-trip chain, required test, failure modes (observation_date type, Decimal fidelity)
- **SA-13 (#128)** — JSONB Migration Validation Rule: row-count confirmation, structural modification sample check, entity reference integrity

### DATA_STANDARDS.md

- **SA-08 (#123)** — Backtesting Fidelity Threshold Registry: canonical `evaluate_direction_only_threshold()` evaluator, false-positive rate table, 4-indicator minimum rule, `ia1_disclosure` requirements
- **#173** — MDA Threshold Tier Upgrade Evidence Criteria: closes ADR-005 Decision 3 gap ("enough historical breach evidence" now defined as ≥2 independent cases, ≥75% sensitivity, ≤20% false positive ceiling)

### POLICY.md

- **SA-10 (#125)** — Output Use in Live Decision Contexts: required disclosures for active negotiations/briefings, geopolitical use sensitivity note
- **SA-06 (#121)** — Scenario Data Retention: soft delete as default, hard delete requires operator auth + audit log, 30-day minimum; resolves STD-REVIEW-002 CONFLICT C-1 as Option A

🤖 Generated with [Claude Code](https://claude.com/claude-code)