### PR TITLE
feat(engine): G18 — n_runs schema, multi-step inputs, capital flow inputs, debt profile

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -327,6 +327,11 @@ class ScenarioConfigSchema(BaseModel):
         When present, legitimacy_index scales ControlInput implementation
         capacity and social response events are generated for high-impact
         ControlInputs when social_response_enabled is set in modules_config.
+    `n_runs` — number of Monte Carlo runs (Issue #89). Default 1 (deterministic).
+        Values > 1 signal distributional output; the schema accepts the field so
+        MC support can be added without a breaking schema change. MC sampling
+        itself is not yet implemented — n_runs > 1 is recorded but produces
+        a single deterministic trajectory until ADR-007 MC support ships.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -339,6 +344,7 @@ class ScenarioConfigSchema(BaseModel):
     start_date: date | None = None
     step_metadata: dict[str, Any] = {}
     political_context: PoliticalContext | None = None
+    n_runs: int = 1
 
 
 class ScheduledInputSchema(BaseModel):

--- a/backend/app/simulation/engine/models.py
+++ b/backend/app/simulation/engine/models.py
@@ -176,6 +176,59 @@ class PropagationRule:
 
 
 # ---------------------------------------------------------------------------
+# Debt structure (Issue #36 — Intergenerational Advocate ARCH-REVIEW-001)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DebtProfile:
+    """Structured debt composition for an entity.
+
+    Captures six dimensions that determine vulnerability profile beyond the
+    simple debt/GDP ratio. Japan at 253% (yen-denominated, domestically held)
+    and Vietnam at 37% (with significant foreign-currency components) have
+    entirely different crisis dynamics — this dataclass makes that distinction
+    computable.
+
+    All fields are fractions (0.0 to 1.0) except where noted.
+
+    Attributes:
+        total_pct_gdp: Total public debt as fraction of GDP (e.g. 0.85 = 85%).
+        foreign_currency_pct: Share of debt denominated in foreign currency.
+            The 'original sin' dimension — foreign-currency debt cannot be
+            inflated away and creates acute rollover risk under FX pressure.
+            MDA threshold: > 0.60 flags elevated rollover risk.
+        short_term_pct: Share of debt maturing within 12 months. Measures
+            rollover cliff risk.
+        domestic_holder_pct: Share held by domestic investors (banks,
+            pension funds, central bank). Higher = less vulnerable to
+            foreign capital exit.
+        multilateral_pct: Share owed to multilateral creditors (IMF, World
+            Bank, regional MDBs). Distinct restructuring dynamics — preferred
+            creditor status limits haircut exposure.
+        interest_service_pct_revenue: Debt service as fraction of government
+            revenue. The fiscal sustainability measure — stock matters less
+            than the income it consumes.
+    """
+
+    total_pct_gdp: Decimal
+    foreign_currency_pct: Decimal
+    short_term_pct: Decimal
+    domestic_holder_pct: Decimal
+    multilateral_pct: Decimal
+    interest_service_pct_revenue: Decimal
+
+    # Threshold at which foreign_currency_pct triggers MDA elevated rollover risk
+    FOREIGN_CURRENCY_MDA_THRESHOLD: Decimal = field(
+        default=Decimal("0.60"), init=False, repr=False, compare=False
+    )
+
+    def is_elevated_rollover_risk(self) -> bool:
+        """Return True if foreign currency debt share exceeds MDA threshold."""
+        return self.foreign_currency_pct > self.FOREIGN_CURRENCY_MDA_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
 # Core entities
 # ---------------------------------------------------------------------------
 
@@ -204,9 +257,34 @@ class SimulationEntity:
     metadata: dict[str, Any]              # non-simulation data
     parent_id: str | None = None      # enclosing entity for hierarchical resolution
     geometry: Geometry | None = None  # spatial reference, populated in Milestone 2
+    debt_profile: DebtProfile | None = None  # Issue #36 — structured debt composition
+
+    # Mapping from debt_profile.* attribute keys to DebtProfile field names.
+    # Used by get_attribute() to expose debt structure as Quantity attributes
+    # for MDA threshold evaluation without duplicating storage.
+    _DEBT_PROFILE_ATTR_MAP: dict[str, str] = field(
+        default_factory=lambda: {
+            "debt_profile.total_pct_gdp": "total_pct_gdp",
+            "debt_profile.foreign_currency_pct": "foreign_currency_pct",
+            "debt_profile.short_term_pct": "short_term_pct",
+            "debt_profile.domestic_holder_pct": "domestic_holder_pct",
+            "debt_profile.multilateral_pct": "multilateral_pct",
+            "debt_profile.interest_service_pct_revenue": "interest_service_pct_revenue",
+        },
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def get_attribute(self, key: str) -> Quantity | None:
         """Return an attribute Quantity, or None if not present.
+
+        Supports two key namespaces:
+          - Direct entity attributes: keys in self.attributes.
+          - Debt profile sub-keys: `"debt_profile.<field>"` keys expose
+            DebtProfile fields as RATIO Quantities when debt_profile is set.
+            This allows MDA thresholds to evaluate debt structure via the
+            same indicator_key mechanism used for all other thresholds.
 
         Args:
             key: Attribute key to look up.
@@ -215,6 +293,15 @@ class SimulationEntity:
             Quantity for the key, or None if the key is absent.
             Use get_attribute_value() for numeric comparison operations.
         """
+        if key in self._DEBT_PROFILE_ATTR_MAP and self.debt_profile is not None:
+            field_name = self._DEBT_PROFILE_ATTR_MAP[key]
+            value = getattr(self.debt_profile, field_name)
+            return Quantity(
+                value=value,
+                unit="ratio",
+                variable_type=VariableType.RATIO,
+                confidence_tier=2,
+            )
         return self.attributes.get(key)
 
     def get_attribute_value(self, key: str, default: Decimal = Decimal("0")) -> Decimal:
@@ -224,7 +311,7 @@ class SimulationEntity:
         Returns Decimal, which is comparable to float via standard Python
         arithmetic and pytest.approx.
         """
-        q = self.attributes.get(key)
+        q = self.get_attribute(key)
         if q is None:
             return default
         return q.value

--- a/backend/app/simulation/orchestration/inputs.py
+++ b/backend/app/simulation/orchestration/inputs.py
@@ -2,6 +2,8 @@
 Control input types for the Input Orchestration Layer — ADR-002, Amendment 1.
 Political economy extensions: Issue #96 (CONDITIONALITY InputSource),
 Issue #93 (implementation_capacity), Issue #157 (CompoundStateCondition).
+Issue #31 (multi-step duration_periods + decay_function on ControlInput base).
+Issue #33 (CapitalFlowInput, DFICommitmentInput, ActorType enum).
 
 ControlInput is the abstract base class for all exogenous inputs injected
 into the simulation. Each concrete subclass represents one category of
@@ -49,6 +51,42 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Enumerations
 # ---------------------------------------------------------------------------
+
+
+class ActorType(Enum):
+    """Type of actor authorising a ControlInput (Issue #33).
+
+    Extends the actor model beyond government and central bank actors to
+    include private capital, development finance, and sovereign investment
+    — the primary channels through which capital flows into and out of
+    developing economies.
+    """
+
+    GOVERNMENT = "government"
+    CENTRAL_BANK = "central_bank"
+    PRIVATE_INVESTOR = "private_investor"
+    DFI = "dfi"
+    SOVEREIGN_INVESTOR = "sovereign_investor"
+    MULTILATERAL = "multilateral"
+
+
+class CapitalFlowType(Enum):
+    """Category of private capital flow for CapitalFlowInput (Issue #33)."""
+
+    FDI = "fdi"
+    PORTFOLIO_INVESTMENT = "portfolio_investment"
+    SOVEREIGN_DEBT = "sovereign_debt"
+    REMITTANCE = "remittance"
+
+
+class DFIInstrumentType(Enum):
+    """Development Finance Institution instrument types (Issue #33)."""
+
+    GUARANTEE = "guarantee"
+    EQUITY_INVESTMENT = "equity_investment"
+    TECHNICAL_ASSISTANCE = "technical_assistance"
+    CONCESSIONAL_LOAN = "concessional_loan"
+    MDB_BUDGET_SUPPORT = "mdb_budget_support"
 
 
 class InputSource(Enum):
@@ -206,11 +244,26 @@ class ControlInput(ABC):
         constraint_mechanism: For InputSource.CONDITIONALITY — how the constraint
             was applied (e.g. 'ELA_WITHDRAWAL_THREAT', 'DISBURSEMENT_SUSPENSION',
             'SANCTIONS'). Empty string for non-conditionality inputs (Issue #96).
+        duration_periods: Number of simulation timesteps this input remains active
+            (Issue #31). Default 1 (one-shot). Values > 1 cause the orchestrator
+            to re-inject the input for the subsequent `duration_periods - 1` steps.
+            The ScenarioRunner expands multi-duration inputs at run() time;
+            the WebScenarioRunner requires duration rows pre-created in
+            scenario_scheduled_inputs.
+        decay_function: How the effect magnitude changes across duration_periods
+            (Issue #31). One of:
+              "constant"           — same magnitude every period (default)
+              "linear_decay"       — linearly decreasing: scale = 1 - (p-1)/n
+              "exponential_decay"  — halves each period: scale = 0.5^(p-1)
+            Ignored when duration_periods == 1.
+        actor_type: Structured actor category from ActorType enum (Issue #33).
+            Complements the free-text actor_role field.
     """
 
     input_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     actor_id: str = ""
     actor_role: str = ""
+    actor_type: ActorType | None = None
     target_entity: str = ""
     effective_date: datetime = field(default=None)  # type: ignore[assignment]
     justification: str = ""
@@ -220,6 +273,8 @@ class ControlInput(ABC):
     implementation_capacity: Decimal = Decimal("1.0")
     constraining_actor_id: str = ""
     constraint_mechanism: str = ""
+    duration_periods: int = 1
+    decay_function: str = "constant"
 
     @abstractmethod
     def to_events(self, timestep: datetime) -> list[Event]:
@@ -296,12 +351,10 @@ class MonetaryRateInput(ControlInput):
     Attributes:
         instrument: The rate instrument being adjusted.
         value: Magnitude and direction of the change as a Decimal fraction.
-        duration_periods: Timesteps this input remains in force.
     """
 
     instrument: MonetaryRateInstrument = MonetaryRateInstrument.POLICY_RATE
     value: Decimal = Decimal("0")
-    duration_periods: int = 1
 
     def to_events(self, timestep: datetime) -> list[Event]:
         """Translate to a monetary rate Event targeting the source entity.
@@ -354,12 +407,10 @@ class MonetaryVolumeInput(ControlInput):
     Attributes:
         instrument: The volume instrument being adjusted.
         value: Monetary volume of the action as a MonetaryValue.
-        duration_periods: Timesteps this input remains in force.
     """
 
     instrument: MonetaryVolumeInstrument = MonetaryVolumeInstrument.ASSET_PURCHASE
     value: MonetaryValue = field(default=None)  # type: ignore[assignment]
-    duration_periods: int = 1
 
     def to_events(self, timestep: datetime) -> list[Event]:
         """Translate to a monetary volume Event targeting the source entity.
@@ -674,6 +725,142 @@ class StructuralPolicyInput(ControlInput):
                     "affected_sector": self.affected_sector,
                     "parameters": self.parameters,
                     "implementation_years": self.implementation_years,
+                },
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Private capital inputs (Issue #33 — Investment Agent RISK-TOLERANT)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class CapitalFlowInput(ControlInput):
+    """A private or sovereign capital flow event.
+
+    Models the capital movements that are the primary transmission mechanism
+    for financial shocks in developing economies: FDI, portfolio flows, and
+    sovereign debt market transactions. Unlike government policy instruments,
+    these flows originate from actors outside the sovereign government.
+
+    Attributes:
+        flow_type: Category of capital movement (FDI, portfolio, sovereign debt,
+            remittance).
+        volume: Signed Decimal — positive = inflow, negative = outflow. Units
+            are % of GDP (RATIO) for cross-country comparability.
+        counterpart_entity: Optional ISO entity ID of the counterpart actor
+            (e.g. the investing country or institution).
+    """
+
+    flow_type: CapitalFlowType = CapitalFlowType.FDI
+    volume: Decimal = Decimal("0")
+    counterpart_entity: str = ""
+
+    def to_events(self, timestep: datetime) -> list[Event]:
+        """Translate to capital flow Events affecting fdi_stock, portfolio_flows,
+        or reserve_adequacy depending on flow_type.
+
+        Args:
+            timestep: Simulation timestep at which this input fires.
+
+        Returns:
+            Single-element list containing the capital flow Event.
+        """
+        from app.simulation.engine.models import Event, MeasurementFramework
+
+        # Attribute targets per flow type
+        _ATTR_MAP: dict[CapitalFlowType, str] = {
+            CapitalFlowType.FDI: "fdi_stock",
+            CapitalFlowType.PORTFOLIO_INVESTMENT: "portfolio_flows",
+            CapitalFlowType.SOVEREIGN_DEBT: "reserve_adequacy",
+            CapitalFlowType.REMITTANCE: "portfolio_flows",
+        }
+        attribute_key = _ATTR_MAP[self.flow_type]
+
+        delta = Quantity(
+            value=self.volume,
+            unit="pct_gdp",
+            variable_type=VariableType.FLOW,
+            measurement_framework=MeasurementFramework.FINANCIAL,
+            confidence_tier=2,
+        )
+        return [
+            Event(
+                event_id=f"{self.input_id}-capital-0",
+                source_entity_id=self.target_entity,
+                event_type=f"capital_flow_{self.flow_type.value}",
+                affected_attributes={attribute_key: delta},
+                propagation_rules=self.propagation_rules,
+                timestep_originated=timestep,
+                framework=MeasurementFramework.FINANCIAL,
+                metadata={
+                    "control_input_id": self.input_id,
+                    "actor_id": self.actor_id,
+                    "flow_type": self.flow_type.value,
+                    "counterpart_entity": self.counterpart_entity,
+                },
+            )
+        ]
+
+
+@dataclass(kw_only=True)
+class DFICommitmentInput(ControlInput):
+    """A Development Finance Institution commitment.
+
+    Covers IFC, MIGA, bilateral DFI, and MDB instruments — the concessional
+    and guarantee mechanisms through which public development finance is
+    channelled. Distinguished from private capital flows by the actor type
+    (DFI) and the instrument type (guarantee, equity, concessional loan, etc.).
+
+    Attributes:
+        instrument: DFI instrument type (guarantee, equity, concessional loan, etc.).
+        volume: Committed amount as % of GDP (RATIO). Positive = commitment inflow.
+        dfi_actor: Optional ISO or institution ID of the DFI (e.g. 'IFC', 'AfDB').
+        disbursement_schedule_years: Number of years over which the commitment
+            is expected to disburse. Informational — does not drive re-injection
+            (use duration_periods for sustained multi-step effects).
+    """
+
+    instrument: DFIInstrumentType = DFIInstrumentType.GUARANTEE
+    volume: Decimal = Decimal("0")
+    dfi_actor: str = ""
+    disbursement_schedule_years: int = 1
+
+    def to_events(self, timestep: datetime) -> list[Event]:
+        """Translate to DFI commitment Events affecting fdi_stock and
+        infrastructure-related attributes.
+
+        Args:
+            timestep: Simulation timestep at which this input fires.
+
+        Returns:
+            Single-element list containing the DFI commitment Event.
+        """
+        from app.simulation.engine.models import Event, MeasurementFramework
+
+        delta = Quantity(
+            value=self.volume,
+            unit="pct_gdp",
+            variable_type=VariableType.FLOW,
+            measurement_framework=MeasurementFramework.FINANCIAL,
+            confidence_tier=2,
+        )
+        return [
+            Event(
+                event_id=f"{self.input_id}-dfi-0",
+                source_entity_id=self.target_entity,
+                event_type=f"dfi_commitment_{self.instrument.value}",
+                affected_attributes={"fdi_stock": delta},
+                propagation_rules=self.propagation_rules,
+                timestep_originated=timestep,
+                framework=MeasurementFramework.FINANCIAL,
+                metadata={
+                    "control_input_id": self.input_id,
+                    "actor_id": self.actor_id,
+                    "dfi_actor": self.dfi_actor,
+                    "instrument": self.instrument.value,
+                    "disbursement_schedule_years": self.disbursement_schedule_years,
                 },
             )
         ]

--- a/backend/app/simulation/orchestration/runner.py
+++ b/backend/app/simulation/orchestration/runner.py
@@ -199,17 +199,23 @@ class ScenarioRunner(InputOrchestrator):
         Advances n_steps times from the initial state. At each step, fires
         scheduled inputs, evaluates contingents, runs modules, and propagates.
 
+        Multi-period inputs (duration_periods > 1) are expanded here: an input
+        scheduled at step S with duration_periods=3 produces continuation entries
+        at steps S+1 and S+2. The magnitude at each continuation step is scaled
+        by the input's decay_function (Issue #31).
+
         Returns:
             List of SimulationStates of length n_steps + 1. Index 0 is the
             initial state. Index i is the state after i steps have been taken.
         """
+        expanded = _expand_multi_period_inputs(self._scheduled_inputs, self._n_steps)
         history: list[SimulationState] = [self._initial_state]
         current_state = self._initial_state
 
         for step_index in range(1, self._n_steps + 1):
             step_inputs = [
                 inp
-                for (idx, inp) in self._scheduled_inputs
+                for (idx, inp) in expanded
                 if idx == step_index
             ]
             current_state = self.advance_timestep(
@@ -376,6 +382,75 @@ class ScenarioRunner(InputOrchestrator):
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _period_scale(decay_function: str, period: int, duration_periods: int) -> float:
+    """Compute the magnitude scale factor for a continuation period.
+
+    period is 1-indexed (period=1 is the original injection, period=2 is the
+    first continuation, etc.). Callers only invoke this for period >= 2.
+
+    decay_function values:
+      "constant"         — returns 1.0 for all periods.
+      "linear_decay"     — linearly decreasing: 1 - (period-1)/duration_periods.
+                           Period 1 = 1.0, last period ≈ 0 (never exactly 0).
+      "exponential_decay"— halves each period: 0.5^(period-1).
+
+    Args:
+        decay_function: Decay schedule name.
+        period: 1-indexed period number.
+        duration_periods: Total duration in periods.
+
+    Returns:
+        Multiplicative scale factor in (0.0, 1.0].
+    """
+    if decay_function == "linear_decay":
+        scale = 1.0 - (period - 1) / max(duration_periods, 1)
+        return max(scale, 0.0)
+    if decay_function == "exponential_decay":
+        return 0.5 ** (period - 1)
+    return 1.0  # "constant" and any unrecognised value
+
+
+def _expand_multi_period_inputs(
+    scheduled_inputs: list[tuple[int, ControlInput]],
+    n_steps: int,
+) -> list[tuple[int, ControlInput]]:
+    """Expand multi-period inputs into their full continuation schedule.
+
+    For each (step, input) where input.duration_periods > 1, generates
+    additional (step + period - 1, scaled_input) entries for periods 2..N,
+    clamped to steps <= n_steps.
+
+    The continuation input has the same fields as the original but with
+    implementation_capacity multiplied by the period-specific decay factor.
+    input_id is preserved — the audit log can group continuations by the
+    originating input_id.
+
+    Args:
+        scheduled_inputs: Original (step_index, ControlInput) pairs.
+        n_steps: Total scenario steps — continuations beyond this are dropped.
+
+    Returns:
+        Expanded list including all original entries plus continuations.
+    """
+    from decimal import Decimal as _Decimal
+
+    expanded: list[tuple[int, ControlInput]] = list(scheduled_inputs)
+
+    for orig_step, inp in scheduled_inputs:
+        if inp.duration_periods <= 1:
+            continue
+        for period in range(2, inp.duration_periods + 1):
+            target_step = orig_step + period - 1
+            if target_step > n_steps:
+                break
+            scale = _period_scale(inp.decay_function, period, inp.duration_periods)
+            new_capacity = inp.implementation_capacity * _Decimal(str(round(scale, 10)))
+            continuation = dataclasses.replace(inp, implementation_capacity=new_capacity)
+            expanded.append((target_step, continuation))
+
+    return expanded
 
 
 def _advance_timestep(current: datetime, delta: timedelta | None) -> datetime:

--- a/backend/tests/unit/test_g18_schema_controlinput_debt.py
+++ b/backend/tests/unit/test_g18_schema_controlinput_debt.py
@@ -1,0 +1,422 @@
+"""Tests for G18 batch — Issue #89 (n_runs schema), #31 (multi-step duration),
+#33 (CapitalFlowInput, DFICommitmentInput, ActorType), #36 (DebtProfile).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.schemas import ScenarioConfigSchema
+from app.simulation.engine.models import DebtProfile, SimulationEntity
+from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.orchestration.inputs import (
+    ActorType,
+    CapitalFlowInput,
+    CapitalFlowType,
+    DFICommitmentInput,
+    DFIInstrumentType,
+    FiscalInstrument,
+    FiscalPolicyInput,
+    InputSource,
+)
+from app.simulation.orchestration.runner import (
+    ScenarioRunner,
+    _expand_multi_period_inputs,
+    _period_scale,
+)
+
+_TS = datetime(2010, 1, 1, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Issue #89 — n_runs on ScenarioConfigSchema
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_config_schema_n_runs_default() -> None:
+    cfg = ScenarioConfigSchema(entities=["GRC"], n_steps=3)
+    assert cfg.n_runs == 1
+
+
+def test_scenario_config_schema_n_runs_explicit() -> None:
+    cfg = ScenarioConfigSchema(entities=["GRC"], n_steps=3, n_runs=100)
+    assert cfg.n_runs == 100
+
+
+def test_scenario_config_schema_n_runs_roundtrip() -> None:
+    cfg = ScenarioConfigSchema(entities=["GRC"], n_steps=3, n_runs=50)
+    data = cfg.model_dump()
+    restored = ScenarioConfigSchema(**data)
+    assert restored.n_runs == 50
+
+
+# ---------------------------------------------------------------------------
+# Issue #36 — DebtProfile dataclass and SimulationEntity integration
+# ---------------------------------------------------------------------------
+
+
+def _make_entity(entity_id: str = "GRC", **attrs: Decimal) -> SimulationEntity:
+    quantities = {
+        k: Quantity(value=v, unit="ratio", variable_type=VariableType.RATIO, confidence_tier=2)
+        for k, v in attrs.items()
+    }
+    return SimulationEntity(
+        id=entity_id,
+        entity_type="country",
+        attributes=quantities,
+        metadata={},
+    )
+
+
+def test_debt_profile_basic_fields() -> None:
+    dp = DebtProfile(
+        total_pct_gdp=Decimal("0.85"),
+        foreign_currency_pct=Decimal("0.35"),
+        short_term_pct=Decimal("0.15"),
+        domestic_holder_pct=Decimal("0.60"),
+        multilateral_pct=Decimal("0.12"),
+        interest_service_pct_revenue=Decimal("0.18"),
+    )
+    assert dp.total_pct_gdp == Decimal("0.85")
+    assert dp.foreign_currency_pct == Decimal("0.35")
+    assert not dp.is_elevated_rollover_risk()
+
+
+def test_debt_profile_elevated_rollover_risk() -> None:
+    dp = DebtProfile(
+        total_pct_gdp=Decimal("0.70"),
+        foreign_currency_pct=Decimal("0.70"),
+        short_term_pct=Decimal("0.20"),
+        domestic_holder_pct=Decimal("0.10"),
+        multilateral_pct=Decimal("0.05"),
+        interest_service_pct_revenue=Decimal("0.25"),
+    )
+    assert dp.is_elevated_rollover_risk()
+
+
+def test_debt_profile_threshold_boundary() -> None:
+    dp_below = DebtProfile(
+        total_pct_gdp=Decimal("0.80"),
+        foreign_currency_pct=Decimal("0.60"),
+        short_term_pct=Decimal("0.10"),
+        domestic_holder_pct=Decimal("0.40"),
+        multilateral_pct=Decimal("0.10"),
+        interest_service_pct_revenue=Decimal("0.15"),
+    )
+    # Exactly 0.60 is not > 0.60
+    assert not dp_below.is_elevated_rollover_risk()
+
+
+def test_simulation_entity_debt_profile_none_by_default() -> None:
+    entity = _make_entity("GRC")
+    assert entity.debt_profile is None
+
+
+def test_simulation_entity_get_attribute_debt_profile_key() -> None:
+    dp = DebtProfile(
+        total_pct_gdp=Decimal("0.85"),
+        foreign_currency_pct=Decimal("0.45"),
+        short_term_pct=Decimal("0.12"),
+        domestic_holder_pct=Decimal("0.55"),
+        multilateral_pct=Decimal("0.08"),
+        interest_service_pct_revenue=Decimal("0.20"),
+    )
+    entity = _make_entity("GRC")
+    object.__setattr__(entity, "debt_profile", dp)
+
+    qty = entity.get_attribute("debt_profile.foreign_currency_pct")
+    assert qty is not None
+    assert qty.value == Decimal("0.45")
+
+
+def test_simulation_entity_get_attribute_value_debt_profile() -> None:
+    dp = DebtProfile(
+        total_pct_gdp=Decimal("1.20"),
+        foreign_currency_pct=Decimal("0.65"),
+        short_term_pct=Decimal("0.18"),
+        domestic_holder_pct=Decimal("0.30"),
+        multilateral_pct=Decimal("0.15"),
+        interest_service_pct_revenue=Decimal("0.30"),
+    )
+    entity = _make_entity("GRC")
+    object.__setattr__(entity, "debt_profile", dp)
+
+    val = entity.get_attribute_value("debt_profile.foreign_currency_pct")
+    assert val == Decimal("0.65")
+
+
+def test_simulation_entity_get_attribute_unknown_key_returns_none() -> None:
+    entity = _make_entity("GRC")
+    assert entity.get_attribute("debt_profile.nonexistent") is None
+    assert entity.get_attribute("nonexistent_attribute") is None
+
+
+def test_simulation_entity_debt_profile_key_without_profile_returns_none() -> None:
+    entity = _make_entity("GRC")
+    # No debt_profile set — should return None, not raise
+    assert entity.get_attribute("debt_profile.foreign_currency_pct") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #31 — duration_periods and decay_function on ControlInput base
+# ---------------------------------------------------------------------------
+
+
+def test_control_input_duration_periods_default() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+    )
+    assert inp.duration_periods == 1
+    assert inp.decay_function == "constant"
+
+
+def test_control_input_duration_periods_explicit() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+        duration_periods=3,
+        decay_function="linear_decay",
+    )
+    assert inp.duration_periods == 3
+    assert inp.decay_function == "linear_decay"
+
+
+def test_period_scale_constant() -> None:
+    for p in range(1, 6):
+        assert _period_scale("constant", p, 5) == pytest.approx(1.0)
+
+
+def test_period_scale_linear_decay() -> None:
+    # period=1: scale=1.0; period=2: scale=0.8; period=3: scale=0.6, etc.
+    assert _period_scale("linear_decay", 1, 5) == pytest.approx(1.0)
+    assert _period_scale("linear_decay", 2, 5) == pytest.approx(0.8)
+    assert _period_scale("linear_decay", 3, 5) == pytest.approx(0.6)
+    assert _period_scale("linear_decay", 5, 5) == pytest.approx(0.2)
+
+
+def test_period_scale_exponential_decay() -> None:
+    assert _period_scale("exponential_decay", 1, 5) == pytest.approx(1.0)
+    assert _period_scale("exponential_decay", 2, 5) == pytest.approx(0.5)
+    assert _period_scale("exponential_decay", 3, 5) == pytest.approx(0.25)
+
+
+def test_expand_multi_period_inputs_single_period() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+        duration_periods=1,
+    )
+    expanded = _expand_multi_period_inputs([(1, inp)], n_steps=5)
+    assert len(expanded) == 1
+    assert expanded[0] == (1, inp)
+
+
+def test_expand_multi_period_inputs_three_periods() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+        duration_periods=3,
+        decay_function="constant",
+    )
+    expanded = _expand_multi_period_inputs([(1, inp)], n_steps=5)
+    # Original + 2 continuations
+    assert len(expanded) == 3
+    steps = sorted(s for s, _ in expanded)
+    assert steps == [1, 2, 3]
+
+
+def test_expand_multi_period_inputs_clamps_to_n_steps() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+        duration_periods=10,
+        decay_function="constant",
+    )
+    expanded = _expand_multi_period_inputs([(1, inp)], n_steps=3)
+    # Only steps 1, 2, 3 — step 4+ is clamped
+    steps = sorted(s for s, _ in expanded)
+    assert steps == [1, 2, 3]
+
+
+def test_expand_multi_period_inputs_linear_decay_scales_capacity() -> None:
+    inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("-0.05"),
+        duration_periods=3,
+        decay_function="linear_decay",
+        implementation_capacity=Decimal("1.0"),
+    )
+    expanded = _expand_multi_period_inputs([(1, inp)], n_steps=5)
+    by_step = dict(expanded)
+
+    # Period 2 scale = 1 - 1/3 ≈ 0.667
+    assert float(by_step[2].implementation_capacity) == pytest.approx(0.6667, abs=1e-4)
+    # Period 3 scale = 1 - 2/3 ≈ 0.333
+    assert float(by_step[3].implementation_capacity) == pytest.approx(0.3333, abs=1e-4)
+
+
+def test_scenario_runner_multi_step_injection() -> None:
+    """Integration: multi-period input fires at three steps in run()."""
+    from datetime import UTC, datetime
+
+    from app.simulation.engine.models import (
+        ResolutionConfig,
+        ResolutionLevel,
+        ScenarioConfig,
+        SimulationState,
+    )
+
+    entities = {
+        "GRC": SimulationEntity(
+            id="GRC",
+            entity_type="country",
+            attributes={
+                "gdp_growth_rate": Quantity(
+                    value=Decimal("-3.0"),
+                    unit="percent",
+                    variable_type=VariableType.RATIO,
+                    confidence_tier=1,
+                )
+            },
+            metadata={},
+        )
+    }
+    ts = datetime(2010, 1, 1, tzinfo=UTC)
+    state = SimulationState(
+        timestep=ts,
+        resolution=ResolutionConfig(global_level=ResolutionLevel.NATION_STATE),
+        entities=entities,
+        relationships=[],
+        events=[],
+        scenario_config=ScenarioConfig(
+            scenario_id="test-g18",
+            name="G18 Test",
+            description="",
+            start_date=ts,
+            end_date=datetime(2016, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+    fiscal_inp = FiscalPolicyInput(
+        target_entity="GRC",
+        instrument=FiscalInstrument.SPENDING_CHANGE,
+        value=Decimal("0.01"),
+        duration_periods=3,
+        decay_function="constant",
+    )
+
+    runner = ScenarioRunner(
+        initial_state=state,
+        scheduled_inputs=[(1, fiscal_inp)],
+        modules=[],
+        n_steps=5,
+    )
+    history = runner.run()
+    # 5 steps + initial = 6 states
+    assert len(history) == 6
+    # At step 3, the continuation should have fired — GDP still updated
+    # (just verify no exception and expected history length)
+    assert history[3].timestep.year == 2013
+
+
+# ---------------------------------------------------------------------------
+# Issue #33 — ActorType, CapitalFlowInput, DFICommitmentInput
+# ---------------------------------------------------------------------------
+
+
+def test_actor_type_enum_values() -> None:
+    assert ActorType.PRIVATE_INVESTOR.value == "private_investor"
+    assert ActorType.DFI.value == "dfi"
+    assert ActorType.SOVEREIGN_INVESTOR.value == "sovereign_investor"
+    assert ActorType.GOVERNMENT.value == "government"
+    assert ActorType.CENTRAL_BANK.value == "central_bank"
+
+
+def test_capital_flow_input_defaults() -> None:
+    inp = CapitalFlowInput(target_entity="ARG")
+    assert inp.flow_type == CapitalFlowType.FDI
+    assert inp.volume == Decimal("0")
+    assert inp.duration_periods == 1
+    assert inp.actor_type is None
+
+
+def test_capital_flow_input_to_events_fdi() -> None:
+    inp = CapitalFlowInput(
+        target_entity="ARG",
+        flow_type=CapitalFlowType.FDI,
+        volume=Decimal("0.03"),
+        actor_type=ActorType.PRIVATE_INVESTOR,
+    )
+    events = inp.to_events(_TS)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.source_entity_id == "ARG"
+    assert "fdi_stock" in evt.affected_attributes
+    assert evt.affected_attributes["fdi_stock"].value == Decimal("0.03")
+    assert evt.event_type == "capital_flow_fdi"
+
+
+def test_capital_flow_input_to_events_portfolio() -> None:
+    inp = CapitalFlowInput(
+        target_entity="GRC",
+        flow_type=CapitalFlowType.PORTFOLIO_INVESTMENT,
+        volume=Decimal("-0.05"),
+    )
+    events = inp.to_events(_TS)
+    assert events[0].affected_attributes["portfolio_flows"].value == Decimal("-0.05")
+    assert events[0].event_type == "capital_flow_portfolio_investment"
+
+
+def test_capital_flow_input_to_events_sovereign_debt() -> None:
+    inp = CapitalFlowInput(
+        target_entity="GRC",
+        flow_type=CapitalFlowType.SOVEREIGN_DEBT,
+        volume=Decimal("0.10"),
+    )
+    events = inp.to_events(_TS)
+    assert "reserve_adequacy" in events[0].affected_attributes
+
+
+def test_dfi_commitment_input_defaults() -> None:
+    inp = DFICommitmentInput(target_entity="ETH")
+    assert inp.instrument == DFIInstrumentType.GUARANTEE
+    assert inp.volume == Decimal("0")
+    assert inp.dfi_actor == ""
+
+
+def test_dfi_commitment_input_to_events() -> None:
+    inp = DFICommitmentInput(
+        target_entity="ETH",
+        instrument=DFIInstrumentType.CONCESSIONAL_LOAN,
+        volume=Decimal("0.02"),
+        dfi_actor="AfDB",
+        actor_type=ActorType.DFI,
+        actor_id="AfDB",
+    )
+    events = inp.to_events(_TS)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.source_entity_id == "ETH"
+    assert "fdi_stock" in evt.affected_attributes
+    assert evt.affected_attributes["fdi_stock"].value == Decimal("0.02")
+    assert evt.event_type == "dfi_commitment_concessional_loan"
+    assert evt.metadata["dfi_actor"] == "AfDB"
+
+
+def test_control_input_actor_type_field() -> None:
+    inp = CapitalFlowInput(
+        target_entity="GRC",
+        volume=Decimal("0.01"),
+        actor_type=ActorType.SOVEREIGN_INVESTOR,
+        source=InputSource.SCENARIO_SCRIPT,
+    )
+    assert inp.actor_type == ActorType.SOVEREIGN_INVESTOR


### PR DESCRIPTION
## Summary

- **Issue #89**: `n_runs: int = 1` on `ScenarioConfigSchema` — MC-ready without breaking change
- **Issue #31**: `duration_periods` + `decay_function` on `ControlInput` base; `ScenarioRunner.run()` expands multi-period inputs with constant/linear/exponential decay
- **Issue #33**: `ActorType` enum + `CapitalFlowInput` (FDI/portfolio/sovereign debt) + `DFICommitmentInput` (guarantee/equity/concessional/MDB)
- **Issue #36**: `DebtProfile` dataclass on `SimulationEntity`; `get_attribute("debt_profile.foreign_currency_pct")` exposes debt structure for MDA evaluation; `is_elevated_rollover_risk()` for >0.60 MDA threshold

## Test plan

- [x] 29 new unit tests in `test_g18_schema_controlinput_debt.py`
- [x] 1006 total tests pass
- [x] `ruff check .` clean
- [x] `mypy app/` clean (51 source files)

## ADRs Affected

- ADR-002 (Input Orchestration Layer) — new ControlInput subclasses and base field extensions
- ADR-001 (Core Data Model) — `DebtProfile` + `debt_profile` on `SimulationEntity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)