### PR TITLE
docs(process): G13 — statistical power template, monoculture risk, IR handover protocol

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -806,6 +806,27 @@ all DIRECTION_ONLY thresholds by chance. A Greece 2010–2012 3-step case has a 
 condition for model confidence.** It asserts directional plausibility; it does not
 validate the model's quantitative accuracy.
 
+Every fidelity report must include the following block verbatim (with template
+variables filled in) in its Known Limitations section (Issue #160). The
+`format_fidelity_report()` function includes this via the
+`parameter_calibration_disclosure` argument — do not remove or abbreviate it:
+
+```
+Statistical power statement:
+- Threshold type: DIRECTION_ONLY (sign check — not magnitude validation)
+- Checks performed: {N} ({indicators} × {steps} steps)
+- False positive rate under null model: {rate:.1%}
+- What PASS validates: The simulation produces the correct sign (direction) for specified indicators
+- What PASS does NOT validate: Quantitative accuracy, magnitude, distributional fit, or endogenous dynamics
+```
+
+Where `{N}` = total number of sign checks, `{rate}` = `(0.5 ** N)` expressed as a
+percentage. For a 6-check case (2 indicators × 3 steps): N=6, rate=1.6%.
+For a 2-check case: N=2, rate=25.0%.
+
+This block must appear in both the printed fidelity report and the JSON artifact
+(Issue #154). A fidelity report that omits it is architecturally incomplete.
+
 **The three-tier threshold hierarchy:**
 
 | Tier | Name | What it checks | When to use |

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -532,6 +532,75 @@ would be the exact inversion of the mission.
 
 ---
 
+## Model Monoculture Risk (Issue #276)
+
+**Source:** Domain Intelligence Council blind interview finding, 2026-05-11.
+Chief Methodologist (unprompted). Carries forward CLAUDE.md §Blindspots are documented,
+not hidden and §No False Precision.
+
+### The Risk
+
+WorldSim is designed to give vulnerable actors the same quality of analytical
+capability that sophisticated institutions currently reserve for themselves. If
+WorldSim achieves institutional adoption, a second-order risk emerges: IMF
+counterparty teams will learn the model's parameterization and optimize
+conditionality proposals against the model's known blindspots rather than against
+underlying economic reality.
+
+When all parties in a negotiation use the same analytical model, the model's
+assumptions become negotiated reality rather than analytical inputs. The model
+then provides worse-than-random guidance on the scenarios where it matters most
+— because those scenarios will have been specifically constructed to look
+favorable under WorldSim's measurement framework while the mechanisms the model
+does not capture are doing the real work.
+
+### WorldSim's Position
+
+**WorldSim is designed to be one analytical instrument among many — not a
+definitive arbiter.**
+
+A finance ministry using WorldSim as its sole analytical tool has not leveled
+the playing field. It has traded one form of analytical dependency for another.
+The tool's value is in structured reasoning alongside other instruments, not in
+replacing independent judgment or expert domain knowledge.
+
+**Methodological diversity is a defense.** A ministry that uses WorldSim
+alongside its own economic team's models, regional peer comparisons, and
+independent expert review is more robust to WorldSim's blindspots than one
+that treats WorldSim outputs as authoritative. The project actively encourages
+this multi-instrument approach.
+
+**Challenging the model is not a failure — it is the intended use.** The
+public methodology documentation exists precisely so that any counterparty,
+critic, or domain expert can inspect, challenge, and improve the model's
+parameterization. A methodology that cannot be publicly challenged cannot be
+trusted. The open-source commitment is a methodological transparency commitment,
+not just an access commitment.
+
+### What the Project Does
+
+1. **Public parameterization disclosure.** Every module documents what it
+   models, what it does not model, and what class of scenarios would cause it
+   to produce misleading outputs. This is a first-class output, not a disclaimer.
+
+2. **Declared Blindspots registry.** Known model limitations are documented
+   explicitly in §Declared Blindspots and surfaced to users — not buried in
+   methodology appendices.
+
+3. **Technical Steering Committee mandate.** The TSC (M13 milestone target)
+   owns the monitoring and response framework for parameterization gaming risk.
+   If systematic optimization against WorldSim's blindspots is detected in
+   real-world conditionality proposals, the TSC has authority to update the
+   model's measurement framework to close the exploited gap.
+
+4. **Goodhart's Law acknowledgment.** WorldSim's own outputs are subject to
+   Goodhart's Law: once a model becomes a target, it ceases to be a good measure.
+   The project will not pretend otherwise. The response to this risk is
+   methodological pluralism and continuous improvement, not claims of model
+   immunity.
+
+---
+
 ## Output Use in Live Decision Contexts (SA-10)
 
 **Source:** STD-REVIEW-002 T1-F10. Issue #125.

--- a/docs/process/independent-review-prompt.md
+++ b/docs/process/independent-review-prompt.md
@@ -203,6 +203,64 @@ Issues produced by the independent review should be:
 The review output is evidence, not a work order. The Engineering Lead
 decides which issues to act on and when.
 
+### Storage Convention (Issue #234)
+
+Every stakeholder review produces a permanent artifact committed to the repository.
+Canonical location: `docs/demo/{milestone}/reviews/YYYY-MM-DD-vX.X.X-stakeholder-review.md`
+
+Example: `docs/demo/m10/reviews/2026-05-30-v0.10.0-stakeholder-review.md`
+
+This path matches the CLAUDE.md §Canonical Artifact Locations table and the
+`docs/demo/{milestone}/reviews/*-stakeholder-review.md` file ownership row in
+`docs/process/agent-raci.md` (IR Agent holds Responsible).
+
+### Report Template
+
+The review instance writes the findings section. The development instance
+adds issue numbers and status before committing. Template:
+
+```markdown
+# Stakeholder Review — vX.X.X (YYYY-MM-DD)
+
+**Scenario run:** [scenario name and configuration]
+**Reviewer role context:** [persona applied — e.g., Lucas Ferreira, Programme Analyst]
+**Mode exercised:** [Mode 1 / Mode 2 / Mode 3]
+
+## Findings
+
+| # | Area | Finding | Severity | GitHub Issue | Status |
+|---|---|---|---|---|---|
+| 1 | [UI / Data / Narrative / Methodology] | [finding description] | [Critical / Major / Minor / Observation] | #NNN | [Open / Fixed / Won't Fix] |
+
+## What Worked
+
+[Narrative — what the tool communicated clearly and correctly]
+
+## What Confused or Misled
+
+[Narrative — confusion points in the order they occurred; include at what point
+a real user would abandon the task]
+
+## Blocking Items for Next Demo
+
+[List any findings that must be resolved before the next milestone demo]
+```
+
+### Handover Protocol
+
+The two-instance protocol closes the loop between review and development:
+
+1. **Review instance** — runs the scenario, applies the persona, writes findings
+   in the template above. Leaves GitHub Issue column as `UNTRACKED` where not yet filed.
+2. **Development instance** — receives the completed findings section, files GitHub
+   issues for each finding, fills in the Issue column, updates Status for any findings
+   already addressed in the current milestone, and commits the completed artifact to
+   `docs/demo/{milestone}/reviews/`.
+
+The committed artifact is the permanent audit trail of stakeholder feedback alongside
+the code that addresses it. A review that produces findings but no committed artifact
+has not completed the handover.
+
 ---
 
-*Pattern documented from M6 session 2026-05-07. Related issues: #227–#232.*
+*Pattern documented from M6 session 2026-05-07. Related issues: #227–#232, #234.*


### PR DESCRIPTION
## Summary

- **#160** — Add verbatim statistical power statement template block to `CODING_STANDARDS.md §What "Passing Backtesting" Means`. Explicit fields for threshold type, checks performed, false positive rate under null model, what PASS validates, what PASS does not validate. Closes ARCH-REVIEW-003 BI3-N-10.
- **#234** — Expand `docs/process/independent-review-prompt.md §Output Handling` with storage convention (`docs/demo/{milestone}/reviews/`), structured report template with placeholder fields (findings table, what worked, what confused, blocking items), two-instance handover protocol.
- **#276** — Add `§Model Monoculture Risk` to `docs/POLICY.md` — Goodhart's Law / model-as-negotiated-reality risk; WorldSim-as-one-instrument-among-many position; TSC mandate for parameterization gaming detection; methodological pluralism as primary defense.

## Test plan

- [ ] Docs-only PR — no Python or frontend changes; pre-push gates not applicable
- [ ] Verify `CODING_STANDARDS.md` statistical power block includes all five required fields with template variables
- [ ] Verify `POLICY.md §Model Monoculture Risk` addresses all three requirements from #276 (one instrument among many, methodological diversity as defense, assumptions-as-negotiated-reality risk)
- [ ] Verify `independent-review-prompt.md` storage path matches CLAUDE.md §Canonical Artifact Locations (`docs/demo/{milestone}/reviews/`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)