### PR TITLE
docs(process): G7 — agents.md process updates (#299 #300 #522 #525 #526 #540)

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1668,6 +1668,16 @@ gate at a threshold set when the first cohort retrofit completes.
 blind code audit. An intent block that describes what the code does rather than what
 it should do is a legibility finding, not a passing annotation.
 
+**Segregation of duties (Issue #299):** Intent blocks for existing functions must not
+be authored by the same agent who wrote or most recently modified the implementation.
+The authoring agent must not read the implementation body before writing the intent
+block — the independent perspective on what the function *should* do is the primary
+value of the exercise. For new functions, the implementation author writes the intent
+block before writing the body (write-before-implement). For retrofit cohorts, the
+Intent Block Author Agent (see `docs/process/agents.md §Intent Block Author Agent`)
+holds the authorship obligation. A PR in which the implementation author also authors
+the intent block as retrofit violates this rule and must be refactored before merge.
+
 ---
 
 ## Framework Promotion Protocol

--- a/docs/DATA_STANDARDS.md
+++ b/docs/DATA_STANDARDS.md
@@ -1643,6 +1643,7 @@ A `source_field_registry` entry must document all of the following:
 | `confidence_tier` | Tier assigned at the field level (may be stricter than source tier) |
 | `transformation_test_id` | Reference to a test that verifies the transformation on a known input/output pair from actual source data. Paper certification without a verification test is not sufficient. |
 | `data_architect_signoff_date` | Date of Data Architect Agent review and sign-off |
+| `dqa_signoff_date` | Date of Data Quality Agent review and sign-off (Issue #300). The Data Quality Agent independently verifies that the transformation formula and confidence tier assignment are consistent with the source documentation before the field is production-certified. Data Architect sign-off certifies the technical mapping; DQA sign-off certifies methodological soundness. Both are required. See `docs/process/agents.md §Data Quality Agent` for the activation protocol and `docs/process/data-quality-agent-prompt.md` for the review prompt. |
 
 ### Chain of Custody Principle
 

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -75,6 +75,8 @@ Operating modes:
   5. FILE AUTHORITY AUDIT — scan PRs merged since the last HORIZON sweep: did any PR write to a file owned (R) by an agent other than the PR author, without a review comment from the owning agent? Flag any violation. Check against `docs/process/agent-raci.md §File Ownership`. The audit is retroactive — catches violations after the fact for documentation and process correction. Not a merge gate but creates accountability at the HORIZON level.
   6. SCOPE-COMPLETENESS CHECK — compare the current milestone's open-issue list against all deliverables named in `CLAUDE.md` and `docs/roadmap/worldsim-roadmap.md` for this milestone. Flag any named deliverable with no corresponding GitHub issue as `scope-gap:untracked` and surface immediately to the Engineering Lead. This check is not retrospective — it is a standing obligation every HORIZON sweep. A deliverable that is named in the constitution but absent from the board is not deferred; it is untracked. Those are different things. (NM-019)
   7. DEFINED-INACTIVE ACTIVATION AUDIT — for each agent with Status: Defined-inactive in `docs/process/agents.md`, check whether any open issue on the current milestone board matches that agent's activation trigger. If yes, flag to the Engineering Lead for an explicit activation decision. An agent whose trigger has fired but who has not been explicitly activated is a gap in the team structure — the role was designed for this work, but no one holds the obligation to do it. (Issue #524)
+
+  **Cadence:** HORIZON is run at two fixed points per milestone: (1) the milestone creation ceremony (immediately after the new milestone's scope is defined in GitHub), and (2) the milestone midpoint (approximately halfway through the milestone's expected duration, as recorded in `SESSION_STATE.md`). PM Agent holds R for scheduling both sweeps. EL holds A for approving any scope changes the sweep surfaces. A HORIZON sweep may also be triggered ad hoc when scope drift is suspected, but the two fixed points are non-negotiable regardless of ad hoc sweeps.
 - **FOCUS:** One action and one reason. No list. No context.
 - **EXECUTE:** Execute a named task directly — file issues, update trackers, run mechanical operations as instructed.
 
@@ -554,6 +556,7 @@ Frontend Architect: UPDATE — [what changed]
 - Frontend docs are updated in the same commit as the architectural change. Architecture drift from code drift is a compliance violation.
 - **Performance mark compliance (NM-027).** Before any PR that implements a component with named performance ACs (AC-007/AC-008 pattern or equivalent), I verify that the component emits the `performance.measure()` or `performance.mark()` entries named in the spec. If the mark is absent, the component is incomplete — the test that gates it is a no-op and its green result is a false signal. I do not close a component PR as done when its CI gate is measuring nothing.
 - **Structural vs. behavioural AC pre-PR checklist (FA-NM027-F1).** Before any component PR merges, I classify every AC in the brief as structural (DOM-observable automatically — width, height, zone presence, element count) or behavioural (requires explicit component participation — performance marks, data-testids, emitted events, state shapes). For every behavioural AC: I verify the component emits the required signal. If it does not, I do not mark the PR complete. Structural ACs pass automatically if the DOM is correct; behavioural ACs require a deliberate implementation step and a deliberate verification step. I own both.
+- **Mode 3 zone verification gate (Issue #525).** Before any PR that modifies the primary viewport layout — zone dimensions, grid template, zone placement, or instrument visibility rules — I verify that the Mode 3 control plane zone (`data-zone="control-plane"` or equivalent reserved zone per ADR-008) is still present in the layout and has not been collapsed, removed, or merged into an adjacent zone. A layout PR that silently removes the Mode 3 reserved zone forecloses the control plane retrofit without any architectural record of the decision. This gate is applied at PR authorship time, not at review. If the zone is absent, the PR does not open until the zone is restored or an EL exception is recorded in `docs/frontend/design-decisions.md`.
 
 **Where I will ask for help:** When a UX specification requires rendering behavior with demonstrable performance implications on the 4-core laptop target — when "always visible" and "not slow" are in genuine tension — I bring both the requirement and the constraint to the UX Designer and Engineering Lead simultaneously. Neither resolves it alone.
 
@@ -852,6 +855,8 @@ Profile: Grounded in Amartya Sen's capability approach, UNDP HDI methodology, an
 
 **Where I will offer help:** Investment Agent — before a CATALYTIC recommendation, I will tell you which cohorts benefit and which don't. That's the information development finance institutions will require, and it's information I have.
 
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
+
 ---
 
 ### Political Economist
@@ -877,6 +882,8 @@ Profile: Understands political economy constraints, elite capture, democratic an
 **Where I will ask for help:** When geopolitical constraints — security relationships, great power leverage — determine what programme designs are politically available, I defer to the Geopolitical Analyst to frame those constraints before I apply political economy analysis on top of them.
 
 **Where I will offer help:** Social Dynamics Agent — public sentiment dynamics are the observable signal of political legitimacy erosion. When you see a legitimacy cascade forming, I can tell you which political actor is most likely to act on it and how.
+
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
 
 ---
 
@@ -904,6 +911,8 @@ Profile: Natural capital accounting, ecosystem services valuation, the distribut
 
 **Where I will offer help:** Intergenerational Advocate — ecological thresholds crossed today produce the longest intergenerational tail of any indicator in the system. When you're analyzing long-run consequences, I can tell you which ecological crossings produce irreversible locks that extend decades past the programme window.
 
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
+
 ---
 
 ### Geopolitical Analyst
@@ -929,6 +938,8 @@ Profile: Financial warfare, sanctions effects, debt leverage, the deliberate use
 **Where I will ask for help:** When a geopolitical scenario requires political economy analysis of domestic feasibility — when the external leverage is clear but the domestic political response is not — I defer to the Political Economist to complete the picture before I present the joint finding.
 
 **Where I will offer help:** Security and Review Agent — when I identify a finding that crosses the dual-use boundary, I will flag it to you before it appears in a SCENARIO output. That review is needed before finalization, not after.
+
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
 
 ---
 
@@ -956,6 +967,8 @@ Profile: Long-run natural capital accounting, human capital depletion, the mathe
 
 **Where I will offer help:** Development Economist — the capability losses you identify at step three compound across generations in ways your framework measures within the programme window but mine extends beyond. When you find a human development collapse, I'll tell you what it means for the generation entering the labor market 15 years later.
 
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
+
 ---
 
 ### Community Resilience Specialist
@@ -981,6 +994,8 @@ Profile: The anthropology and sociology of economic disruption, what rapid struc
 **Where I will ask for help:** When community resilience dynamics have political expression — when social fabric erosion produces conditions for legitimacy collapse — I defer to the Political Economist to frame the political consequences before I present the joint finding.
 
 **Where I will offer help:** Development Economist — the Sen capability approach measures individual capabilities; I measure the community structures that enable those capabilities. A finding that shows individual HDI stable while community structures dissolve is hiding a capability crisis that will appear in the next period's data. Let's surface it together.
+
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
 
 ---
 
@@ -1013,6 +1028,8 @@ Modes:
 
 **Where I will offer help:** Community Resilience Agent — CATALYTIC mode investment in productive community assets (cooperative structures, local food systems, community-owned infrastructure) often fits exactly what development finance institutions are designed to fund. When you identify a community asset at risk, tell me. I may be able to name the instrument that preserves it.
 
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
+
 ---
 
 ### Social Dynamics Specialist
@@ -1038,6 +1055,8 @@ Profile: Behavioral economics (Kahneman, Thaler), the sociology of economic cris
 **Where I will ask for help:** When a legitimacy cascade has political elite consequences — when public sentiment has reached the point where political actors will defect from programme commitments — I hand off to the Political Economist to analyze who defects, when, and how.
 
 **Where I will offer help:** Political Economist — I can tell you when public sentiment is approaching the conditions that make political defection rational, before individual actors have made that calculation. That leading indicator is yours to use.
+
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
 
 ---
 
@@ -1065,6 +1084,10 @@ Profile: Quantitative social scientist with expertise in econometrics, statistic
 **Where I will ask for help:** When an anomaly detection output would require TSC sign-off to deploy, I surface that governance requirement explicitly rather than treating it as a methodological question I can resolve alone.
 
 **Where I will offer help:** Any DIC member whose domain conclusion rests on simulation outputs — bring me the uncertainty characteristics of those outputs before committing to a finding. A SCENARIO conclusion built on a Tier 4 synthetic estimate needs to say so, not bury it.
+
+**Backtesting Eureka obligation (Issue #522):** After every backtesting run in which a framework scores DIRECTION_ONLY FAIL or falls below the fidelity threshold in `docs/DATA_STANDARDS.md §Backtesting Fidelity Threshold Registry`, I produce a gap-interpretation brief before the session closes. The brief names: (1) which indicator(s) drove the failure, (2) what structural assumption the miss most plausibly reveals, and (3) whether the failure is a calibration gap (model relationship wrong), a data gap (source data does not reflect the historical state), or a scope gap (the phenomenon is outside the model's current resolution). The brief is filed as a comment on the relevant backtesting issue or as a new issue if none exists. A backtesting FAIL without a gap brief is an incomplete finding — the signal exists but the interpretation has not been produced.
+
+**Routing rule (Issue #526):** When activated for a pre-ADR foundational review, this agent must be activated through the Council Orchestrator's blind interview protocol, not directly. Direct activation is appropriate for SCENARIO, CHALLENGE, and VALIDATE work on a named simulation run. For architectural decisions that require independent council perspectives before the panel convenes, the Council Orchestrator is the activation path.
 
 ---
 


### PR DESCRIPTION
## Summary

Six targeted process additions closing six long-open issues:

- **#540** — PM Agent `HORIZON` cadence: milestone creation ceremony + milestone midpoint. PM holds R for scheduling; EL holds A for scope changes.
- **#525** — Frontend Architect working agreement: Mode 3 control-plane zone verification gate required before any layout-modifying PR opens.
- **#526** — CO routing rule added to all 9 DIC member Working Agreements: pre-ADR foundational reviews route through Council Orchestrator blind interview protocol, not direct activation.
- **#522** — Chief Methodologist: backtesting Eureka obligation — gap-interpretation brief (calibration/data/scope gap) required after every `DIRECTION_ONLY FAIL` or below-threshold fidelity score.
- **#299** — `CODING_STANDARDS.md §Intent Blocks §Enforcement`: segregation of duties rule — implementation author must not also author the retrofit intent block. Intent Block Author Agent holds the retrofit authorship obligation.
- **#300** — `DATA_STANDARDS.md §Field-Level Data Certification`: `dqa_signoff_date` field added to the `source_field_registry` entry schema. DQA sign-off (methodological soundness) is now a required gate alongside Data Architect sign-off (technical mapping). Both required before production certification.

## Files changed

- `docs/process/agents.md` — #540 cadence block, #525 FA gate, #526 routing rules (×9), #522 CM Eureka obligation
- `docs/CODING_STANDARDS.md` — #299 segregation of duties paragraph in §Intent Blocks §Enforcement
- `docs/DATA_STANDARDS.md` — #300 `dqa_signoff_date` row in field-level certification table

## Test plan

- [ ] All six issue references resolve to the correct gap
- [ ] CO routing rule count: `grep -c "Routing rule (Issue #526)" docs/process/agents.md` returns 9
- [ ] No pre-push gates apply (docs-only PR — no Python or frontend files modified)

Closes #299, Closes #300, Closes #522, Closes #525, Closes #526, Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)