### PR TITLE
feat(api): G10 — scenario output disclaimers: temporal scope and Level 1 resolution (#98 #100 #158)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -60,6 +60,7 @@ from app.schemas import (
     TrajectoryFrameworkPoint,
     TrajectoryResponse,
     TrajectoryStep,
+    build_temporal_scope_note,
 )
 from app.simulation.mda_checker import alerts_from_events_snapshot
 from app.simulation.repositories.quantity_serde import IA1_CANONICAL_PHRASE
@@ -303,6 +304,9 @@ def _build_detail_response(
         created_at=created_at_str,
         configuration=config,
         scheduled_inputs=scheduled,
+        temporal_scope_note=build_temporal_scope_note(
+            config.n_steps, config.timestep_label, config.start_date
+        ),
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,6 +15,36 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 
 # ---------------------------------------------------------------------------
+# Output disclaimer constants — Issue #98, #100, #158
+# ---------------------------------------------------------------------------
+
+# Level 1 resolution disclaimer: static for all current scenarios.
+# Subnational / community impacts are structurally invisible at nation-state
+# aggregation. ARCH-REVIEW-002 BI2-N-09, ARCH-REVIEW-003 BI3-N-08.
+RESOLUTION_DISCLAIMER_L1: str = (
+    "Outputs represent national-level aggregates (Level 1 resolution). "
+    "Subnational, community, and regional impacts are not representable "
+    "at this resolution. Differential impact across regions, income cohorts, "
+    "or demographic groups requires Level 2–4 resolution, which is not "
+    "available in this scenario. "
+    "See docs/scenarios/module-capability-registry.md for interpretation guidance."
+)
+
+RESOLUTION_LEVEL_CURRENT: int = 1
+
+
+def build_temporal_scope_note(n_steps: int, timestep_label: str, start_date: object) -> str:
+    """Generate temporal scope note from scenario config. Issue #98."""
+    start_str = str(start_date) if start_date is not None else "the configured start date"
+    return (
+        f"This scenario models {n_steps} {timestep_label} timestep(s) from {start_str}. "
+        "Consequences that compound over longer time horizons — including intergenerational "
+        "capability losses, long-run debt sustainability, and ecological system responses — "
+        "are outside the modeled window and are not represented in this output."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Trajectory endpoint schemas — Issue #458
 # ---------------------------------------------------------------------------
 
@@ -315,7 +345,12 @@ class ScenarioResponse(BaseModel):
 
 
 class ScenarioDetailResponse(BaseModel):
-    """Full scenario record including configuration and scheduled inputs."""
+    """Full scenario record including configuration and scheduled inputs.
+
+    `temporal_scope_note` is generated from scenario configuration and surfaces
+    the intergenerational / long-horizon limitation per ARCH-REVIEW-002 BI2-N-07
+    (Issue #98). Computed at response time — not stored in the database.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -327,6 +362,7 @@ class ScenarioDetailResponse(BaseModel):
     created_at: str
     configuration: ScenarioConfigSchema
     scheduled_inputs: list[ScheduledInputSchema]
+    temporal_scope_note: str
 
 
 class RunSummaryResponse(BaseModel):
@@ -346,6 +382,9 @@ class SnapshotRecord(BaseModel):
     `modules_active` lists the domain modules that contributed to this snapshot.
     Empty list for all M3 snapshots (no domain modules implemented). Populated
     in M4+ from the `_modules_active` key in state_data. See Issue #145, #146.
+
+    `resolution_disclaimer` surfaces the Level 1 resolution limitation per
+    ARCH-REVIEW-002 BI2-N-09 (Issue #100, #158). Static for all current scenarios.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -355,10 +394,16 @@ class SnapshotRecord(BaseModel):
     timestep: str
     state_data: dict[str, Any]
     modules_active: list[str] = []
+    resolution_disclaimer: str = RESOLUTION_DISCLAIMER_L1
 
 
 class AdvanceResponse(BaseModel):
-    """Response from POST /scenarios/{id}/advance — ADR-004 Decision 4."""
+    """Response from POST /scenarios/{id}/advance — ADR-004 Decision 4.
+
+    `resolution_level` and `resolution_disclaimer` surface the Level 1
+    resolution limitation per ARCH-REVIEW-002 BI2-N-09 and ARCH-REVIEW-003
+    BI3-N-08 (Issue #158). Static for all current scenarios.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -367,6 +412,8 @@ class AdvanceResponse(BaseModel):
     steps_remaining: int
     final_status: str
     is_complete: bool
+    resolution_level: int = RESOLUTION_LEVEL_CURRENT
+    resolution_disclaimer: str = RESOLUTION_DISCLAIMER_L1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_scenario_schemas.py
+++ b/backend/tests/unit/test_scenario_schemas.py
@@ -194,6 +194,8 @@ def test_scenario_response_with_description() -> None:
 
 
 def test_scenario_detail_response_fields() -> None:
+    from app.schemas import build_temporal_scope_note
+
     detail = ScenarioDetailResponse(
         scenario_id="abc",
         name="Greece test",
@@ -203,13 +205,18 @@ def test_scenario_detail_response_fields() -> None:
         created_at="2026-04-23T10:00:00+00:00",
         configuration=ScenarioConfigSchema(entities=["GRC"], n_steps=3),
         scheduled_inputs=[],
+        temporal_scope_note=build_temporal_scope_note(3, "annual", None),
     )
     assert detail.configuration.entities == ["GRC"]
     assert detail.configuration.n_steps == 3
     assert detail.scheduled_inputs == []
+    assert "3 annual" in detail.temporal_scope_note
+    assert "intergenerational" in detail.temporal_scope_note
 
 
 def test_scenario_detail_response_with_inputs() -> None:
+    from app.schemas import build_temporal_scope_note
+
     detail = ScenarioDetailResponse(
         scenario_id="abc",
         name="Test",
@@ -225,6 +232,7 @@ def test_scenario_detail_response_with_inputs() -> None:
                 input_data={"k": "v"},
             )
         ],
+        temporal_scope_note=build_temporal_scope_note(2, "annual", "2010-01-01"),
     )
     assert len(detail.scheduled_inputs) == 1
     assert detail.scheduled_inputs[0].input_type == "FiscalPolicyInput"

--- a/docs/scenarios/module-capability-registry.md
+++ b/docs/scenarios/module-capability-registry.md
@@ -478,11 +478,19 @@ threshold effects are not yet modelled.
 - Policy optimisation — endogenous response is partial; social and political
   feedback absent
 - Crisis threshold predictions — no threshold dynamics within current engine
-- Subnational or community-level impacts — Level 1 nation-state resolution
-  only; country averages conceal regional and community differentiation
-  (ARCH-REVIEW-003 BI3-N-08)
-- Intergenerational effects (annual timesteps; long-horizon consequences
-  outside modelled window)
+- **Subnational or community-level impacts** — Level 1 nation-state resolution
+  only; country averages conceal regional and community differentiation.
+  All scenario API outputs carry a `resolution_disclaimer` field stating this
+  limitation explicitly (Issue #100, #158 / ARCH-REVIEW-002 BI2-N-09,
+  ARCH-REVIEW-003 BI3-N-08). Rural clinic closures, island emigration,
+  regional unemployment differentials — these dynamics are structurally
+  invisible at Level 1 and cannot be inferred from national aggregates.
+- **Intergenerational and long-horizon effects** — annual-timestep scenarios
+  model N steps from a start date; consequences compounding over 20–30 years
+  (education truncation, working-age emigration, pension restructuring) are
+  outside the modeled window. All scenario detail responses carry a
+  `temporal_scope_note` field stating the modeled window explicitly (Issue #98
+  / ARCH-REVIEW-002 BI2-N-07).
 - Risk-adjusted scenario comparison (no variance or distributional output;
   `DeltaRecord.delta` is a point estimate only)
 - Full ecological or governance composite scores — both modules are initial

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -325,6 +325,7 @@ endpoints:
             step: {type: integer}
             input_type: {type: string}
             input_data: {type: object}
+        temporal_scope_note: {type: string, description: "Generated from n_steps + timestep_label + start_date. States the modeled window and notes that intergenerational / long-horizon consequences are outside it. Issue #98 / ARCH-REVIEW-002 BI2-N-07."}
       status_404: "Scenario not found"
     db_reads: [scenarios, scenario_scheduled_inputs]
 
@@ -379,6 +380,8 @@ endpoints:
         steps_remaining: {type: integer}
         final_status: {type: string, values: ["running", "completed"]}
         is_complete: {type: boolean}
+        resolution_level: {type: integer, description: "Always 1 for current scenarios — nation-state Level 1 resolution. Issue #158 / ARCH-REVIEW-002 BI2-N-09."}
+        resolution_disclaimer: {type: string, description: "Static disclaimer: subnational/community impacts not representable at Level 1 resolution. Issue #158."}
       status_404: "Scenario not found"
       status_409: "Scenario is already completed"
     db_reads: [scenarios, scenario_state_snapshots, simulation_entities, mda_thresholds]
@@ -407,6 +410,7 @@ endpoints:
               Full state_data JSONB. Top-level keys: entity_id strings +
               _envelope_version + _modules_active. See database.yml state_data.
           modules_active: {type: "string[]"}
+          resolution_disclaimer: {type: string, description: "Static Level 1 resolution disclaimer. Issue #100 / ARCH-REVIEW-002 BI2-N-09."}
       status_404: "Scenario not found"
     db_reads: [scenarios, scenario_state_snapshots]
 


### PR DESCRIPTION
## Summary

Three ARCH-REVIEW-002/003 findings implemented: scenario API outputs now carry explicit disclaimers for their known limitations.

- **#98** (ARCH-REVIEW-002 BI2-N-07): `temporal_scope_note` added to `ScenarioDetailResponse`. Generated from `n_steps + timestep_label + start_date` at response time — no DB change. Tells the consumer exactly what window is modeled and that intergenerational / long-horizon consequences are outside it.

- **#100** (ARCH-REVIEW-002 BI2-N-09): `resolution_disclaimer` added to `SnapshotRecord`. Static string for all current Level 1 scenarios, explaining that subnational / community / regional impacts are not representable at national aggregation.

- **#158** (ARCH-REVIEW-003 BI3-N-08): `resolution_level: int` and `resolution_disclaimer: str` added to `AdvanceResponse`. Static for current scenarios (always `1`). Both fields added to `api_contracts.yml` advance response spec.

## Changes

| File | Change |
|---|---|
| `backend/app/schemas.py` | Constants + `build_temporal_scope_note()`; new fields on `AdvanceResponse`, `SnapshotRecord`, `ScenarioDetailResponse` |
| `backend/app/api/scenarios.py` | `_build_detail_response` computes and passes `temporal_scope_note`; imports `build_temporal_scope_note` |
| `backend/tests/unit/test_scenario_schemas.py` | Two `ScenarioDetailResponse` constructions updated; assertions on note content |
| `docs/schema/api_contracts.yml` | Fields added to advance, snapshots, and scenario-detail endpoint specs |
| `docs/scenarios/module-capability-registry.md` | Subnational and intergenerational bullets expanded; reference to API disclaimer fields |

## Test plan

- [ ] 926 tests passing, ruff clean (pre-push gates satisfied)
- [ ] `GET /scenarios/{id}` response contains `temporal_scope_note`
- [ ] `POST /scenarios/{id}/advance` response contains `resolution_level=1` and `resolution_disclaimer`
- [ ] `GET /scenarios/{id}/snapshots` items contain `resolution_disclaimer`

Closes #98, Closes #100, Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)