### PR TITLE
feat(orchestration): political economy constraints — CONDITIONALITY, implementation_capacity, CompoundStateCondition

### DIFF
--- a/backend/app/simulation/orchestration/inputs.py
+++ b/backend/app/simulation/orchestration/inputs.py
@@ -1,5 +1,7 @@
 """
 Control input types for the Input Orchestration Layer — ADR-002, Amendment 1.
+Political economy extensions: Issue #96 (CONDITIONALITY InputSource),
+Issue #93 (implementation_capacity), Issue #157 (CompoundStateCondition).
 
 ControlInput is the abstract base class for all exogenous inputs injected
 into the simulation. Each concrete subclass represents one category of
@@ -19,13 +21,19 @@ Amendment 1 (SCR-001 / ADR-002 Amendment 1):
   MonetaryVolumeInstrument correspondingly.
 - All to_events() implementations produce Quantity deltas in
   affected_attributes (dict[str, Quantity]), not float deltas.
+
+Political economy extensions (Issue #96, #93, #157):
+- InputSource.CONDITIONALITY encodes externally coerced decisions.
+- ControlInput.implementation_capacity scales event magnitudes to model
+  partial implementation, political feasibility constraints.
+- CompoundStateCondition enables AND/OR multi-attribute trigger logic.
 """
 
 from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -48,6 +56,12 @@ class InputSource(Enum):
 
     Recorded in every ControlInputAuditRecord so the provenance of every
     exogenous decision is traceable to its source channel.
