### PR TITLE
docs(process): formalize DRAFT ADR status — closes #57

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -304,7 +304,21 @@ before implementation begins. The process:
 4. The Architect Agent consults `docs/process/agent-raci.md` to derive the panel
 5. The implementing agent must be in the panel — this is not optional
 6. The Architect Agent drafts the ADR; the panel reviews; the Engineering Lead signs off
-7. Status moves to ACCEPTED; the backlog entry is updated
+7. Status moves to Accepted; License Status is set to CURRENT; the backlog entry is updated
+
+**ADR Status vs. License Status** — these are two distinct fields (Issue #57):
+
+- **Status: DRAFT** — the ADR is being written. Set this when the ADR file is first
+  created. A DRAFT ADR has no License Status. It may not be used as the basis for
+  implementation, and no dependent ADR may reach Accepted status while its parent
+  remains DRAFT.
+- **Status: Accepted** — the Engineering Lead has accepted the design decisions.
+  Set at step 7 above. Acceptance assigns the initial License Status of CURRENT.
+- **License Status** (CURRENT / UNDER-REVIEW / SUPERSEDED / REVOKED) — tracks
+  validity of an accepted ADR against current standards. Only applies after Accepted.
+
+New ADRs must open with `Status: DRAFT` in their header. The full lifecycle is
+defined in `docs/MILESTONE_RUNBOOK.md §Architecture License Framework`.
 
 The Architecture Backlog (`docs/architecture/backlog.md`) is the authoritative
 source for ADR numbers and status. Do not assign ADR numbers informally.

--- a/docs/MILESTONE_RUNBOOK.md
+++ b/docs/MILESTONE_RUNBOOK.md
@@ -363,6 +363,44 @@ debt when the standards it was written against have since changed — it may
 describe a valid implementation path that now violates a standard that didn't
 exist when it was written.
 
+### ADR Status Lifecycle
+
+ADR **Status** is a workflow state that tracks where an ADR is in the
+authoring and acceptance process. It is distinct from **License Status**,
+which applies only to accepted ADRs and tracks the ongoing validity of their
+design decisions.
+
+**DRAFT** — The ADR is being written. It has been assigned a number from the
+Architecture Backlog (`docs/architecture/backlog.md`) but has not yet been
+accepted by the Engineering Lead. Draft ADRs may not be used as the basis for
+implementation, and no dependent ADR may reference a DRAFT ADR. Draft work
+may proceed alongside DRAFT parent ADRs, but no ADR may reach Accepted status
+while a parent it depends on remains in DRAFT.
+
+**Accepted** — The Engineering Lead has reviewed the ADR and accepted its
+design decisions. Acceptance triggers the assignment of an initial License
+Status (always CURRENT at acceptance). No implementation of a significant
+feature may begin without an Accepted ADR.
+
+The full ADR lifecycle is:
+
+```
+Status: DRAFT  →  (EL accepts)  →  Status: Accepted
+                                         │
+                                         ▼
+                                   License: CURRENT
+                                         │
+                             ┌───────────┼───────────┐
+                             ▼           ▼           ▼
+                       UNDER-REVIEW  SUPERSEDED   REVOKED
+```
+
+License Status transitions are governed by the Renewal Triggers and License
+States defined below. An ADR moves from License CURRENT to UNDER-REVIEW when
+a renewal trigger fires; from UNDER-REVIEW back to CURRENT when the review is
+complete; to SUPERSEDED when a newer ADR replaces it; and to REVOKED when
+the architecture it describes must not be used.
+
 ### License States
 
 **CURRENT** — The ADR was written against standards that remain in force. It
@@ -424,8 +462,8 @@ The practical consequence: if an Architecture Review moves ADR-001 to
 UNDER-REVIEW pending a standards update, any ADR that references ADR-001's
 data model (e.g., an ADR defining how the Macroeconomic Module uses
 `SimulationEntity.attributes`) must wait until ADR-001 is renewed to CURRENT
-before it can be finalized and accepted. Draft work may proceed, but no ADR
-may reach Accepted status while its parent is UNDER-REVIEW.
+before it can be finalized and accepted. Work in DRAFT status may proceed, but no ADR may reach Accepted status
+while its parent is UNDER-REVIEW.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `Status: DRAFT` as a formal, defined ADR workflow state in `docs/MILESTONE_RUNBOOK.md §Architecture License Framework`
- Introduces a new `### ADR Status Lifecycle` sub-section that clearly separates **Status** (DRAFT → Accepted) from **License Status** (CURRENT / UNDER-REVIEW / SUPERSEDED / REVOKED)
- Includes ASCII lifecycle diagram showing the full ADR state machine
- Updates `docs/CONTRIBUTING.md §ADR Process` to specify that new ADRs open with `Status: DRAFT` and explains the two-field distinction

## Closes

Closes #57

## Why

`MILESTONE_RUNBOOK.md` referenced "Draft work" without defining what DRAFT means or how it differs from the four post-acceptance License States. The Dependency Rule sentence ("Draft work may proceed, but...") assumed the existence of DRAFT without defining it.

## Test plan

- [ ] Read `docs/MILESTONE_RUNBOOK.md §Architecture License Framework` — confirms DRAFT is defined with acceptance criteria and lifecycle diagram
- [ ] Read `docs/CONTRIBUTING.md §ADR Process` — confirms new ADRs are instructed to open with `Status: DRAFT`
- [ ] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)