### PR TITLE
docs(ux): Pillar 3 session provenance standard and component vocabulary — M11.5 (#719)

### DIFF
--- a/docs/schema/session_recording.yml
+++ b/docs/schema/session_recording.yml
@@ -130,11 +130,12 @@ artifact:
 
 # ---------------------------------------------------------------------------
 # Linkage to Pillar 3 (Session Provenance Standard)
-# When the Pillar 3 session manifest standard is established (Issue #719),
-# this schema will be extended with a manifest_id field linking the recording
-# artifact to the full session manifest. The session_id already serves as the
-# linking key — manifest_id will be added as a required field in schema
-# version 2.0 once the Pillar 3 standard is ratified.
+# The Pillar 3 session manifest standard is established at:
+#   docs/ux/usability-sessions/pillar-3-provenance.md (Issue #719, v1.0)
+# The session_id is the primary linking key connecting this artifact to the
+# session manifest, think-aloud transcript, coordinator field notes, and
+# findings document. No new field is required — the session_id already serves
+# as the primary key and this schema remains at version 1.0.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------

--- a/docs/ux/usability-sessions/pillar-3-provenance.md
+++ b/docs/ux/usability-sessions/pillar-3-provenance.md
@@ -1,0 +1,253 @@
+# Pillar 3 — Session Provenance Standard
+
+**Milestone 11.5 — Usability Validation and Experience Audit**
+
+| | |
+|---|---|
+| Authors | Data Architect Agent (§2–4), PM Agent (§1, §5) |
+| Consulted | Frontend Architect Agent (component naming), UX Designer Agent (zone classification) |
+| Status | ESTABLISHED — effective for all M11.5 sessions |
+| Issue | #719 |
+| Version | 1.0 (2026-06-04) |
+
+---
+
+## §1 — Purpose (PM Agent)
+
+A usability finding is empirical evidence. For findings to be comparable across sessions,
+versions, and agents, every session must be precisely documented at the moment it runs —
+not reconstructed afterward.
+
+This standard governs the provenance record for every Pillar 2 usability session. It
+specifies:
+
+- The session manifest schema (§2) — what is recorded and when
+- The linking protocol (§3) — how the five session artifacts are connected
+- The versioning strategy (§4) — how the standard tracks application changes
+- The manifest directory and naming convention (§5)
+
+The **semantic component vocabulary** is maintained as a companion document:
+`docs/ux/usability-sessions/vocabulary.md`
+
+Both documents must be established before any Pillar 2 session runs. This document
+establishes the standard; the vocabulary is the reference the standard names.
+
+---
+
+## §2 — Session Manifest Schema (Data Architect Agent)
+
+The session manifest is a Markdown document filled in by the coordinator before the
+session begins (static fields) and immediately after it ends (outcome fields). It is
+the human-readable provenance record — not a substitute for the machine-generated
+interaction trace, but the document that makes the trace interpretable six months
+from now by an agent who was not present.
+
+### 2.1 Schema
+
+```yaml
+# Session manifest — Pillar 3 provenance record
+# Standard version: 1.0
+# File: docs/ux/usability-sessions/manifests/<session_id>-manifest.md
+
+session_id: "<YYYY-MM-DD-persona-N-NNN>"
+manifest_version: "1.0"
+
+## Application state
+
+app_version: "<e.g. v0.11.0>"
+git_commit: "<8-char SHA — from git rev-parse --short HEAD>"
+active_modules:
+  - "<e.g. EcologicalModule>"
+  - "<e.g. GovernanceModule>"
+  - "<e.g. PoliticalEconomyModule>"
+active_fixtures:
+  - "<e.g. greece_2010_2015>"
+  - "<e.g. argentina_2001_2002>"
+
+## Agent configuration
+
+agent_id: "<e.g. claude-sonnet-4-6>"
+persona_id: "<e.g. persona-2>"
+persona_name: "<e.g. Finance Ministry Negotiator — Eleni Papadopoulos>"
+canonical_use_case: "<e.g. IMF loan evaluation>"
+task_prompt_version: "pillar-2-methodology.md §Appendix A / Persona 2 / v1.0"
+cold_start: true
+orientation_provided: "<verbatim description of any briefing given beyond the task prompt, or 'none'>"
+
+## Environmental conditions
+
+viewport_width: <integer — CSS pixels>
+viewport_height: <integer — CSS pixels>
+browser: "<user agent string>"
+frontend_url: "http://localhost:5173"
+backend_url: "http://localhost:8000"
+session_url: "http://localhost:5173/?usability_session=<session_id>&persona=<persona_id>&use_case=<use_case>"
+
+## Session timing
+
+session_started_at: "<ISO8601 UTC — from rrweb artifact started_at>"
+session_ended_at: "<ISO8601 UTC — from rrweb artifact ended_at>"
+duration_ms: <integer — from rrweb artifact duration_ms>
+ended_by: "<agent | coordinator | time-limit>"
+
+## Outcome (completed after session)
+
+task_completed: <true | false | partial>
+concluded_marker_present: <true | false>
+think_aloud_markers_count:
+  LOOKING_FOR: <integer>
+  EXPECTED: <integer>
+  FOUND: <integer>
+  CONFUSED: <integer>
+  GAVE_UP_ON: <integer>
+  TRIED: <integer>
+  CONCLUDED: <integer>
+session_valid: <true | false>
+invalidity_reason: "<if session_valid is false, state the reason>"
+
+## Artifact links
+
+interaction_trace: "backend/sessions/<session_id>.json"
+transcript: "docs/ux/usability-sessions/transcripts/<session_id>-transcript.md"
+field_notes: "docs/ux/usability-sessions/transcripts/<session_id>-field-notes.md"
+findings: "docs/ux/usability-sessions/findings/<session_id>-findings.md"
+```
+
+### 2.2 Field notes
+
+**`active_modules`** — List every module that was enabled in the running backend at
+session time. Check `backend/app/api/scenarios.py` or the scenario configuration for
+the modules instantiated. If the session used a pre-built fixture (Greece, Argentina),
+list the modules enabled in that fixture's `build_*_scenario()` function.
+
+**`git_commit`** — Run `git rev-parse --short HEAD` on the running frontend/backend
+at session time. Both should match; if they differ, record both.
+
+**`cold_start`** — Always `true` for M11.5 sessions. A session where the agent was
+given any description of WorldSim's interface, layout, or features before navigation
+began is not a valid cold-start session and must be recorded as invalid.
+
+**`ended_by`** — `agent` if the agent clicked End Session; `coordinator` if the
+coordinator clicked it after the agent emitted `[CONCLUDED: ...]`; `time-limit` if
+the 45-minute limit was reached.
+
+**`session_valid`** — A session is valid if all three conditions hold: (1) the
+interaction trace exists and is non-empty, (2) the think-aloud transcript contains
+at least one each of `[LOOKING FOR:]`, (`[FOUND:]` or `[CONFUSED:]`), and `[CONCLUDED:]`,
+(3) coordinator field notes are written. A session that fails any condition is recorded
+as invalid; it may be re-run with a new session ID.
+
+---
+
+## §3 — Linking Protocol (Data Architect Agent)
+
+The `session_id` is the primary key connecting all five session artifacts. It is
+assigned by the coordinator before the session begins and appears in every artifact's
+filename and content.
+
+### 3.1 Artifact map
+
+| Artifact | Path | Author | Created |
+|---|---|---|---|
+| Interaction trace | `backend/sessions/<session_id>.json` | Pillar 1 (rrweb) | Automatically on End Session |
+| Think-aloud transcript | `docs/ux/usability-sessions/transcripts/<session_id>-transcript.md` | Agent | During session |
+| Coordinator field notes | `docs/ux/usability-sessions/transcripts/<session_id>-field-notes.md` | Coordinator | Immediately after session |
+| Findings document | `docs/ux/usability-sessions/findings/<session_id>-findings.md` | UX Designer + PM | Within 48h of session |
+| Session manifest | `docs/ux/usability-sessions/manifests/<session_id>-manifest.md` | Coordinator | Before + immediately after session |
+
+### 3.2 Cross-reference rule
+
+Every finding in the findings document must cite its source session_id. The session_id
+appears in the finding header (see Pillar 2 methodology §8 finding format). This is the
+chain that makes a finding traceable: finding → session_id → manifest → all four other
+artifacts.
+
+A finding without a session_id citation is not a valid finding.
+
+### 3.3 Vocabulary reference
+
+Every finding that locates a failure in a specific UI component must use the canonical
+vocabulary term from `vocabulary.md`. The vocabulary term appears in the finding's
+`Component:` field. A finding that uses a non-canonical component reference (e.g.,
+"the alert panel" instead of `zone-1b / alert-row`) cannot be reliably linked to
+future sessions running against a changed component.
+
+---
+
+## §4 — Versioning Strategy (Data Architect Agent)
+
+### 4.1 This standard
+
+The standard version is recorded in every manifest (`manifest_version`). When a
+breaking change is made to the manifest schema (a required field is added, renamed,
+or removed), the standard version is bumped and the change is logged in §4.3.
+
+Additive changes (a new optional field is added) do not require a version bump but
+must be logged.
+
+### 4.2 The semantic component vocabulary
+
+The vocabulary document (`vocabulary.md`) carries its own version. Every session
+manifest records the vocabulary version in use at session time as part of the
+application state record — this is implicit in the `git_commit` field, since the
+vocabulary is versioned alongside the application. If the vocabulary version cannot
+be derived from the git commit (e.g., a manual session run outside the normal
+workflow), the coordinator records it explicitly in the `task_prompt_version` field.
+
+When a UI component is added, renamed, or removed:
+
+- **Added component** — add to vocabulary, log in §Changelog of `vocabulary.md`,
+  no version bump required
+- **Renamed component** — update vocabulary entry, mark old name as deprecated with
+  a `→` pointer to the new name, bump vocabulary minor version, log in §Changelog
+- **Removed component** — remove vocabulary entry, mark as `[REMOVED vX.Y]`, bump
+  vocabulary minor version, log in §Changelog
+
+The vocabulary update must be in the same PR as the component change. Schema drift
+between the live application and the vocabulary is a compliance violation equivalent
+to API contract drift.
+
+### 4.3 Changelog
+
+| Date | Standard version | Change |
+|---|---|---|
+| 2026-06-04 | 1.0 | Initial standard established (Issue #719) |
+
+---
+
+## §5 — Manifest Directory and Naming Convention (PM Agent)
+
+Manifests are stored at:
+
+```
+docs/ux/usability-sessions/manifests/<session_id>-manifest.md
+```
+
+The directory is created alongside this standard. Session manifests are committed to
+the repository as the session runs — they are not ephemeral notes. A manifest that
+exists only locally is not a valid provenance record.
+
+The `session_id` in the filename must exactly match the `session_id` in the Pillar 1
+rrweb artifact filename (`backend/sessions/<session_id>.json`) and the `usability_session`
+URL parameter used to initiate the session. Any mismatch between these three is a
+linking failure and must be corrected before the findings document is written.
+
+---
+
+## §6 — Relation to Pillar 1 Artifact (Data Architect Agent)
+
+The Pillar 1 session artifact (`backend/sessions/<session_id>.json`, schema version 1.0)
+already captures a subset of what this standard requires: `app_version`, `git_commit`,
+`persona_id`, `canonical_use_case`, `cold_start`, `viewport_width`, `viewport_height`,
+`user_agent`, `started_at`, `ended_at`, `duration_ms`.
+
+The session manifest does not duplicate these fields — it references the interaction
+trace artifact as the authoritative source for machine-generated fields. The manifest
+adds what the Pillar 1 artifact cannot capture: active modules, active fixtures,
+agent_id, task_prompt version, ended_by, outcome fields, and the full artifact link map.
+
+The schema comment in `docs/schema/session_recording.yml` previously anticipated a
+`manifest_id` field linking the recording to a future manifest standard. That linkage
+is now established through the `session_id` — no new field is required, and the
+recording schema remains at version 1.0. The `session_recording.yml` comment has been
+updated to reflect this resolution.

--- a/docs/ux/usability-sessions/vocabulary.md
+++ b/docs/ux/usability-sessions/vocabulary.md
@@ -1,0 +1,246 @@
+# WorldSim Semantic Component Vocabulary
+
+**Milestone 11.5 — Usability Validation and Experience Audit**
+
+| | |
+|---|---|
+| Authors | UX Designer Agent (zone/component classification), Frontend Architect Agent (element naming) |
+| Authority | Pillar 3 provenance standard (`pillar-3-provenance.md §4.2`) |
+| Status | v1.0 — effective for all M11.5 sessions |
+| Issue | #719 |
+
+---
+
+## Purpose
+
+This vocabulary is the naming system for WorldSim's interface components at three levels
+of granularity: **zone**, **component**, and **element**. Every usability finding that
+locates a failure in the interface must cite the canonical term from this document in
+its `Component:` field.
+
+A finding that references "Zone 1B" is precise enough to locate the panel but not the
+specific failure. A finding that references `zone-1b / alert-severity-badge` is precise
+enough to drive a targeted design or implementation fix.
+
+**Citing the vocabulary:** Use the format `<zone-token> / <component-token> / <element-token>`
+(omit levels that are not needed for precision). Examples:
+
+- `zone-1b` — the entire MDA Alert Panel
+- `zone-1b / alert-row` — a single alert row within the panel
+- `zone-1b / alert-row / severity-badge` — the CRITICAL/WARNING badge on a row
+
+---
+
+## Level 1 — Zones
+
+Zones are the top-level regions of the WorldSim viewport. They correspond directly to
+the zones defined in `docs/ux/information-hierarchy.md`.
+
+| Token | Display name | Location | Requires interaction to reach |
+|---|---|---|---|
+| `zone-header` | Persistent Header | Above all zones, always visible | Never |
+| `zone-1a` | Trajectory View | Zone 1, primary instrument | Never |
+| `zone-1b` | MDA Alert Panel | Zone 1, co-primary | Never |
+| `zone-1c` | PMM Widget | Zone 1, co-primary | Never |
+| `zone-1d` | Four-Framework Current Position | Zone 1, co-primary | Never |
+| `zone-2a` | Radar Chart | Zone 2 | One scroll or one click |
+| `zone-2b` | Framework Panels | Zone 2 | One scroll or one click |
+| `zone-3a` | Methodology Notes | Zone 3 | Two or more interactions |
+| `zone-3b` | Raw Indicator Tables | Zone 3 | Two or more interactions |
+| `zone-scenario-list` | Scenario List | Landing state (no scenario loaded) | Never (landing state) |
+| `zone-scenario-create` | Scenario Creation Form | Zone 2 | One click from landing |
+| `zone-entity-drawer` | Entity Detail Drawer | Slide-in drawer | Drawer open action |
+| `zone-choropleth` | Choropleth Map | Geographic context surface | Never (always visible in scenario view) |
+| `zone-control-plane` | Control Plane | Reserved — Mode 3 (not yet built) | N/A |
+| `zone-replay-viewer` | Session Replay Viewer | Shown when `?replay_session=` in URL | N/A |
+| `zone-session-banner` | Session Recording Banner | Fixed overlay, top of viewport | Never (shown when `?usability_session=` in URL) |
+
+---
+
+## Level 2 — Components
+
+Components are the distinct interactive or informational units within each zone.
+
+### zone-header
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-header / entity-selector` | Entity Selector | Dropdown or label showing the current entity name |
+| `zone-header / mode-indicator` | Mode Indicator | Replay / Simulation / Active Control label |
+
+### zone-1a — Trajectory View
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-1a / trajectory-chart` | Trajectory Chart | The Recharts ComposedChart canvas |
+| `zone-1a / step-axis` | Step Axis | The shared horizontal step axis |
+| `zone-1a / financial-curve` | Financial Composite Curve | The financial framework composite score line |
+| `zone-1a / human-dev-curve` | Human Development Curve | The human development composite score line |
+| `zone-1a / ecological-curve` | Ecological Composite Curve | The ecological composite score line |
+| `zone-1a / governance-curve` | Governance Composite Curve | The governance composite score line |
+| `zone-1a / ci-band` | Confidence Interval Band | Shaded uncertainty band around a curve |
+| `zone-1a / step-marker` | Step Event Marker | Label on step axis for a significant event |
+| `zone-1a / legend` | Chart Legend | Curve identification legend |
+| `zone-1a / attribute-selector` | Attribute Selector | Dropdown for selecting a single indicator to overlay |
+
+### zone-1b — MDA Alert Panel
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-1b / alert-list` | Alert List | The scrollable container of all active alerts |
+| `zone-1b / alert-row` | Alert Row | A single MDA alert entry |
+| `zone-1b / no-alerts-state` | No Alerts State | Empty state shown when no thresholds are breached |
+| `zone-1b / overflow-indicator` | Overflow Indicator | "+N more alerts" count when alerts exceed visible height |
+
+### zone-1b / alert-row — Alert Row Elements
+
+| Token | Display name | Description | `data-testid` |
+|---|---|---|---|
+| `zone-1b / alert-row / severity-badge` | Severity Badge | CRITICAL or WARNING label | `alert-line-1` (compact) |
+| `zone-1b / alert-row / framework-tag` | Framework Tag | financial / human\_development / ecological / governance source label | `alert-framework-source` |
+| `zone-1b / alert-row / indicator-name` | Indicator Name | The name of the breached indicator | `alert-line-1` |
+| `zone-1b / alert-row / threshold-value` | Threshold Value | The MDA floor value that was crossed | `alert-line-2` |
+| `zone-1b / alert-row / mode-text` | Mode Text | "crossed" / "is projected to cross" depending on mode | `alert-mode-text` |
+| `zone-1b / alert-row / causal-attribution` | Causal Attribution | "Caused by:" attribution line | `alert-causal-attribution` |
+| `zone-1b / alert-row / negotiation-label` | Negotiation Label | The negotiation-context framing text | `alert-negotiation-label` |
+
+### zone-1c — PMM Widget
+
+| Token | Display name | Description | `data-testid` |
+|---|---|---|---|
+| `zone-1c / pmm-label` | PMM Label | "Policy Maneuver Margin" heading | `pmm-label` |
+| `zone-1c / pmm-value` | PMM Value | The numeric PMM value (0.00–1.00) | `pmm-value` |
+| `zone-1c / pmm-direction-arrow` | Direction Arrow | Trend arrow (↑ / ↓ / →) | `pmm-direction-arrow` |
+| `zone-1c / pmm-breached-note` | Breached Note | "—" state label when all thresholds breached | `pmm-breached-note` |
+| `zone-1c / pmm-pending` | Pending State | Loading/pending state before first computation | `pmm-pending` |
+
+### zone-1d — Four-Framework Current Position
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-1d / framework-row` | Framework Row | Single row for one framework (financial / human\_development / ecological / governance) |
+| `zone-1d / framework-row / score` | Framework Score | The numeric composite score for the framework |
+| `zone-1d / framework-row / label` | Framework Label | The framework name |
+| `zone-1d / framework-row / null-indicator` | Null Score Indicator | Dashed border style when score is null/unavailable |
+| `zone-1d / ecological-boundary-note` | Ecological Boundary Note | "1.0 = boundary" sub-label on the ecological row |
+
+### zone-2a — Radar Chart
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-2a / radar-chart` | Radar Chart Canvas | The SVG radar chart |
+| `zone-2a / radar-axis` | Radar Axis | A single axis (one per framework) |
+| `zone-2a / radar-polygon` | Score Polygon | The filled polygon representing the current composite scores |
+
+### zone-2b — Framework Panels
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-2b / framework-panel` | Framework Panel | A single framework's detail panel |
+| `zone-2b / indicator-row` | Indicator Row | A single indicator within a framework panel |
+| `zone-2b / indicator-row / name` | Indicator Name | Display name of the indicator |
+| `zone-2b / indicator-row / value` | Indicator Value | Current value and unit |
+| `zone-2b / indicator-row / confidence-badge` | Confidence Badge | Tier 1–5 confidence label |
+
+### zone-3a — Methodology Notes
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-3a / methodology-note` | Methodology Note | Collapsed disclosure for a specific model limitation or synthetic data flag |
+
+### zone-3b — Raw Indicator Tables
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-3b / indicator-table` | Indicator Table | Full tabular view of all indicator values across all steps |
+
+### zone-scenario-list
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-scenario-list / scenario-card` | Scenario Card | A single scenario entry in the list |
+| `zone-scenario-list / create-btn` | Create Scenario Button | The primary action to create a new scenario |
+| `zone-scenario-list / scenario-card / name` | Scenario Name | The scenario's display name |
+| `zone-scenario-list / scenario-card / status` | Scenario Status | pending / running / complete status label |
+| `zone-scenario-list / scenario-card / entity` | Entity Label | The scenario's country/entity name |
+
+### zone-scenario-create
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-scenario-create / country-field` | Country Field | Country/entity input |
+| `zone-scenario-create / start-year-field` | Start Year Field | Scenario start year input |
+| `zone-scenario-create / steps-field` | Steps Field | Number of steps input |
+| `zone-scenario-create / module-toggle` | Module Toggle | Enable/disable toggle for a simulation module (one per module) |
+| `zone-scenario-create / submit-btn` | Submit Button | Create scenario action button |
+
+### zone-scenario-controls
+
+| Token | Display name | Description | `data-testid` |
+|---|---|---|---|
+| `zone-scenario-controls / advance-step-btn` | Advance Step Button | Runs the next simulation step | `advance-step-btn` |
+| `zone-scenario-controls / step-counter` | Step Counter | Current step / total steps display | — |
+
+### zone-session-banner
+
+| Token | Display name | Description | `data-testid` |
+|---|---|---|---|
+| `zone-session-banner / recording-indicator` | Recording Indicator | Red dot + session ID text | `session-recording-banner` |
+| `zone-session-banner / end-session-btn` | End Session Button | Stops recording and saves artifact | `end-session-btn` |
+| `zone-session-banner / save-success` | Save Success State | Green success confirmation after save | — |
+
+### zone-choropleth
+
+| Token | Display name | Description | `data-testid` |
+|---|---|---|---|
+| `zone-choropleth / map-canvas` | Map Canvas | The choropleth SVG map | `choropleth-map` |
+| `zone-choropleth / entity-highlight` | Entity Highlight | The highlighted region for the active entity | — |
+
+### zone-entity-drawer
+
+| Token | Display name | Description |
+|---|---|---|
+| `zone-entity-drawer / drawer-panel` | Drawer Panel | The slide-in detail panel |
+| `zone-entity-drawer / close-btn` | Close Button | Closes the drawer |
+
+---
+
+## Level 3 — Elements
+
+Level 3 elements are listed inline within the component tables above (see the element
+rows under `zone-1b / alert-row` and `zone-1d / framework-row`). For zones where no
+element-level vocabulary exists yet, add entries here as findings require the precision.
+
+---
+
+## Vocabulary Usage in Findings
+
+When writing a finding, use the most precise vocabulary level that is needed to locate
+the failure. If the failure is visible anywhere within Zone 1B, cite `zone-1b`. If the
+failure is specific to the severity badge on a single alert row, cite
+`zone-1b / alert-row / severity-badge`.
+
+**Preferred form:**
+```
+Component: zone-1b / alert-row / severity-badge
+```
+
+**Acceptable for zone-level findings:**
+```
+Component: zone-1b
+```
+
+**Not acceptable (non-canonical):**
+```
+Component: the red badge in the alerts section
+Component: the alert panel
+Component: Zone 1B alert severity
+```
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0 | 2026-06-04 | Initial vocabulary established for M11.5 (Issue #719). Covers all components present in v0.11.0 / PR #724 baseline. |


### PR DESCRIPTION
## Summary

- **`pillar-3-provenance.md`** (DA Agent + PM Agent) — Session manifest schema covering all four North Star categories: application state (version, git commit, active modules, active fixtures), agent configuration (agent_id, persona, canonical use case, task prompt version, cold_start flag), environmental conditions (viewport, browser, URLs), session timing and outcome fields. Linking protocol: `session_id` connects all five artifacts; cross-reference rule for findings; vocabulary citation rule. Versioning strategy: manifest version recorded per session; vocabulary tracked via same-PR rule with ADDED/RENAMED/REMOVED change types.
- **`vocabulary.md`** (UX Designer + FA Agent) — Three-level semantic naming system (zone → component → element) for all current WorldSim UI components. 16 zone tokens; component and element tables for every zone including `data-testid` cross-references where applicable. Usage rules and non-canonical reference prohibition. Changelog anchored at v1.0 / v0.11.0 baseline.
- **`docs/schema/session_recording.yml`** — Pillar 3 linkage comment updated: standard is now established; `session_id` is the linking key; recording schema remains v1.0 (no new field required).
- Creates `docs/ux/usability-sessions/manifests/` artifact directory.

## Test plan

- [ ] Both documents render correctly on GitHub (no stray headings, tables display)
- [ ] Every component currently visible in the running frontend has a vocabulary entry
- [ ] `session_recording.yml` linkage comment references the correct document path
- [ ] Manifest schema covers all four North Star categories (app state, agent config, environment, session identity)

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)