+
+    CONDITIONALITY (Issue #96): the decision was made under binding external
+    constraint imposed by another actor (IMF, ECB, creditor bloc). Distinguished
+    from SCENARIO_SCRIPT to record that the policy was not freely chosen.
+    Use constraining_actor_id and constraint_mechanism on the ControlInput to
+    record who imposed the constraint and by what mechanism.
     """
 
     UI = "ui"
@@ -56,6 +70,7 @@ class InputSource(Enum):
     BULK_FEED = "bulk_feed"
     SCENARIO_SCRIPT = "scenario_script"
     CONTINGENT_TRIGGER = "contingent_trigger"
+    CONDITIONALITY = "conditionality"
 
 
 class MonetaryRateInstrument(Enum):
@@ -142,6 +157,13 @@ class ComparisonOperator(Enum):
     EQ = "=="
 
 
+class LogicalOperator(Enum):
+    """Logical operators for CompoundStateCondition evaluation (Issue #157)."""
+
+    AND = "and"
+    OR = "or"
+
+
 # ---------------------------------------------------------------------------
 # Control input base class
 # ---------------------------------------------------------------------------
@@ -173,6 +195,17 @@ class ControlInput(ABC):
         propagation_rules: Rules governing how generated Events propagate
             through the relationship graph. Empty list means the effect
             applies only to the source entity with no graph propagation.
+        implementation_capacity: Political feasibility multiplier in [0.0, 1.0]
+            (Issue #93). Scales event magnitudes from to_events() to model partial
+            implementation, political constraints, and watered-down execution.
+            Default 1.0 preserves existing behaviour — full implementation.
+            0.5 means 50% of the intended policy magnitude is actually transmitted.
+        constraining_actor_id: For InputSource.CONDITIONALITY — the external actor
+            that imposed the constraint (e.g. 'IMF', 'ECB', 'US_TREASURY').
+            Empty string for freely chosen decisions (Issue #96).
+        constraint_mechanism: For InputSource.CONDITIONALITY — how the constraint
+            was applied (e.g. 'ELA_WITHDRAWAL_THREAT', 'DISBURSEMENT_SUSPENSION',
+            'SANCTIONS'). Empty string for non-conditionality inputs (Issue #96).
     """
 
     input_id: str = field(default_factory=lambda: str(uuid.uuid4()))
@@ -184,6 +217,9 @@ class ControlInput(ABC):
     source: InputSource = InputSource.SCENARIO_SCRIPT
     timestamp: datetime = field(default=None)  # type: ignore[assignment]
     propagation_rules: list[PropagationRule] = field(default_factory=list)
+    implementation_capacity: Decimal = Decimal("1.0")
+    constraining_actor_id: str = ""
+    constraint_mechanism: str = ""
 
     @abstractmethod
     def to_events(self, timestep: datetime) -> list[Event]:
@@ -191,6 +227,8 @@ class ControlInput(ABC):
 
         The InputOrchestrator calls this during inject() to convert the
         policy decision into Events the propagation engine can apply.
+        Subclasses must implement this method — do not call it directly;
+        use get_events() to benefit from implementation_capacity scaling.
 
         Args:
             timestep: Current simulation timestep at which the input fires.
@@ -199,6 +237,44 @@ class ControlInput(ABC):
             List of Events representing this input's effect on simulation state.
             May return multiple Events (e.g. TradePolicyInput with retaliation).
         """
+
+    def get_events(self, timestep: datetime) -> list[Event]:
+        """Return scaled events for this control input (Issue #93).
+
+        Calls to_events() and multiplies every affected_attributes Quantity
+        value by implementation_capacity. This models partial implementation,
+        political feasibility constraints, and watered-down policy execution.
+
+        implementation_capacity=1.0 (default) returns events unchanged.
+        implementation_capacity=0.5 halves all event magnitudes.
+        implementation_capacity=0.0 produces zero-magnitude events (no effect).
+
+        Args:
+            timestep: Current simulation timestep at which the input fires.
+
+        Returns:
+            Events with magnitudes scaled by implementation_capacity.
+        """
+        raw_events = self.to_events(timestep)
+        if self.implementation_capacity == Decimal("1.0"):
+            return raw_events
+        scale = self.implementation_capacity
+        scaled: list[Event] = []
+        for evt in raw_events:
+            scaled_attrs = {
+                k: Quantity(
+                    value=q.value * scale,
+                    unit=q.unit,
+                    variable_type=q.variable_type,
+                    measurement_framework=q.measurement_framework,
+                    observation_date=q.observation_date,
+                    source_id=q.source_id,
+                    confidence_tier=q.confidence_tier,
+                )
+                for k, q in evt.affected_attributes.items()
+            }
+            scaled.append(replace(evt, affected_attributes=scaled_attrs))
+        return scaled
 
 
 # ---------------------------------------------------------------------------
@@ -661,6 +737,54 @@ class StateCondition:
 
 
 @dataclass(kw_only=True)
+class CompoundStateCondition:
+    """Multi-attribute AND/OR trigger logic for ContingentInput (Issue #157).
+
+    Enables crisis-realistic compound conditions that single-attribute
+    StateCondition cannot express:
+      - Capital controls fire when BOTH reserves < 3 months AND outflow > 15%
+      - Bank runs accelerate when depositor_confidence < 0.3 OR bank_holiday > 0.5
+      - IMF Article IV intervention when reserves AND current_account AND debt_service
+        all breach thresholds simultaneously
+
+    Conditions are evaluated recursively — a CompoundStateCondition may nest
+    StateCondition instances or other CompoundStateCondition instances.
+
+    Attributes:
+        operator: LogicalOperator.AND (all sub-conditions must hold) or
+                  LogicalOperator.OR (at least one must hold).
+        conditions: List of conditions to evaluate. Must not be empty.
+    """
+
+    operator: LogicalOperator
+    conditions: list[StateCondition | CompoundStateCondition] = field(
+        default_factory=list
+    )
+
+    def is_met(self, state: SimulationState) -> bool:
+        """Evaluate whether this compound condition holds.
+
+        AND: all sub-conditions must return True.
+        OR: at least one sub-condition must return True.
+
+        Short-circuits: AND stops at first False; OR stops at first True.
+        Empty conditions list returns False (conservative — no conditions means
+        unknown state, not satisfied).
+
+        Args:
+            state: Simulation state to evaluate the conditions against.
+
+        Returns:
+            True if the compound condition holds.
+        """
+        if not self.conditions:
+            return False
+        if self.operator == LogicalOperator.AND:
+            return all(c.is_met(state) for c in self.conditions)
+        return any(c.is_met(state) for c in self.conditions)
+
+
+@dataclass(kw_only=True)
 class ContingentInput:
     """A ControlInput that fires automatically when a state condition is met.
 
@@ -683,7 +807,12 @@ class ContingentInput:
     """
 
     contingent_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    condition: StateCondition = field(default=None)  # type: ignore[assignment]
+    # condition accepts StateCondition (single attribute) or CompoundStateCondition
+    # (multi-attribute AND/OR logic — Issue #157). Backward compatible: existing
+    # callers using StateCondition continue to work unchanged.
+    condition: StateCondition | CompoundStateCondition = field(
+        default=None  # type: ignore[assignment]
+    )
     input: ControlInput = field(default=None)  # type: ignore[assignment]
     cooldown_periods: int = 1
     documented_rationale: str = ""

--- a/backend/app/simulation/orchestration/runner.py
+++ b/backend/app/simulation/orchestration/runner.py
@@ -229,8 +229,10 @@ class ScenarioRunner(InputOrchestrator):
     ) -> list[Event]:
         """Translate one ControlInput to Events and record it in the audit log.
 
-        Calls control_input.to_events() with the current simulation timestep,
+        Calls control_input.get_events() with the current simulation timestep,
         then appends a ControlInputAuditRecord capturing the full provenance.
+        get_events() applies implementation_capacity scaling (Issue #93) before
+        returning events.
 
         Args:
             control_input: The exogenous input to process.
@@ -242,7 +244,7 @@ class ScenarioRunner(InputOrchestrator):
         from app.simulation.orchestration.audit import ControlInputAuditRecord
 
         now = datetime.now(UTC)
-        events = control_input.to_events(control_input.effective_date or now)
+        events = control_input.get_events(control_input.effective_date or now)
         record = ControlInputAuditRecord(
             record_id=str(uuid.uuid4()),
             scenario_id=self._initial_state.scenario_config.scenario_id,

--- a/backend/app/simulation/web_scenario_runner.py
+++ b/backend/app/simulation/web_scenario_runner.py
@@ -275,7 +275,7 @@ class WebScenarioRunner:
             prior_events = [
                 e
                 for inp in inputs_by_step.get(current_step, [])
-                for e in inp.to_events(current_state.timestep)
+                for e in inp.get_events(current_state.timestep)
             ]
             if prior_events:
                 current_state = replace(current_state, events=prior_events)

--- a/backend/tests/unit/test_political_economy_orchestration.py
+++ b/backend/tests/unit/test_political_economy_orchestration.py
@@ -9,11 +9,8 @@ All tests are pure-Python unit tests with no database or HTTP layer dependency.
 """
 from __future__ import annotations
 
-from dataclasses import replace
 from datetime import datetime
 from decimal import Decimal
-
-import pytest
 
 from app.simulation.engine.models import (
     MeasurementFramework,
@@ -173,7 +170,8 @@ class TestImplementationCapacityScaling:
         assert len(raw) == len(scaled)
         for r, s in zip(raw, scaled, strict=True):
             for k in r.affected_attributes:
-                assert s.affected_attributes[k].value == r.affected_attributes[k].value * Decimal("0.5")
+                expected = r.affected_attributes[k].value * Decimal("0.5")
+                assert s.affected_attributes[k].value == expected
 
     def test_get_events_zero_capacity_zeroes_magnitude(self) -> None:
         """implementation_capacity=0.0 → all event attribute values are zero."""

--- a/backend/tests/unit/test_political_economy_orchestration.py
+++ b/backend/tests/unit/test_political_economy_orchestration.py
@@ -1,0 +1,361 @@
+"""Unit tests for political economy orchestration extensions.
+
+Covers:
+  Issue #96  — InputSource.CONDITIONALITY + constraining_actor_id + constraint_mechanism
+  Issue #93  — implementation_capacity scaling via get_events()
+  Issue #157 — CompoundStateCondition AND/OR logic with recursive nesting
+
+All tests are pure-Python unit tests with no database or HTTP layer dependency.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.engine.models import (
+    MeasurementFramework,
+    ResolutionConfig,
+    ScenarioConfig,
+    SimulationEntity,
+    SimulationState,
+)
+from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.orchestration.inputs import (
+    ComparisonOperator,
+    CompoundStateCondition,
+    FiscalInstrument,
+    FiscalPolicyInput,
+    InputSource,
+    LogicalOperator,
+    StateCondition,
+)
+
+_BASE_DATE = datetime(2010, 1, 1)
+_EPOCH = datetime(2010, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _q(value: float) -> Quantity:
+    return Quantity(
+        value=Decimal(str(value)),
+        unit="ratio",
+        variable_type=VariableType.RATIO,
+        measurement_framework=MeasurementFramework.FINANCIAL,
+        confidence_tier=2,
+    )
+
+
+def _state_with(entity_id: str, **attrs: float) -> SimulationState:
+    entity = SimulationEntity(
+        id=entity_id,
+        entity_type="country",
+        attributes={k: _q(v) for k, v in attrs.items()},
+        metadata={},
+    )
+    return SimulationState(
+        timestep=_EPOCH,
+        resolution=ResolutionConfig(),
+        entities={entity_id: entity},
+        relationships=[],
+        events=[],
+        scenario_config=ScenarioConfig(
+            scenario_id="test",
+            name="Test",
+            description="",
+            start_date=_EPOCH,
+            end_date=datetime(2020, 1, 1),
+        ),
+    )
+
+
+def _fiscal(value: str = "-0.08", capacity: str = "1.0") -> FiscalPolicyInput:
+    return FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        sector="government",
+        value=Decimal(value),
+        duration_years=1,
+        implementation_capacity=Decimal(capacity),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #96 — InputSource.CONDITIONALITY + constraining fields
+# ---------------------------------------------------------------------------
+
+
+class TestCondionalityInputSource:
+    def test_conditionality_value_in_enum(self) -> None:
+        assert InputSource.CONDITIONALITY.value == "conditionality"
+
+    def test_conditionality_is_distinct_from_scenario_script(self) -> None:
+        assert InputSource.CONDITIONALITY != InputSource.SCENARIO_SCRIPT
+
+    def test_constraining_actor_id_default_empty(self) -> None:
+        inp = _fiscal()
+        assert inp.constraining_actor_id == ""
+
+    def test_constraint_mechanism_default_empty(self) -> None:
+        inp = _fiscal()
+        assert inp.constraint_mechanism == ""
+
+    def test_conditionality_fields_settable(self) -> None:
+        inp = FiscalPolicyInput(
+            target_entity="GRC",
+            instrument=FiscalInstrument.SPENDING_CHANGE,
+            sector="government",
+            value=Decimal("-0.08"),
+            duration_years=1,
+            source=InputSource.CONDITIONALITY,
+            constraining_actor_id="IMF",
+            constraint_mechanism="ELA_WITHDRAWAL_THREAT",
+        )
+        assert inp.source == InputSource.CONDITIONALITY
+        assert inp.constraining_actor_id == "IMF"
+        assert inp.constraint_mechanism == "ELA_WITHDRAWAL_THREAT"
+
+    def test_conditionality_audit_trail_distinguishable(self) -> None:
+        """CONDITIONALITY source is distinguishable from SCENARIO_SCRIPT in audit."""
+        free_choice = FiscalPolicyInput(
+            target_entity="GRC",
+            instrument=FiscalInstrument.SPENDING_CHANGE,
+            sector="government",
+            value=Decimal("-0.08"),
+            duration_years=1,
+            source=InputSource.SCENARIO_SCRIPT,
+        )
+        coerced = FiscalPolicyInput(
+            target_entity="GRC",
+            instrument=FiscalInstrument.SPENDING_CHANGE,
+            sector="government",
+            value=Decimal("-0.08"),
+            duration_years=1,
+            source=InputSource.CONDITIONALITY,
+            constraining_actor_id="IMF",
+            constraint_mechanism="DISBURSEMENT_SUSPENSION",
+        )
+        assert free_choice.source != coerced.source
+        assert coerced.constraining_actor_id == "IMF"
+
+
+# ---------------------------------------------------------------------------
+# Issue #93 — implementation_capacity scaling via get_events()
+# ---------------------------------------------------------------------------
+
+
+class TestImplementationCapacityScaling:
+    def test_default_capacity_is_one(self) -> None:
+        inp = _fiscal()
+        assert inp.implementation_capacity == Decimal("1.0")
+
+    def test_get_events_full_capacity_unchanged(self) -> None:
+        """implementation_capacity=1.0 → get_events() returns unscaled events."""
+        inp = _fiscal(value="-0.08", capacity="1.0")
+        raw = inp.to_events(_BASE_DATE)
+        scaled = inp.get_events(_BASE_DATE)
+        assert len(raw) == len(scaled)
+        for r, s in zip(raw, scaled, strict=True):
+            for k in r.affected_attributes:
+                assert r.affected_attributes[k].value == s.affected_attributes[k].value
+
+    def test_get_events_half_capacity_halves_magnitude(self) -> None:
+        """implementation_capacity=0.5 → event magnitudes halved."""
+        inp = _fiscal(value="-0.08", capacity="0.5")
+        raw = inp.to_events(_BASE_DATE)
+        scaled = inp.get_events(_BASE_DATE)
+        assert len(raw) == len(scaled)
+        for r, s in zip(raw, scaled, strict=True):
+            for k in r.affected_attributes:
+                assert s.affected_attributes[k].value == r.affected_attributes[k].value * Decimal("0.5")
+
+    def test_get_events_zero_capacity_zeroes_magnitude(self) -> None:
+        """implementation_capacity=0.0 → all event attribute values are zero."""
+        inp = _fiscal(value="-0.08", capacity="0.0")
+        scaled = inp.get_events(_BASE_DATE)
+        for evt in scaled:
+            for q in evt.affected_attributes.values():
+                assert q.value == Decimal("0")
+
+    def test_get_events_preserves_event_structure(self) -> None:
+        """Scaling must not change event_type, source_entity_id, or metadata."""
+        inp = _fiscal(value="-0.08", capacity="0.75")
+        raw = inp.to_events(_BASE_DATE)
+        scaled = inp.get_events(_BASE_DATE)
+        for r, s in zip(raw, scaled, strict=True):
+            assert r.event_type == s.event_type
+            assert r.source_entity_id == s.source_entity_id
+            assert r.framework == s.framework
+
+    def test_get_events_preserves_confidence_tier(self) -> None:
+        """Scaling must not change the confidence_tier of attribute Quantities."""
+        inp = _fiscal(value="-0.08", capacity="0.5")
+        raw = inp.to_events(_BASE_DATE)
+        scaled = inp.get_events(_BASE_DATE)
+        for r, s in zip(raw, scaled, strict=True):
+            for k in r.affected_attributes:
+                assert (r.affected_attributes[k].confidence_tier ==
+                        s.affected_attributes[k].confidence_tier)
+
+    def test_to_events_unaffected_by_capacity(self) -> None:
+        """to_events() must not apply scaling — raw output is always unscaled."""
+        inp = _fiscal(value="-0.10", capacity="0.3")
+        raw = inp.to_events(_BASE_DATE)
+        # The raw events should contain the full -0.10 magnitude
+        for evt in raw:
+            for q in evt.affected_attributes.values():
+                assert abs(q.value) == Decimal("0.10")
+
+
+# ---------------------------------------------------------------------------
+# Issue #157 — CompoundStateCondition AND/OR logic
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundStateCondition:
+    def _cond(
+        self, entity_id: str, attr: str, op: ComparisonOperator, threshold: float
+    ) -> StateCondition:
+        return StateCondition(
+            entity_id=entity_id,
+            attribute=attr,
+            operator=op,
+            threshold=threshold,
+        )
+
+    def test_and_both_met(self) -> None:
+        """AND: both conditions met → is_met returns True."""
+        state = _state_with("GRC", reserves=2.0, outflow=0.20)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                self._cond("GRC", "reserves", ComparisonOperator.LT, 3.0),
+                self._cond("GRC", "outflow", ComparisonOperator.GT, 0.15),
+            ],
+        )
+        assert compound.is_met(state) is True
+
+    def test_and_first_not_met(self) -> None:
+        """AND: first condition not met → is_met returns False (short-circuit)."""
+        state = _state_with("GRC", reserves=5.0, outflow=0.20)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                self._cond("GRC", "reserves", ComparisonOperator.LT, 3.0),  # 5.0 < 3.0 → False
+                self._cond("GRC", "outflow", ComparisonOperator.GT, 0.15),
+            ],
+        )
+        assert compound.is_met(state) is False
+
+    def test_and_second_not_met(self) -> None:
+        """AND: second condition not met → is_met returns False."""
+        state = _state_with("GRC", reserves=2.0, outflow=0.10)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                self._cond("GRC", "reserves", ComparisonOperator.LT, 3.0),
+                self._cond("GRC", "outflow", ComparisonOperator.GT, 0.15),  # 0.10 > 0.15 → False
+            ],
+        )
+        assert compound.is_met(state) is False
+
+    def test_or_first_met(self) -> None:
+        """OR: first condition met → is_met returns True (short-circuit)."""
+        state = _state_with("GRC", confidence=0.25, bank_holiday=0.0)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.OR,
+            conditions=[
+                self._cond("GRC", "confidence", ComparisonOperator.LT, 0.30),  # True
+                self._cond("GRC", "bank_holiday", ComparisonOperator.GT, 0.50),  # False
+            ],
+        )
+        assert compound.is_met(state) is True
+
+    def test_or_second_met(self) -> None:
+        """OR: only second condition met → is_met returns True."""
+        state = _state_with("GRC", confidence=0.50, bank_holiday=0.70)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.OR,
+            conditions=[
+                self._cond("GRC", "confidence", ComparisonOperator.LT, 0.30),  # False
+                self._cond("GRC", "bank_holiday", ComparisonOperator.GT, 0.50),  # True
+            ],
+        )
+        assert compound.is_met(state) is True
+
+    def test_or_none_met(self) -> None:
+        """OR: no conditions met → is_met returns False."""
+        state = _state_with("GRC", confidence=0.60, bank_holiday=0.30)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.OR,
+            conditions=[
+                self._cond("GRC", "confidence", ComparisonOperator.LT, 0.30),
+                self._cond("GRC", "bank_holiday", ComparisonOperator.GT, 0.50),
+            ],
+        )
+        assert compound.is_met(state) is False
+
+    def test_empty_conditions_returns_false(self) -> None:
+        """Empty conditions list is conservative — returns False."""
+        state = _state_with("GRC", gdp_growth=-0.05)
+        compound = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[],
+        )
+        assert compound.is_met(state) is False
+
+    def test_nested_compound_conditions(self) -> None:
+        """Nested AND within OR evaluates recursively."""
+        state = _state_with("GRC", reserves=2.0, outflow=0.20, gdp_growth=-0.10)
+        # (reserves < 3 AND outflow > 0.15) OR (gdp_growth < -0.05)
+        inner_and = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                self._cond("GRC", "reserves", ComparisonOperator.LT, 3.0),
+                self._cond("GRC", "outflow", ComparisonOperator.GT, 0.15),
+            ],
+        )
+        outer_or = CompoundStateCondition(
+            operator=LogicalOperator.OR,
+            conditions=[
+                inner_and,
+                self._cond("GRC", "gdp_growth", ComparisonOperator.LT, -0.05),
+            ],
+        )
+        assert outer_or.is_met(state) is True
+
+    def test_nested_and_fails_when_inner_condition_not_met(self) -> None:
+        """Nested compound: inner AND fails → outer AND fails."""
+        state = _state_with("GRC", reserves=5.0, outflow=0.20, deficit=0.10)
+        # (reserves < 3 AND outflow > 0.15) AND deficit > 0.05
+        inner_and = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                self._cond("GRC", "reserves", ComparisonOperator.LT, 3.0),  # False
+                self._cond("GRC", "outflow", ComparisonOperator.GT, 0.15),
+            ],
+        )
+        outer_and = CompoundStateCondition(
+            operator=LogicalOperator.AND,
+            conditions=[
+                inner_and,
+                self._cond("GRC", "deficit", ComparisonOperator.GT, 0.05),
+            ],
+        )
+        assert outer_and.is_met(state) is False
+
+    def test_state_condition_backward_compatible(self) -> None:
+        """Existing StateCondition.is_met() still works — no regression."""
+        state = _state_with("GRC", gdp_growth=-0.05)
+        cond = self._cond("GRC", "gdp_growth", ComparisonOperator.LT, 0.0)
+        assert cond.is_met(state) is True
+
+    def test_logical_operator_enum_values(self) -> None:
+        assert LogicalOperator.AND.value == "and"
+        assert LogicalOperator.OR.value == "or"


### PR DESCRIPTION
## Summary

Three political economy orchestration extensions (M11 stretch goal):

- **#96 — CONDITIONALITY InputSource**: `InputSource.CONDITIONALITY` added to distinguish externally coerced decisions from freely chosen policy. `ControlInput` extended with `constraining_actor_id` and `constraint_mechanism` fields. The Greece IMF program acceptance can now be recorded as CONDITIONALITY with `constraining_actor_id='IMF'`, `constraint_mechanism='ELA_WITHDRAWAL_THREAT'` — distinct from `SCENARIO_SCRIPT` (free choice) in the audit trail.

- **#93 — implementation_capacity scaling**: `implementation_capacity: Decimal` field added to `ControlInput` (default `1.0`). `get_events()` wrapper added — applies scaling to all event attribute magnitudes. Models partial implementation, political feasibility constraints, and watered-down policy execution. `WebScenarioRunner` and `InputOrchestrator.inject()` updated to use `get_events()`. Existing `to_events()` callers unaffected.

- **#157 — CompoundStateCondition**: `LogicalOperator` enum (AND/OR) and `CompoundStateCondition` dataclass with recursive `is_met()`. Enables multi-attribute AND/OR trigger logic for `ContingentInput`. `ContingentInput.condition` now accepts `StateCondition | CompoundStateCondition`. Backward compatible — existing single-condition usage unchanged.

## Closes

- Closes #96
- Closes #93
- Closes #157

## Test plan

- [x] `ruff check .` — clean
- [x] 942/942 unit tests pass (24 new tests)
- [x] Backward compatibility: all existing `to_events()` callers pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)