### PR TITLE
feat(simulation): G20 — horizon degradation envelope, fidelity artifact, restore endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,15 @@ jobs:
           cd backend
           pytest -m backtesting --tb=short -v
 
+      - name: Upload fidelity report artifacts (Issue #154)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fidelity-reports-${{ github.run_id }}
+          path: backend/tests/backtesting/reports/
+          retention-days: 90
+          if-no-files-found: ignore
+
   # ---------------------------------------------------------------------------
   # Playwright E2E job — M4 retrospective hard gate (Issue #190)
   #

--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -55,6 +55,8 @@ from app.schemas import (
     ScenarioCreateRequest,
     ScenarioDetailResponse,
     ScenarioResponse,
+    ScenarioRestoreRequest,
+    ScenarioRestoreResponse,
     ScheduledInputSchema,
     SnapshotRecord,
     TrajectoryFrameworkPoint,
@@ -1102,6 +1104,106 @@ async def delete_scenario(
         )
 
     return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# POST /scenarios/restore — Issue #155
+# ---------------------------------------------------------------------------
+
+
+@router.post("/scenarios/restore", response_model=ScenarioRestoreResponse, status_code=201)
+async def restore_scenario(
+    req: ScenarioRestoreRequest,
+    conn: Annotated[asyncpg.Connection, Depends(get_db)],
+) -> ScenarioRestoreResponse:
+    """Reconstruct a scenario from a deleted tombstone into the live scenarios table.
+
+    Creates a new scenario in 'pending' status using the tombstoned configuration
+    and scheduled_inputs. The restored scenario starts at step 0 — the caller
+    re-advances if desired. Does NOT require entity state (Issue #147 provides
+    that for full SA-11 restoration; this endpoint covers configuration restoration).
+
+    Returns 404 if tombstone_id not found.
+    Returns 409 if the engine version stored in the tombstone is incompatible
+        with the live engine and force_audit_override is not set.
+
+    Name conflict: if a scenario with the tombstone's original name already exists
+    in the scenarios table, the restored scenario is named '{name} (restored)'.
+    """
+    tombstone = await conn.fetchrow(
+        """
+        SELECT scenario_id, name, configuration, scheduled_inputs,
+               engine_version, git_commit_hash
+        FROM scenario_deleted_tombstones
+        WHERE scenario_id = $1
+        """,
+        req.tombstone_id,
+    )
+    if tombstone is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Tombstone '{req.tombstone_id}' not found.",
+        )
+
+    check_reconstruction_compatibility(
+        tombstone_engine_version=tombstone["engine_version"],
+        tombstone_git_commit_hash=tombstone["git_commit_hash"],
+    )
+
+    cfg_raw = tombstone["configuration"]
+    if isinstance(cfg_raw, str):
+        cfg_raw = json.loads(cfg_raw)
+
+    inputs_raw = tombstone["scheduled_inputs"]
+    if isinstance(inputs_raw, str):
+        inputs_raw = json.loads(inputs_raw)
+
+    # Resolve name — append "(restored)" suffix if the original name is taken.
+    original_name: str = tombstone["name"]
+    existing = await conn.fetchval(
+        "SELECT 1 FROM scenarios WHERE name = $1 LIMIT 1",
+        original_name,
+    )
+    restored_name = f"{original_name} (restored)" if existing else original_name
+
+    new_scenario_id = str(uuid.uuid4())
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO scenarios
+                (scenario_id, name, description, status,
+                 configuration, version, engine_version_hash)
+            VALUES ($1, $2, NULL, 'pending', $3, 1, $4)
+            """,
+            new_scenario_id,
+            restored_name,
+            json.dumps(cfg_raw),
+            _GIT_COMMIT_HASH,
+        )
+
+        for inp in (inputs_raw if isinstance(inputs_raw, list) else []):
+            if not isinstance(inp, dict):
+                continue
+            await conn.execute(
+                """
+                INSERT INTO scenario_scheduled_inputs
+                    (id, scenario_id, step, input_type, input_data)
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                str(uuid.uuid4()),
+                new_scenario_id,
+                int(inp.get("step", 0)),
+                str(inp.get("input_type", "")),
+                json.dumps(inp.get("input_data", {})),
+            )
+
+    return ScenarioRestoreResponse(
+        scenario_id=new_scenario_id,
+        name=restored_name,
+        status="pending",
+        restored_from_tombstone_id=req.tombstone_id,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -368,6 +368,25 @@ class ScenarioCreateRequest(BaseModel):
     scheduled_inputs: list[ScheduledInputSchema] = []
 
 
+class ScenarioRestoreRequest(BaseModel):
+    """Request body for POST /scenarios/restore (Issue #155)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    tombstone_id: str
+
+
+class ScenarioRestoreResponse(BaseModel):
+    """Response from POST /scenarios/restore."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    scenario_id: str
+    name: str
+    status: str
+    restored_from_tombstone_id: str
+
+
 class ScenarioResponse(BaseModel):
     """Scenario summary — list and create responses."""
 

--- a/backend/app/simulation/repositories/quantity_serde.py
+++ b/backend/app/simulation/repositories/quantity_serde.py
@@ -43,7 +43,11 @@ IA1_CANONICAL_PHRASE: str = (
     "MAGNITUDE_WITHIN_20PCT validation exists for at least two independent "
     "historical cases. All outputs should be interpreted as structured reasoning "
     "tools, not predictions. Verify against current data before consequential "
-    "use."
+    "use. "
+    "Horizon degradation schedule: confidence_tier degrades by +1 for every "
+    "5 projection steps beyond the baseline, capped at Tier 5. The "
+    "_steps_projected field in each snapshot state_data envelope records the "
+    "projection distance used when computing effective_tier at the output layer."
 )
 
 
@@ -75,9 +79,11 @@ _ENVELOPE_VERSION = "1"
 # ---------------------------------------------------------------------------
 
 # "2" adds _modules_active list to the top-level state_data envelope.
+# "3" adds _steps_projected int to record projection horizon at write time
+#     (Issue #151 — horizon degradation; resolves ADR-001 Amendment 1 IA-1).
 # Increment when M4+ modules add structural fields that change snapshot
 # interpretation. See ARCH-REVIEW-003 BI3-I-02 and Issue #145.
-STATE_DATA_ENVELOPE_VERSION = "2"
+STATE_DATA_ENVELOPE_VERSION = "3"
 
 
 def quantity_to_jsonb_envelope(q: Quantity) -> dict[str, Any]:

--- a/backend/app/simulation/repositories/snapshot_repository.py
+++ b/backend/app/simulation/repositories/snapshot_repository.py
@@ -66,7 +66,9 @@ class ScenarioSnapshotRepository:
         Args:
             conn: asyncpg connection. Not closed by this method.
             scenario_id: FK to scenarios.scenario_id.
-            step: Step index (0 = initial state).
+            step: Step index (0 = initial state). Used as steps_projected in
+                the state_data envelope — the output layer reads this to apply
+                effective_tier horizon degradation (Issue #151, ADR-001 IA-1).
             timestep: Simulation time for this step.
             state: Full SimulationState at this step.
             modules_active: Names of domain modules that contributed to this
@@ -77,7 +79,7 @@ class ScenarioSnapshotRepository:
         """
         disclosure = IA1_CANONICAL_PHRASE
         validate_ia1_disclosure(disclosure)
-        state_data = _serialize_state(state, modules_active or [])
+        state_data = _serialize_state(state, modules_active or [], steps_projected=step)
         events_json = json.dumps(events_snapshot) if events_snapshot is not None else None
 
         await conn.execute(
@@ -105,12 +107,16 @@ class ScenarioSnapshotRepository:
 def _serialize_state(
     state: SimulationState,
     modules_active: list[str],
+    steps_projected: int = 0,
 ) -> dict[str, object]:
-    """Serialize a SimulationState to the v2 state_data JSONB envelope format.
+    """Serialize a SimulationState to the v3 state_data JSONB envelope format.
 
     Top-level keys:
-      _envelope_version — STATE_DATA_ENVELOPE_VERSION ("2")
+      _envelope_version — STATE_DATA_ENVELOPE_VERSION ("3")
       _modules_active   — list of domain module names that contributed
+      _steps_projected  — projection horizon in steps (= step index); used by
+                          the output layer to apply effective_tier horizon
+                          degradation (Issue #151, ADR-001 Amendment 1 IA-1)
       <entity_id>       — dict[attr_key → SA-09 Quantity envelope]
 
     Metadata keys use underscore prefix to distinguish them from entity IDs.
@@ -120,6 +126,7 @@ def _serialize_state(
     data: dict[str, object] = {
         "_envelope_version": STATE_DATA_ENVELOPE_VERSION,
         "_modules_active": modules_active,
+        "_steps_projected": steps_projected,
     }
     for entity_id, entity in state.entities.items():
         data[entity_id] = {

--- a/backend/tests/backtesting/fidelity_report.py
+++ b/backend/tests/backtesting/fidelity_report.py
@@ -1,13 +1,18 @@
 """Fidelity report formatter for WorldSim backtesting runs.
 
-Produces a human-readable report for CI log output. The report is printed
-regardless of pass/fail so that fidelity data appears in every CI execution
-and can be tracked across milestones.
+Produces a human-readable report for CI log output and a JSON artifact for
+cross-run fidelity tracking. The report is printed regardless of pass/fail so
+that fidelity data appears in every CI execution and can be tracked across
+milestones.
 """
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 
@@ -126,6 +131,85 @@ def format_fidelity_report(
     ]
 
     return "\n".join(lines)
+
+
+def _resolve_commit_sha() -> str:
+    """Return the current git commit SHA-1, or 'unknown' if unavailable."""
+    try:
+        result = subprocess.check_output(  # noqa: S603
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+        return result.decode().strip()
+    except Exception:  # noqa: BLE001
+        return os.environ.get("GITHUB_SHA", "unknown")
+
+
+def write_fidelity_artifact(
+    case_id: str,
+    thresholds_met: dict[str, bool],
+    engine_version: str = "0.3.0",
+    deferred_thresholds: dict[str, str] | None = None,
+    extra_results: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Write a JSON fidelity artifact for cross-run tracking (Issue #154).
+
+    Artifact format:
+      case_id       — backtesting case identifier (e.g. 'greece_2010_2012')
+      run_date      — ISO-8601 date of this CI run
+      commit_sha    — full git SHA-1 of HEAD
+      engine_version — semantic version string from _ENGINE_VERSION
+      thresholds    — list of threshold IDs checked
+      results       — list of {threshold_id, passed, note} records
+      overall       — "PASS" or "FAIL"
+
+    Written to tests/backtesting/reports/{case_id}-{date}-{sha8}.json.
+    The reports/ directory is created if it doesn't exist.
+
+    Args:
+        case_id: Short identifier for the backtesting case, used in filename
+            and artifact metadata (e.g. 'greece_2010_2012').
+        thresholds_met: Dict mapping threshold_name → bool.
+        engine_version: Semantic version of the simulation engine.
+        deferred_thresholds: Deferred (non-blocking) threshold names → status.
+        extra_results: Additional result dicts to include verbatim.
+
+    Returns:
+        Path of the written artifact file.
+    """
+    commit_sha = _resolve_commit_sha()
+    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")  # noqa: UP017
+    sha8 = commit_sha[:8] if commit_sha != "unknown" else "unknown"
+    filename = f"{case_id}-{run_date}-{sha8}.json"
+
+    reports_dir = Path(__file__).parent / "reports"
+    reports_dir.mkdir(exist_ok=True)
+    artifact_path = reports_dir / filename
+
+    all_passed = all(thresholds_met.values())
+    results: list[dict[str, Any]] = [
+        {"threshold_id": name, "passed": passed, "note": None}
+        for name, passed in sorted(thresholds_met.items())
+    ]
+    if deferred_thresholds:
+        for name, status in sorted(deferred_thresholds.items()):
+            results.append({"threshold_id": name, "passed": None, "note": f"DEFERRED: {status}"})
+    if extra_results:
+        results.extend(extra_results)
+
+    artifact: dict[str, Any] = {
+        "case_id": case_id,
+        "run_date": run_date,
+        "commit_sha": commit_sha,
+        "engine_version": engine_version,
+        "thresholds": sorted(thresholds_met.keys()),
+        "results": results,
+        "overall": "PASS" if all_passed else "FAIL",
+    }
+
+    artifact_path.write_text(json.dumps(artifact, indent=2))
+    return artifact_path
 
 
 def _extract_gdp_value(

--- a/backend/tests/backtesting/test_greece_2010_2012.py
+++ b/backend/tests/backtesting/test_greece_2010_2012.py
@@ -33,6 +33,7 @@ from tests.backtesting.fidelity_report import (
     _extract_health_expenditure_value,
     _extract_unemployment_value,
     format_fidelity_report,
+    write_fidelity_artifact,
 )
 from tests.fixtures.greece_2010_2012_actuals import (
     ACTUALS,
@@ -225,6 +226,12 @@ async def test_greece_2010_2012_direction_only_fidelity(
             deferred_thresholds=deferred_thresholds,
         )
         print(f"\n{report}")
+        artifact_path = write_fidelity_artifact(
+            case_id="greece_2010_2015",
+            thresholds_met=thresholds_met,
+            deferred_thresholds=deferred_thresholds,
+        )
+        print(f"\nFidelity artifact written: {artifact_path}")
         print(f"\nECOLOGICAL: {ECOLOGICAL_COMPOSITE_DISCLOSURE}")
 
         # Assert all thresholds pass

--- a/backend/tests/fixtures/greece_2010_2012_actuals.py
+++ b/backend/tests/fixtures/greece_2010_2012_actuals.py
@@ -60,7 +60,11 @@ IA1_DISCLOSURE: str = (
     "MAGNITUDE_WITHIN_20PCT validation exists for at least two independent "
     "historical cases. All outputs should be interpreted as structured reasoning "
     "tools, not predictions. Verify against current data before consequential "
-    "use."
+    "use. "
+    "Horizon degradation schedule: confidence_tier degrades by +1 for every "
+    "5 projection steps beyond the baseline, capped at Tier 5. The "
+    "_steps_projected field in each snapshot state_data envelope records the "
+    "projection distance used when computing effective_tier at the output layer."
 )
 
 PARAMETER_CALIBRATION_DISCLOSURE: str = (

--- a/backend/tests/unit/test_g20_horizon_degradation_restore.py
+++ b/backend/tests/unit/test_g20_horizon_degradation_restore.py
@@ -1,0 +1,627 @@
+"""Unit tests for G20: horizon degradation envelope + fidelity artifact + restore endpoint.
+
+Issues covered: #151 (_steps_projected horizon metadata), #154 (write_fidelity_artifact),
+#155 (POST /scenarios/restore).
+
+No database required — all tests exercise pure logic: schema shapes, serialization
+behaviour, artifact writing, and restore endpoint logic via mocked asyncpg connections.
+
+Coverage:
+  STATE_DATA_ENVELOPE_VERSION = "3"  (quantity_serde)
+    1.  STATE_DATA_ENVELOPE_VERSION is exactly "3".
+    2.  Version string is a digit string, not an integer.
+
+  _serialize_state / _steps_projected  (snapshot_repository)
+    3.  step=0 → _steps_projected == 0 in serialized envelope.
+    4.  step=3 → _steps_projected == 3 in serialized envelope.
+    5.  _steps_projected is an int in the serialized dict.
+    6.  _steps_projected is present alongside _modules_active and _envelope_version.
+
+  write_snapshot — _steps_projected passed through
+    7.  write_snapshot(step=2) stores _steps_projected=2 in the JSON written to DB.
+    8.  write_snapshot(step=0) stores _steps_projected=0 in the JSON written to DB.
+
+  IA1_CANONICAL_PHRASE horizon degradation extension  (quantity_serde)
+    9.  IA1_CANONICAL_PHRASE contains "Horizon degradation schedule".
+    10. IA1_CANONICAL_PHRASE contains "_steps_projected".
+    11. IA1_CANONICAL_PHRASE contains "Tier 5".
+    12. IA1_DISCLOSURE in greece fixtures equals IA1_CANONICAL_PHRASE exactly.
+
+  write_fidelity_artifact  (fidelity_report)
+    13. Artifact file is created at the correct path pattern.
+    14. Artifact JSON is valid and includes required top-level keys.
+    15. overall is "PASS" when all thresholds pass.
+    16. overall is "FAIL" when any threshold fails.
+    17. deferred_thresholds appear in results with passed=None.
+    18. results list includes one entry per threshold.
+    19. engine_version defaults to "0.3.0".
+    20. engine_version can be overridden.
+    21. commit_sha is a non-empty string.
+    22. run_date is a valid YYYY-MM-DD date string.
+    23. Artifact filename follows {case_id}-{date}-{sha8}.json pattern.
+
+  ScenarioRestoreRequest / ScenarioRestoreResponse  (schemas)
+    24. ScenarioRestoreRequest has tombstone_id field.
+    25. ScenarioRestoreResponse has scenario_id, name, status, restored_from_tombstone_id.
+    26. ScenarioRestoreResponse.status is always "pending" in a real restore.
+
+  restore_scenario endpoint logic  (api/scenarios)
+    27. 404 raised when tombstone_id not found.
+    28. Version match passes; restored scenario returned with status="pending".
+    29. Name conflict → restored name is "{original} (restored)".
+    30. No name conflict → restored name equals original name.
+    31. Version mismatch raises 409.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas import ScenarioRestoreRequest, ScenarioRestoreResponse
+from app.simulation.repositories.quantity_serde import (
+    IA1_CANONICAL_PHRASE,
+    STATE_DATA_ENVELOPE_VERSION,
+)
+from app.simulation.repositories.snapshot_repository import (
+    ScenarioSnapshotRepository,
+    _serialize_state,
+)
+from tests.backtesting.fidelity_report import write_fidelity_artifact
+from tests.fixtures.greece_2010_2012_actuals import IA1_DISCLOSURE
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_state() -> object:
+    """Return a SimulationState with one entity and one attribute."""
+    from app.simulation.engine.models import (  # noqa: PLC0415
+        ResolutionConfig,
+        ScenarioConfig,
+        SimulationEntity,
+        SimulationState,
+    )
+    from app.simulation.engine.quantity import Quantity, VariableType  # noqa: PLC0415
+
+    qty = Quantity(
+        value=Decimal("-0.054"),
+        unit="ratio",
+        variable_type=VariableType.RATIO,
+        confidence_tier=2,
+    )
+    entity = SimulationEntity(
+        id="GRC",
+        entity_type="country",
+        attributes={"gdp_growth": qty},
+        metadata={},
+    )
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    end = datetime(2016, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    return SimulationState(
+        timestep=ts,
+        resolution=ResolutionConfig(),
+        entities={"GRC": entity},
+        relationships=[],
+        events=[],
+        scenario_config=ScenarioConfig(
+            scenario_id="test-id",
+            name="Test",
+            description="",
+            start_date=ts,
+            end_date=end,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# STATE_DATA_ENVELOPE_VERSION = "3"
+# ---------------------------------------------------------------------------
+
+
+def test_state_data_envelope_version_is_three() -> None:
+    """Test 1: STATE_DATA_ENVELOPE_VERSION must be exactly '3'."""
+    assert STATE_DATA_ENVELOPE_VERSION == "3"
+
+
+def test_state_data_envelope_version_is_string() -> None:
+    """Test 2: version is a str digit, not an int."""
+    assert isinstance(STATE_DATA_ENVELOPE_VERSION, str)
+
+
+# ---------------------------------------------------------------------------
+# _serialize_state / _steps_projected
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_state_step0_has_steps_projected_zero() -> None:
+    """Test 3: step=0 → _steps_projected == 0."""
+    state = _make_minimal_state()
+    result = _serialize_state(state, [], steps_projected=0)  # type: ignore[arg-type]
+    assert result["_steps_projected"] == 0
+
+
+def test_serialize_state_step3_has_steps_projected_three() -> None:
+    """Test 4: step=3 → _steps_projected == 3."""
+    state = _make_minimal_state()
+    result = _serialize_state(state, [], steps_projected=3)  # type: ignore[arg-type]
+    assert result["_steps_projected"] == 3
+
+
+def test_serialize_state_steps_projected_is_int() -> None:
+    """Test 5: _steps_projected value is an int in the serialized dict."""
+    state = _make_minimal_state()
+    result = _serialize_state(state, [], steps_projected=2)  # type: ignore[arg-type]
+    assert isinstance(result["_steps_projected"], int)
+
+
+def test_serialize_state_has_all_envelope_keys() -> None:
+    """Test 6: _steps_projected is present alongside _modules_active and _envelope_version."""
+    state = _make_minimal_state()
+    result = _serialize_state(state, ["MacroeconomicModule"], steps_projected=1)  # type: ignore[arg-type]
+    assert "_envelope_version" in result
+    assert "_modules_active" in result
+    assert "_steps_projected" in result
+    assert result["_envelope_version"] == "3"
+    assert result["_modules_active"] == ["MacroeconomicModule"]
+    assert result["_steps_projected"] == 1
+
+
+# ---------------------------------------------------------------------------
+# write_snapshot — _steps_projected passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_snapshot_step2_sets_steps_projected_2() -> None:
+    """Test 7: write_snapshot(step=2) stores _steps_projected=2 in JSON."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value="INSERT 1")
+
+    state = _make_minimal_state()
+    repo = ScenarioSnapshotRepository()
+    ts = datetime(2012, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    await repo.write_snapshot(conn, "s-1", 2, ts, state)  # type: ignore[arg-type]
+
+    state_data_arg = conn.execute.call_args.args[5]
+    parsed = json.loads(state_data_arg)
+    assert parsed["_steps_projected"] == 2
+
+
+@pytest.mark.asyncio
+async def test_write_snapshot_step0_sets_steps_projected_0() -> None:
+    """Test 8: write_snapshot(step=0) stores _steps_projected=0 in JSON."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value="INSERT 1")
+
+    state = _make_minimal_state()
+    repo = ScenarioSnapshotRepository()
+    ts = datetime(2010, 1, 1, tzinfo=timezone.utc)  # noqa: UP017
+    await repo.write_snapshot(conn, "s-1", 0, ts, state)  # type: ignore[arg-type]
+
+    parsed = json.loads(conn.execute.call_args.args[5])
+    assert parsed["_steps_projected"] == 0
+
+
+# ---------------------------------------------------------------------------
+# IA1_CANONICAL_PHRASE horizon degradation extension
+# ---------------------------------------------------------------------------
+
+
+def test_ia1_canonical_phrase_contains_horizon_degradation() -> None:
+    """Test 9: IA1_CANONICAL_PHRASE contains 'Horizon degradation schedule'."""
+    assert "Horizon degradation schedule" in IA1_CANONICAL_PHRASE
+
+
+def test_ia1_canonical_phrase_contains_steps_projected() -> None:
+    """Test 10: IA1_CANONICAL_PHRASE references _steps_projected field."""
+    assert "_steps_projected" in IA1_CANONICAL_PHRASE
+
+
+def test_ia1_canonical_phrase_contains_tier_5_cap() -> None:
+    """Test 11: IA1_CANONICAL_PHRASE references Tier 5 cap."""
+    assert "Tier 5" in IA1_CANONICAL_PHRASE
+
+
+def test_ia1_disclosure_matches_canonical_phrase_exactly() -> None:
+    """Test 12: IA1_DISCLOSURE in greece fixtures equals IA1_CANONICAL_PHRASE exactly."""
+    assert IA1_DISCLOSURE == IA1_CANONICAL_PHRASE
+
+
+# ---------------------------------------------------------------------------
+# write_fidelity_artifact
+# ---------------------------------------------------------------------------
+
+
+def _run_write_artifact(
+    case_id: str = "test_case",
+    thresholds: dict[str, bool] | None = None,
+    deferred: dict[str, str] | None = None,
+    engine_version: str = "0.3.0",
+    reports_dir: Path | None = None,
+) -> tuple[Path, dict]:
+    """Helper: run write_fidelity_artifact, return (path, parsed_json)."""
+    if thresholds is None:
+        thresholds = {"threshold_a": True, "threshold_b": True}
+
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc1234567890",
+    ):
+        if reports_dir is not None:
+            with patch(
+                "tests.backtesting.fidelity_report.Path.__new__",
+                side_effect=lambda cls, *a, **kw: Path(*a, **kw),
+            ):
+                artifact_path = write_fidelity_artifact(
+                    case_id=case_id,
+                    thresholds_met=thresholds,
+                    engine_version=engine_version,
+                    deferred_thresholds=deferred,
+                )
+        else:
+            artifact_path = write_fidelity_artifact(
+                case_id=case_id,
+                thresholds_met=thresholds,
+                engine_version=engine_version,
+                deferred_thresholds=deferred,
+            )
+    return artifact_path, json.loads(artifact_path.read_text())
+
+
+def test_write_fidelity_artifact_creates_file() -> None:
+    """Test 13: artifact file is created at the expected path."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="deadbeef12345678",
+    ):
+        path = write_fidelity_artifact(
+            case_id="greece_test",
+            thresholds_met={"t1": True},
+        )
+    assert path.exists()
+    assert path.suffix == ".json"
+    path.unlink(missing_ok=True)
+
+
+def test_write_fidelity_artifact_has_required_keys() -> None:
+    """Test 14: artifact JSON includes all required top-level keys."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_keys",
+            thresholds_met={"t1": True},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    required_keys = {
+        "case_id", "run_date", "commit_sha", "engine_version",
+        "thresholds", "results", "overall",
+    }
+    assert required_keys.issubset(data.keys())
+
+
+def test_write_fidelity_artifact_overall_pass_when_all_pass() -> None:
+    """Test 15: overall is 'PASS' when all thresholds are True."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_pass",
+            thresholds_met={"t1": True, "t2": True},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert data["overall"] == "PASS"
+
+
+def test_write_fidelity_artifact_overall_fail_when_any_fails() -> None:
+    """Test 16: overall is 'FAIL' when any threshold is False."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_fail",
+            thresholds_met={"t1": True, "t2": False},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert data["overall"] == "FAIL"
+
+
+def test_write_fidelity_artifact_deferred_thresholds_in_results() -> None:
+    """Test 17: deferred thresholds appear in results with passed=None."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_deferred",
+            thresholds_met={"t1": True},
+            deferred_thresholds={"deferred_t": "FAIL — no module (Issue #87)"},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    deferred_results = [r for r in data["results"] if r["threshold_id"] == "deferred_t"]
+    assert len(deferred_results) == 1
+    assert deferred_results[0]["passed"] is None
+    assert "DEFERRED" in deferred_results[0]["note"]
+
+
+def test_write_fidelity_artifact_results_count_matches_thresholds() -> None:
+    """Test 18: results list has one entry per threshold key."""
+    thresholds = {"a": True, "b": False, "c": True}
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_count",
+            thresholds_met=thresholds,
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    blocking_results = [r for r in data["results"] if r["passed"] is not None]
+    assert len(blocking_results) == len(thresholds)
+
+
+def test_write_fidelity_artifact_default_engine_version() -> None:
+    """Test 19: engine_version defaults to '0.3.0'."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_ver_default",
+            thresholds_met={"t1": True},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert data["engine_version"] == "0.3.0"
+
+
+def test_write_fidelity_artifact_custom_engine_version() -> None:
+    """Test 20: engine_version can be overridden."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_ver_custom",
+            thresholds_met={"t1": True},
+            engine_version="1.2.3",
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert data["engine_version"] == "1.2.3"
+
+
+def test_write_fidelity_artifact_commit_sha_non_empty() -> None:
+    """Test 21: commit_sha is a non-empty string."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abcdef1234567890",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_sha",
+            thresholds_met={"t1": True},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert isinstance(data["commit_sha"], str)
+    assert len(data["commit_sha"]) > 0
+
+
+def test_write_fidelity_artifact_run_date_format() -> None:
+    """Test 22: run_date is a valid YYYY-MM-DD date string."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="abc12345",
+    ):
+        path = write_fidelity_artifact(
+            case_id="test_date",
+            thresholds_met={"t1": True},
+        )
+    data = json.loads(path.read_text())
+    path.unlink(missing_ok=True)
+    assert re.match(r"^\d{4}-\d{2}-\d{2}$", data["run_date"])
+
+
+def test_write_fidelity_artifact_filename_pattern() -> None:
+    """Test 23: filename follows {case_id}-{date}-{sha8}.json pattern."""
+    with patch(
+        "tests.backtesting.fidelity_report._resolve_commit_sha",
+        return_value="deadbeef12345678",
+    ):
+        path = write_fidelity_artifact(
+            case_id="greece_2010_2015",
+            thresholds_met={"t1": True},
+        )
+    path.unlink(missing_ok=True)
+    assert path.stem.startswith("greece_2010_2015-")
+    parts = path.stem.split("-")
+    assert len(parts) >= 3
+    sha8_part = parts[-1]
+    assert sha8_part == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# ScenarioRestoreRequest / ScenarioRestoreResponse schemas
+# ---------------------------------------------------------------------------
+
+
+def test_restore_request_has_tombstone_id_field() -> None:
+    """Test 24: ScenarioRestoreRequest has tombstone_id field."""
+    req = ScenarioRestoreRequest(tombstone_id="abc-123")
+    assert req.tombstone_id == "abc-123"
+
+
+def test_restore_response_has_all_fields() -> None:
+    """Test 25: ScenarioRestoreResponse has the four required fields."""
+    resp = ScenarioRestoreResponse(
+        scenario_id="new-id",
+        name="Greece (restored)",
+        status="pending",
+        restored_from_tombstone_id="old-id",
+    )
+    assert resp.scenario_id == "new-id"
+    assert resp.name == "Greece (restored)"
+    assert resp.status == "pending"
+    assert resp.restored_from_tombstone_id == "old-id"
+
+
+def test_restore_response_status_is_pending() -> None:
+    """Test 26: status value in a valid restore response is 'pending'."""
+    resp = ScenarioRestoreResponse(
+        scenario_id="x",
+        name="y",
+        status="pending",
+        restored_from_tombstone_id="z",
+    )
+    assert resp.status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# restore_scenario endpoint logic
+# ---------------------------------------------------------------------------
+
+
+def _make_tombstone_row(
+    *,
+    name: str = "Greece 2010",
+    engine_version: str = "0.3.0",
+    git_commit_hash: str | None = None,
+) -> dict:
+    return {
+        "scenario_id": "tombstone-id-1",
+        "name": name,
+        "configuration": json.dumps({
+            "n_steps": 3, "entities": ["GRC"],
+            "timestep_label": "annual", "initial_attributes": {},
+        }),
+        "scheduled_inputs": json.dumps([]),
+        "engine_version": engine_version,
+        "git_commit_hash": git_commit_hash,
+    }
+
+
+@pytest.mark.asyncio
+async def test_restore_scenario_404_when_tombstone_not_found() -> None:
+    """Test 27: 404 raised when tombstone_id not found."""
+    from fastapi import HTTPException  # noqa: PLC0415
+
+    from app.api.scenarios import restore_scenario  # noqa: PLC0415
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await restore_scenario(ScenarioRestoreRequest(tombstone_id="missing-id"), conn)
+
+    assert exc_info.value.status_code == 404
+    assert "missing-id" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_restore_scenario_returns_pending_scenario() -> None:
+    """Test 28: successful restore returns ScenarioRestoreResponse with status='pending'."""
+    from app.api.scenarios import _ENGINE_VERSION, restore_scenario  # noqa: PLC0415
+
+    conn = MagicMock()
+    tombstone = _make_tombstone_row(engine_version=_ENGINE_VERSION)
+    conn.fetchrow = AsyncMock(return_value=tombstone)
+    conn.fetchval = AsyncMock(return_value=None)  # no name conflict
+    conn.execute = AsyncMock(return_value="INSERT 1")
+
+    class _FakeTx:
+        async def __aenter__(self) -> _FakeTx:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+    conn.transaction = MagicMock(return_value=_FakeTx())
+
+    result = await restore_scenario(ScenarioRestoreRequest(tombstone_id="tombstone-id-1"), conn)
+
+    assert isinstance(result, ScenarioRestoreResponse)
+    assert result.status == "pending"
+    assert result.restored_from_tombstone_id == "tombstone-id-1"
+    assert result.name == "Greece 2010"
+
+
+@pytest.mark.asyncio
+async def test_restore_scenario_name_conflict_appends_restored() -> None:
+    """Test 29: when original name is taken, restored name is '{original} (restored)'."""
+    from app.api.scenarios import _ENGINE_VERSION, restore_scenario  # noqa: PLC0415
+
+    conn = MagicMock()
+    tombstone = _make_tombstone_row(name="Greece 2010", engine_version=_ENGINE_VERSION)
+    conn.fetchrow = AsyncMock(return_value=tombstone)
+    conn.fetchval = AsyncMock(return_value=1)  # name conflict exists
+    conn.execute = AsyncMock(return_value="INSERT 1")
+
+    class _FakeTx:
+        async def __aenter__(self) -> _FakeTx:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+    conn.transaction = MagicMock(return_value=_FakeTx())
+
+    result = await restore_scenario(ScenarioRestoreRequest(tombstone_id="tombstone-id-1"), conn)
+
+    assert result.name == "Greece 2010 (restored)"
+
+
+@pytest.mark.asyncio
+async def test_restore_scenario_no_conflict_uses_original_name() -> None:
+    """Test 30: when original name is not taken, restored name equals original."""
+    from app.api.scenarios import _ENGINE_VERSION, restore_scenario  # noqa: PLC0415
+
+    conn = MagicMock()
+    tombstone = _make_tombstone_row(name="Unique Name", engine_version=_ENGINE_VERSION)
+    conn.fetchrow = AsyncMock(return_value=tombstone)
+    conn.fetchval = AsyncMock(return_value=None)  # no conflict
+    conn.execute = AsyncMock(return_value="INSERT 1")
+
+    class _FakeTx:
+        async def __aenter__(self) -> _FakeTx:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+    conn.transaction = MagicMock(return_value=_FakeTx())
+
+    result = await restore_scenario(ScenarioRestoreRequest(tombstone_id="tombstone-id-1"), conn)
+
+    assert result.name == "Unique Name"
+
+
+@pytest.mark.asyncio
+async def test_restore_scenario_version_mismatch_raises_409() -> None:
+    """Test 31: version mismatch raises HTTPException 409."""
+    from fastapi import HTTPException  # noqa: PLC0415
+
+    from app.api.scenarios import restore_scenario  # noqa: PLC0415
+
+    conn = MagicMock()
+    tombstone = _make_tombstone_row(engine_version="0.1.0")  # mismatched version
+    conn.fetchrow = AsyncMock(return_value=tombstone)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await restore_scenario(ScenarioRestoreRequest(tombstone_id="tombstone-id-1"), conn)
+
+    assert exc_info.value.status_code == 409

--- a/backend/tests/unit/test_web_scenario_runner.py
+++ b/backend/tests/unit/test_web_scenario_runner.py
@@ -472,8 +472,8 @@ def test_validate_ia1_disclosure_accepts_valid_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_snapshot_state_data_has_envelope_version_2() -> None:
-    """Issue #145: top-level state_data _envelope_version must be '2'."""
+async def test_snapshot_state_data_has_envelope_version_3() -> None:
+    """Issue #151: top-level state_data _envelope_version must be '3' (adds _steps_projected)."""
     conn = MagicMock()
     conn.execute = AsyncMock(return_value="INSERT 1")
 
@@ -483,9 +483,11 @@ async def test_snapshot_state_data_has_envelope_version_2() -> None:
     await repo.write_snapshot(conn, "s-1", 0, ts, state)
 
     parsed = json.loads(conn.execute.call_args.args[5])
-    assert parsed["_envelope_version"] == "2", (
-        f"Expected state_data _envelope_version '2', got {parsed.get('_envelope_version')!r}"
+    assert parsed["_envelope_version"] == "3", (
+        f"Expected state_data _envelope_version '3', got {parsed.get('_envelope_version')!r}"
     )
+    assert "_steps_projected" in parsed, "v3 envelope must include _steps_projected"
+    assert isinstance(parsed["_steps_projected"], int)
 
 
 @pytest.mark.asyncio

--- a/docs/adr/ADR-001-simulation-core-data-model.md
+++ b/docs/adr/ADR-001-simulation-core-data-model.md
@@ -302,9 +302,13 @@ mixed-type (ARCH-4 disposition from SCR-001, approved by Engineering Lead).
 
 ### Known Limitations at Amendment Time
 
-**IA-1:** Confidence tier does not degrade with projection horizon. A 30-year
-forward projection retains the tier of its historical input. Time-horizon
-degradation is Milestone 3 scope.
+**IA-1 — RESOLVED (M11, Issue #151):** Confidence tier horizon degradation is
+implemented at the output layer via `effective_tier(source_tier, horizon_steps)`
+in `app/api/scenarios.py` and recorded in each snapshot's `_steps_projected`
+envelope field. Schedule: +1 tier per 5 projection steps, capped at Tier 5.
+`IA1_CANONICAL_PHRASE` in `quantity_serde.py` documents the schedule verbatim.
+The `_steps_projected` key was added in state_data envelope version "3"
+(`STATE_DATA_ENVELOPE_VERSION`). Closed by Issue #151 (ARCH-REVIEW-003 BI3-N-01).
 
 **CM-1:** The lower-of-two rule overstates uncertainty when inputs are
 independent and mutually corroborating. This is accepted — overstatement


### PR DESCRIPTION
## Summary

- **Issue #151** (`_steps_projected`): `STATE_DATA_ENVELOPE_VERSION` bumped to `"3"`; `_steps_projected` key added to state_data envelope at write time; `IA1_CANONICAL_PHRASE` extended with horizon degradation schedule. ADR-001 IA-1 marked RESOLVED (M11).
- **Issue #154** (fidelity artifact): `write_fidelity_artifact()` added to `fidelity_report.py`; CI backtesting job uploads `fidelity-reports-{run_id}` artifact (90-day retention).
- **Issue #155** (restore endpoint): `POST /scenarios/restore` reconstructs a deleted scenario from its tombstone into a new pending scenario; name-conflict safe; calls `check_reconstruction_compatibility()` for version gate.

## Test plan

- [ ] 31 new unit tests in `test_g20_horizon_degradation_restore.py` — 1062 total pass locally
- [ ] Updated `test_web_scenario_runner::test_snapshot_state_data_has_envelope_version_3` (was v2)
- [ ] Updated `test_backtesting_fixtures::test_ia1_disclosure_matches_canonical_phrase` (extended phrase)
- [ ] `ruff check .` passes (pre-push gate cleared)
- [ ] CI backtesting job uploads fidelity artifact on every run

🤖 Generated with [Claude Code](https://claude.com/claude-code)