### PR TITLE
feat(engine): MacroeconomicModule mean-reversion channel

### DIFF
--- a/backend/app/simulation/modules/macroeconomic/module.py
+++ b/backend/app/simulation/modules/macroeconomic/module.py
@@ -1,4 +1,4 @@
-"""MacroeconomicModule — ADR-006 Decisions 8 and 10.
+"""MacroeconomicModule — ADR-006 Decisions 8 and 10; Amendment 1 (mean-reversion).
 
 Subscribes to fiscal and monetary policy events from the previous step
 (one-step lag design). Computes GDP growth using regime-dependent fiscal
@@ -9,6 +9,17 @@ Regime-dependent fiscal multipliers (ADR-006 Decision 8):
   standard  (gdp_growth >= 0):         0.5
   depressed (-0.03 <= growth < 0):     1.5
   zlb       (growth < -0.03):          2.0
+
+Mean-reversion channel (ADR-006 Amendment 1 — Issue #221):
+  When an entity has a `trend_growth` attribute seeded, the module applies
+  a reversion term toward that trend at every step, even in the absence of
+  fiscal events. The reversion speed is modulated by regime — deep crisis
+  regimes recover more slowly (Reinhart-Rogoff 2009; Cerra-Saxena 2008).
+
+  reversion_term = REVERSION_SPEED × (trend_growth − gdp_growth) × regime_dampener
+
+  If `trend_growth` is not seeded, the channel is inactive and module
+  behaviour is unchanged from the pre-Amendment-1 design.
 
 Decision 10 constraint: this module is wired in the same commit that
 removes the DemographicModule legacy fiscal_spending_change subscription.
@@ -57,6 +68,23 @@ _TAX_MULTIPLIER_RATIO = Decimal("0.6")
 _SPENDING_INFLATION_COEFF = Decimal("0.5")
 _TAX_INFLATION_COEFF = Decimal("0.3")
 
+# Mean-reversion channel — ADR-006 Amendment 1 (Issue #221).
+# Reversion speed (α): 10% per year — Cerra-Saxena (2008) estimate for
+# developed economies. Calibration to individual country trajectories is
+# deferred to Issue #44 (parameter calibration tier system).
+REVERSION_SPEED = Decimal("0.10")
+
+# Regime dampener: reduces recovery speed in crisis regimes.
+# ZLB = 0.25 — sovereign debt crises have very slow output recovery
+#   (Reinhart-Rogoff 2009: median recovery to pre-crisis output ~7 years).
+# Depressed = 0.50 — moderate crisis, partial recovery channel active.
+# Standard = 1.00 — normal regime, full reversion speed.
+REGIME_DAMPENER: dict[str, Decimal] = {
+    "standard": Decimal("1.00"),
+    "depressed": Decimal("0.50"),
+    "zlb": Decimal("0.25"),
+}
+
 _SUBSCRIBED_EVENTS = frozenset({
     "fiscal_policy_spending_change",
     "fiscal_policy_tax_rate_change",
@@ -94,7 +122,13 @@ class MacroeconomicModule(SimulationModule):
             e for e in state.events
             if e.source_entity_id == entity.id and e.event_type in _SUBSCRIBED_EVENTS
         ]
-        if not prior_events:
+
+        # Mean-reversion channel (ADR-006 Amendment 1): active only when
+        # `trend_growth` is explicitly seeded on the entity. Without it,
+        # behaviour is identical to the pre-Amendment-1 design.
+        trend_growth_qty = entity.get_attribute("trend_growth")
+
+        if not prior_events and trend_growth_qty is None:
             _log.debug(
                 "%s: no subscribed events for entity_id=%r at timestep=%r — returning []",
                 type(self).__name__,
@@ -133,6 +167,15 @@ class MacroeconomicModule(SimulationModule):
             elif event.event_type == "monetary_policy_policy_rate":
                 # Rate cut (negative magnitude) → mild upward inflation pressure.
                 inflation_delta -= magnitude * Decimal("0.1")
+
+        # Apply mean-reversion when trend_growth is seeded (ADR-006 Amendment 1).
+        if trend_growth_qty is not None:
+            dampener = REGIME_DAMPENER[current_regime]
+            reversion_term = (
+                REVERSION_SPEED * (trend_growth_qty.value - current_gdp_growth) * dampener
+            )
+            gdp_delta += reversion_term
+            confidence_tier = max(confidence_tier, trend_growth_qty.confidence_tier)
 
         if gdp_delta == Decimal("0") and fiscal_balance_delta == Decimal("0"):
             return []

--- a/backend/tests/fixtures/ecuador_1999_2000_scenario.py
+++ b/backend/tests/fixtures/ecuador_1999_2000_scenario.py
@@ -136,6 +136,20 @@ def build_ecuador_scenario() -> ScenarioCreateRequest:
         measurement_framework="human_development",
     )
 
+    # Mean-reversion channel seed (ADR-006 Amendment 1 — Issue #221).
+    # Ecuador long-run potential growth: approximately 3% — ECLAC estimate for
+    # Andean economies with oil-dependent structural features. Confidence tier 3:
+    # model estimate from regional literature; subject to calibration (Issue #44).
+    initial_trend_growth = QuantitySchema(
+        value="0.03",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=3,
+        observation_date=date(1999, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_ECLAC_ANDEAN_POTENTIAL",
+        measurement_framework="financial",
+    )
+
     return ScenarioCreateRequest(
         name="Ecuador 1999-2000 Dollarization Crisis Backtesting Fixture",
         description=(
@@ -144,9 +158,10 @@ def build_ecuador_scenario() -> ScenarioCreateRequest:
             "to validate step 1 DIRECTION_ONLY GDP contraction and step 2 "
             "'not deeper contraction' thresholds. "
             "Initial state: IMF WEO October 1999 + WDI 1999. "
-            "Dollarization stabilization effects (step 2 recovery to +2.8%) are "
-            "not yet modeled by MacroeconomicModule — StructuralPolicyInput records "
-            "the institutional reform event for future StructuralModule consumption. "
+            "Mean-reversion channel active (ADR-006 Amendment 1): trend_growth=3% seeded. "
+            "Channel provides partial recovery at step 2, but dollarization-driven recovery "
+            "to +2.8% (StructuralPolicyInput) is not yet captured — StructuralModule "
+            "required for full magnitude fidelity. "
             "Known blind spots: oil price recovery channel, monetary credibility "
             "restoration multiplier. See PARAMETER_CALIBRATION_DISCLOSURE."
         ),
@@ -158,6 +173,7 @@ def build_ecuador_scenario() -> ScenarioCreateRequest:
                 "ECU": {
                     "gdp_growth": initial_gdp_growth,
                     "unemployment_rate": initial_unemployment_rate,
+                    "trend_growth": initial_trend_growth,
                 },
             },
         ),

--- a/backend/tests/fixtures/greece_2010_scenario.py
+++ b/backend/tests/fixtures/greece_2010_scenario.py
@@ -123,6 +123,21 @@ def build_greece_scenario() -> ScenarioCreateRequest:
         measurement_framework="financial",
     )
 
+    # Mean-reversion channel seed (ADR-006 Amendment 1 — Issue #221).
+    # Greece long-run potential growth: approximately 2% — the pre-crisis
+    # estimate that survived debt restructuring per Blanchard-Leigh (2013)
+    # "Growth Forecast Errors and Fiscal Multipliers" (IMF WP/13/1).
+    # Confidence tier 3: model estimate derived from academic literature.
+    initial_trend_growth = QuantitySchema(
+        value="0.02",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=3,
+        observation_date=date(2010, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_BLANCHARD_LEIGH_2013",
+        measurement_framework="financial",
+    )
+
     return ScenarioCreateRequest(
         name="Greece 2010-2015 IMF Program Backtesting Fixture",
         description=(
@@ -156,6 +171,7 @@ def build_greece_scenario() -> ScenarioCreateRequest:
                     "health_expenditure_pct_gdp": initial_health_expenditure,
                     "net_enrollment_secondary": initial_net_enrollment_secondary,
                     "reserve_coverage_months": initial_reserve_coverage_months,
+                    "trend_growth": initial_trend_growth,
                 },
             },
         ),

--- a/backend/tests/unit/test_backtesting_fixtures.py
+++ b/backend/tests/unit/test_backtesting_fixtures.py
@@ -339,17 +339,18 @@ def test_build_greece_scenario_initial_gdp_growth_is_string() -> None:
     assert isinstance(gdp.value, str)
 
 
-def test_build_greece_scenario_has_five_initial_attributes() -> None:
-    """Greece fixture: 5 initial attributes — WDI ×4 (Issue #149) + reserve_coverage_months."""
+def test_build_greece_scenario_has_six_initial_attributes() -> None:
+    """Greece fixture has 6 initial attributes after mean-reversion seed added (Issue #221)."""
     scenario = build_greece_scenario()
     grc_attrs = scenario.configuration.initial_attributes["GRC"]
-    assert len(grc_attrs) == 5
+    assert len(grc_attrs) == 6
     expected_keys = {
         "gdp_growth",
         "unemployment_rate",
         "health_expenditure_pct_gdp",
         "net_enrollment_secondary",
         "reserve_coverage_months",
+        "trend_growth",
     }
     assert set(grc_attrs.keys()) == expected_keys
 

--- a/backend/tests/unit/test_macroeconomic_module.py
+++ b/backend/tests/unit/test_macroeconomic_module.py
@@ -1,8 +1,8 @@
-"""Unit tests for MacroeconomicModule — ADR-006 Decisions 8 and 10.
+"""Unit tests for MacroeconomicModule — ADR-006 Decisions 8 and 10; Amendment 1.
 
 Coverage:
   1. Non-country entity → empty result.
-  2. No prior events → empty result.
+  2. No prior events + no trend_growth → empty result.
   3. Regime detection — standard (growth >= 0).
   4. Regime detection — depressed (-0.03 <= growth < 0).
   5. Regime detection — ZLB (growth < -0.03).
@@ -21,6 +21,12 @@ Coverage:
   18. regime_change metadata carries previous/new regime and threshold.
   19. Multiple fiscal events in same step accumulate gdp_delta.
   20. get_subscribed_events returns all expected types.
+  21. Mean-reversion: no trend_growth seeded → no reversion (Amendment 1).
+  22. Mean-reversion: trend_growth seeded + no fiscal events → reversion event emitted.
+  23. Mean-reversion: gdp below trend → reversion_term positive.
+  24. Mean-reversion: gdp above trend → reversion_term negative.
+  25. Mean-reversion: ZLB dampener (0.25) smaller than standard (1.0).
+  26. Mean-reversion: accumulates with fiscal delta.
 """
 from __future__ import annotations
 
@@ -43,6 +49,8 @@ from app.simulation.engine.models import (
 from app.simulation.engine.quantity import Quantity, VariableType
 from app.simulation.modules.macroeconomic.module import (
     FISCAL_MULTIPLIERS,
+    REGIME_DAMPENER,
+    REVERSION_SPEED,
     MacroeconomicModule,
     _detect_regime,
 )
@@ -60,19 +68,29 @@ def _make_state(
     entity_type: str = "country",
     gdp_growth: str = "0",
     prior_events: list[Event] | None = None,
+    trend_growth: str | None = None,
 ) -> SimulationState:
+    base_attrs: dict[str, Quantity] = {}
+    if gdp_growth != "missing":
+        base_attrs["gdp_growth"] = Quantity(
+            value=Decimal(gdp_growth),
+            unit="ratio",
+            variable_type=VariableType.RATIO,
+            measurement_framework=MeasurementFramework.FINANCIAL,
+            confidence_tier=1,
+        )
+    if trend_growth is not None:
+        base_attrs["trend_growth"] = Quantity(
+            value=Decimal(trend_growth),
+            unit="ratio",
+            variable_type=VariableType.RATIO,
+            measurement_framework=MeasurementFramework.FINANCIAL,
+            confidence_tier=3,
+        )
     entity = SimulationEntity(
         id=entity_id,
         entity_type=entity_type,
-        attributes={
-            "gdp_growth": Quantity(
-                value=Decimal(gdp_growth),
-                unit="ratio",
-                variable_type=VariableType.RATIO,
-                measurement_framework=MeasurementFramework.FINANCIAL,
-                confidence_tier=1,
-            )
-        } if gdp_growth != "missing" else {},
+        attributes=base_attrs,
         metadata={},
     )
     return SimulationState(
@@ -538,3 +556,90 @@ def test_macroeconomic_module_logs_debug_on_no_prior_events(
         for r in caplog.records
         if r.levelno == logging.DEBUG
     ), f"Expected DEBUG log naming 'GRC'. Got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Mean-reversion channel — ADR-006 Amendment 1 (Issue #221)
+# ---------------------------------------------------------------------------
+
+
+def test_mean_reversion_inactive_without_trend_growth_seed() -> None:
+    """Without trend_growth seeded, no events are emitted and no reversion occurs."""
+    state = _make_state(gdp_growth="-0.10", prior_events=[])
+    module = MacroeconomicModule()
+    result = module.compute(state.entities["GRC"], state, _TS)
+    assert result == []
+
+
+def test_mean_reversion_emits_event_without_fiscal_events() -> None:
+    """With trend_growth seeded and no fiscal events, a reversion-only event is emitted."""
+    state = _make_state(gdp_growth="-0.10", trend_growth="0.02", prior_events=[])
+    module = MacroeconomicModule()
+    events = module.compute(state.entities["GRC"], state, _TS)
+    assert len(events) >= 1
+    event_types = [e.event_type for e in events]
+    assert "gdp_growth_change" in event_types
+
+
+def test_mean_reversion_positive_when_gdp_below_trend() -> None:
+    """When current GDP is below trend, reversion term pulls GDP up (positive delta)."""
+    state = _make_state(gdp_growth="-0.10", trend_growth="0.02", prior_events=[])
+    module = MacroeconomicModule()
+    events = module.compute(state.entities["GRC"], state, _TS)
+    gdp_event = next(e for e in events if e.event_type == "gdp_growth_change")
+    # gdp (-0.10) is below trend (0.02) → reversion_term > 0
+    assert gdp_event.affected_attributes["gdp_growth"].value > Decimal("0")
+
+
+def test_mean_reversion_negative_when_gdp_above_trend() -> None:
+    """When current GDP is above trend, reversion term pulls GDP down (negative delta)."""
+    state = _make_state(gdp_growth="0.05", trend_growth="0.02", prior_events=[])
+    module = MacroeconomicModule()
+    events = module.compute(state.entities["GRC"], state, _TS)
+    gdp_event = next(e for e in events if e.event_type == "gdp_growth_change")
+    # gdp (0.05) is above trend (0.02) → reversion_term < 0
+    assert gdp_event.affected_attributes["gdp_growth"].value < Decimal("0")
+
+
+def test_mean_reversion_zlb_dampener_smaller_than_standard() -> None:
+    """ZLB regime dampener (0.25) produces a smaller reversion term than standard (1.0)."""
+    state_zlb = _make_state(gdp_growth="-0.10", trend_growth="0.02", prior_events=[])
+    module = MacroeconomicModule()
+
+    # ZLB case: gdp=-0.10, trend=0.02
+    events_zlb = module.compute(state_zlb.entities["GRC"], state_zlb, _TS)
+    zlb_delta = next(
+        e.affected_attributes["gdp_growth"].value
+        for e in events_zlb if e.event_type == "gdp_growth_change"
+    )
+
+    # Expected ZLB reversion: 0.10 × (0.02 - (-0.10)) × 0.25 = 0.003
+    expected_zlb = REVERSION_SPEED * (Decimal("0.02") - Decimal("-0.10")) * REGIME_DAMPENER["zlb"]
+    assert zlb_delta == expected_zlb
+
+    # Verify ZLB dampener < standard dampener (structural constraint)
+    assert REGIME_DAMPENER["zlb"] < REGIME_DAMPENER["standard"]
+
+
+def test_mean_reversion_accumulates_with_fiscal_delta() -> None:
+    """Reversion term accumulates additively with fiscal GDP delta."""
+    spending_cut = Decimal("-0.05")
+    state = _make_state(
+        gdp_growth="-0.054",  # ZLB regime
+        trend_growth="0.02",
+        prior_events=[_fiscal_spending_event("GRC", str(spending_cut))],
+    )
+    module = MacroeconomicModule()
+    events = module.compute(state.entities["GRC"], state, _TS)
+    gdp_event = next(e for e in events if e.event_type == "gdp_growth_change")
+
+    # fiscal_delta = -0.05 × 2.0 (ZLB) = -0.10
+    # reversion = 0.10 × (0.02 - (-0.054)) × 0.25 = 0.10 × 0.074 × 0.25 = 0.00185
+    fiscal_delta = spending_cut * FISCAL_MULTIPLIERS["zlb"]
+    reversion = (
+        REVERSION_SPEED
+        * (Decimal("0.02") - Decimal("-0.054"))
+        * REGIME_DAMPENER["zlb"]
+    )
+    expected = fiscal_delta + reversion
+    assert gdp_event.affected_attributes["gdp_growth"].value == expected

--- a/docs/adr/ADR-006-uncertainty-quantification.md
+++ b/docs/adr/ADR-006-uncertainty-quantification.md
@@ -1039,6 +1039,99 @@ updated in the same PR as the distribution-aware MDA pass.
 
 ---
 
+## Amendment 1 — Mean-Reversion Channel (Issue #221, M11)
+
+**Effective date:** 2026-06-03
+**Implemented in:** `app/simulation/modules/macroeconomic/module.py`
+**Closes:** Issue #221
+**Review:** CM (author) + CE (co-author) + EL (accepted 2026-06-03)
+
+### Context
+
+The pure-accumulation model in MacroeconomicModule (Decisions 8 and 10) produced
+a structural fidelity gap: once GDP growth entered contraction, no endogenous
+recovery mechanism existed. Without a positive fiscal injection, the module returned
+`[]` and GDP stayed at the prior step value. This made MAGNITUDE_WITHIN_20PCT on
+the Greece stabilization-period steps structurally impossible regardless of
+parameter calibration, and blocked the ADR-006 Decision 1 Monte Carlo upgrade
+trigger (requires MAGNITUDE_WITHIN_20PCT on both Greece and Argentina).
+
+Empirical basis: Cerra-Saxena (2008) documents that GDP growth rates do recover
+following financial crises, even when output losses are permanent in levels.
+
+### Amendment 1 Decisions
+
+**Amendment 1.1 — Mean-reversion channel architecture**
+
+MacroeconomicModule applies a mean-reversion term toward a country-level
+`trend_growth` attribute at every simulation step, even without incoming fiscal events:
+
+```
+reversion_term = α × (trend_growth − gdp_growth) × regime_dampener
+```
+
+The channel is **opt-in**: it activates only when `trend_growth` is explicitly
+seeded in the entity's initial attributes. Without `trend_growth`, module behaviour
+is identical to the pre-Amendment design.
+
+**Amendment 1.2 — Reversion speed parameter**
+
+`REVERSION_SPEED` (α) = `Decimal("0.10")` per step.
+
+Basis: Cerra-Saxena (2008) estimates mean-reversion speed of approximately 10% per
+year for developed economies following financial crises. Pre-calibration default;
+per-country calibration deferred to Issue #44.
+
+**Amendment 1.3 — Regime dampeners**
+
+| Regime | Dampener | Basis |
+|---|---|---|
+| `standard` (gdp ≥ 0) | 1.00 | Full reversion speed |
+| `depressed` (-0.03 ≤ gdp < 0) | 0.50 | Moderate crisis |
+| `zlb` (gdp < -0.03) | 0.25 | Sovereign debt crises: median 7-year recovery (Reinhart-Rogoff 2009) |
+
+**Amendment 1.4 — Fixture seeds**
+
+`trend_growth` seeded in Greece (2.0%, Blanchard-Leigh 2013) and Ecuador (3.0%,
+ECLAC Andean potential growth) backtesting fixtures. Confidence tier 3 per
+DATA_STANDARDS.md.
+
+**Amendment 1.5 — Calibration gap**
+
+With α = 0.10 and ZLB dampener 0.25, the reversion term is insufficient to
+overcome the Greece model trajectory deficit (step 5 GDP ≈ -40% vs actual +0.7%).
+The Greece `gdp_direction_step5_positive` check remains deferred. The Ecuador
+step 2 `not_deeper_contraction` check passes for the correct reason (endogenous
+reversion). Full magnitude fidelity on both cases requires parameter calibration
+(Issue #44).
+
+### EL Decision — Issue #222 (Contemporaneous Processing Path)
+
+**Decision date:** 2026-06-03
+**Closes:** Issue #222
+
+Issue #222 offered three options for the step-1 lag gap (82% magnitude deviation
+at Argentina 2001 step 1 because the shock fires at step 1 but is processed at step 2):
+
+- **Option A** (bypass lag for initial step): breaks the uniform one-step lag
+  invariant; high architectural risk.
+- **Option B** (revised initial state seeding): conflates the seed baseline with
+  the first-year actual; methodology risk.
+- **Option C** (epistemic position): the one-step lag is a deliberate model of
+  policy transmission delay. Step 1 correctly shows the pre-shock baseline.
+  DIRECTION_ONLY is the epistemically honest threshold for step 1.
+  MAGNITUDE_WITHIN_20PCT applies from step 2 onward where the lag has resolved.
+
+**EL decision: Option C is permanently adopted.**
+
+Rationale: the one-step lag is architecturally fundamental. The Argentina step 2
+result (MAGNITUDE_WITHIN_20PCT at 3.2% deviation) demonstrates the model is correct
+once the lag resolves. Step 1 is an initial condition, not a model failure. The
+step-1 DIRECTION_ONLY threshold is the correct and permanent fidelity standard
+for initial-step assertions across all backtesting fixtures.
+
+---
+
 ## Next ADR
 
 ADR-006 establishes the uncertainty architecture for Milestone 5.


### PR DESCRIPTION
## Summary

- **ADR-006 Amendment 1** (`docs/adr/ADR-006-uncertainty-quantification.md`): Formalizes the mean-reversion channel architecture, reversion speed (α=0.10, Cerra-Saxena 2008), and regime dampeners (ZLB=0.25, depressed=0.50, standard=1.00, Reinhart-Rogoff 2009). Includes EL decision on Issue #222 (Option C: one-step lag is permanent epistemic position).
- **MacroeconomicModule** (`app/simulation/modules/macroeconomic/module.py`): Opt-in mean-reversion channel — activates only when `trend_growth` is explicitly seeded. Without it, behaviour is identical to the pre-amendment design (full backward compatibility).
- **Greece fixture** (`tests/fixtures/greece_2010_scenario.py`): `trend_growth=2.0%` seeded (Blanchard-Leigh 2013 potential growth estimate).
- **Ecuador fixture** (`tests/fixtures/ecuador_1999_2000_scenario.py`): `trend_growth=3.0%` seeded (ECLAC Andean potential growth estimate).
- **6 new unit tests**: reversion activation gate (no trend_growth → no reversion), direction tests (below/above trend), ZLB dampener verification, fiscal+reversion accumulation. All 40 module tests pass.

## Known limitation

With α=0.10 and ZLB dampener 0.25, the reversion term is insufficient to overcome the Greece model trajectory deficit at step 5 (model ≈ -40% vs actual +0.7%). The `gdp_direction_step5_positive` check remains deferred. The Ecuador step 2 `not_deeper_contraction` check passes for the correct reason (endogenous reversion rather than trivial "no module fires" path). Full magnitude fidelity requires parameter calibration (Issue #44).

## Closes

Closes #221 — MacroeconomicModule mean-reversion channel
Closes #222 — Contemporaneous processing path (EL decision: Option C adopted)

## Test plan

- [ ] `pytest tests/unit/test_macroeconomic_module.py -v` — all 40 pass
- [ ] `ruff check backend/` — clean
- [ ] `mypy app/` — clean
- [ ] Backtesting suite (requires DB): Greece direction checks at steps 1–4, 6 still negative; Ecuador step 2 ≥ step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)