### PR TITLE
docs(process): G11 — formalize demo → Socratic TEST ordering in Milestone Closure Ceremony (#664 Gap 3)

### DIFF
--- a/docs/MILESTONE_RUNBOOK.md
+++ b/docs/MILESTONE_RUNBOOK.md
@@ -228,13 +228,18 @@ Audit above is complete.**
    skip this step with a one-line note on the exit checklist confirming no demo was
    scheduled. If the stakeholder session is explicitly deferred, record the rationale
    and deferral date as a comment on the exit checklist issue.
-   Note: the canonical ordering of this step relative to step 5 (Socratic Agent TEST)
-   is being formalized in Issue #664. Until that issue closes, the demo cycle must
-   complete within the same milestone as the TEST — sequencing is at EL discretion.
 
 5. **Socratic Agent TEST session completed.** The Engineering Lead has demonstrated
    genuine understanding of the milestone's architectural contributions. This is not
    a formality — it is the checkpoint that ensures the codebase remains governable.
+
+   **Ordering rule (Issue #664 Gap 3):** Step 5 occurs after step 4 (stakeholder
+   session). The Socratic Agent TEST is the Engineering Lead's demonstration of
+   architectural understanding; the demo stakeholder session is one of the inputs
+   that should inform it. If the stakeholder session surfaces a critical architectural
+   misunderstanding, the TEST must cover it — which is only possible if the session
+   occurs first. Odd-numbered milestones (no demo) are exempt from this dependency
+   and may run the TEST at any point after the exit checklist is confirmed.
 
 6. **Release tag created.** Tag the merge commit with semantic versioning:
    `v0.N.0` for Milestones 0 through 4 (pre-release). Tag message includes a brief


### PR DESCRIPTION
## Summary

Resolves the last open gap in Issue #664: the canonical ordering between the demo stakeholder session (Closure Ceremony step 4) and the Socratic Agent TEST (step 5).

**What changed:** The "sequencing is at EL discretion until Issue #664 closes" note in step 4 is replaced by an explicit ordering rule in step 5: stakeholder session → Socratic TEST. The rationale is documented: demo findings may surface architectural understanding gaps that the TEST must cover, which requires the session to occur first.

**What was already addressed in prior PRs:**
- Gap 1 (severity vocabulary): Issue #663 body and `demo-preparation-standard.md §Step 6b` already use CRITICAL/HIGH/MEDIUM/LOW.
- Gap 2 (demo in Closure Ceremony): Step 4 "Demo cycle complete" was already present in the Runbook.
- Gap 4 (HIGH finding GitHub tracking): The tracking requirement text was already in `demo-preparation-standard.md §Step 8`.

## Files changed

- `docs/MILESTONE_RUNBOOK.md` — step 4 note removed; step 5 ordering rule added (8 lines net)

## Test plan

- [ ] No pre-push gates apply (docs-only PR)
- [ ] Step 4 no longer contains the EL-discretion sequencing note
- [ ] Step 5 contains the explicit ordering rule with odd-milestone exemption

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)