### PR TITLE
feat(ux): M11.5 Session 1 — Pillar 1 infra validation, sessions.py path fix

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-04 (M11.5 Pillar 3 complete — PR #730 merged: session provenance standard + semantic component vocabulary, closes #719; all three pre-session gates now closed — #717 ✅ #718 ✅ #719 ✅)**
+**Last updated: 2026-06-04 (M11.5 Session 1 infrastructure validation complete — PR #732 open: sessions.py path fix (parents[3]→parents[2]), Playwright session runner, four Pillar 3 artifacts for 2026-06-04-persona-2-001 (INVALID — cold-start violated; Pillar 1 end-to-end confirmed functional))**
 **Current milestone:** M11.5 — Usability Validation and Experience Audit (GitHub Milestone 14; North Star: `docs/vision/milestone-11-5-north-star.md`)
 **Previous milestone:** M11 — Engine Investigation and Political Economy (formally closed 2026-06-04, tagged v0.11.0)
 
@@ -77,7 +77,9 @@ M9 formally closed. Issue #213 (M9 Exit Checklist) closed 2026-05-24. M10 milest
 
 ## Open PRs
 
-No open PRs — board clear as of 2026-06-04 (post PR #730 merge).
+| PR | Branch | Title | Gate |
+|---|---|---|---|
+| #732 | feat/usability-session-1-infra-validation | feat(ux): M11.5 Session 1 — Pillar 1 infra validation, sessions.py path fix | Merge when CI green |
 
 ## M11 Work Streams — 2026-06-04 Sprint
 
@@ -111,6 +113,8 @@ No open PRs — board clear as of 2026-06-04 (post PR #730 merge).
 | #719 ✅ | Pillar 3 — session provenance standard and semantic component vocabulary | **Closed 2026-06-04** — PR #730 merged. `pillar-3-provenance.md`: manifest schema (app state, agent config, environment, outcome, artifact links), linking protocol (session_id primary key), versioning strategy (same-PR vocabulary update rule). `vocabulary.md`: 16 zone tokens, component + element tables for all current UI components, data-testid cross-refs, v1.0 changelog. `session_recording.yml` Pillar 3 stub resolved. `docs/ux/usability-sessions/manifests/` directory created. |
 | #720 | Milestone 11.5 Exit Checklist | Blocks milestone closure |
 
+**M11.5 Session 1 status:** INVALID infrastructure validation run complete (2026-06-04). Session ID: `2026-06-04-persona-2-001`. Pillar 1 end-to-end confirmed functional (recording banner, End Session, artifact write). Bug fixed: `backend/app/api/sessions.py` `parents[3]→parents[2]` (artifact was writing to unmounted `/sessions/` inside Docker). PR #732 open. All four Pillar 3 artifacts produced in `docs/ux/usability-sessions/`. Next: genuine cold-start Persona 2 session — ID `2026-06-04-persona-2-002`; requires fresh agent with no WorldSim context and a Greece scenario pre-loaded in the database.
+
 **M11 formally closed:** Issue #262 closed 2026-06-04, GitHub Milestone 12 (M11) closed, tagged `v0.11.0`. Compliance gate: SCAN-025 recorded, KI-002 filed (mypy Python version mismatch, pre-existing). ADR license renewals complete (ADR-001/002/005/007/008/010 → M11.5; ADR-011 license section added; ADR-009 diagram added). Socratic Agent TEST complete (in-session 2026-06-04).
 
 **Exit criterion (M11.5):** Can a finance ministry analyst with no prior WorldSim orientation use this tool to produce a finding they could cite in a negotiation?
@@ -119,6 +123,7 @@ No open PRs — board clear as of 2026-06-04 (post PR #730 merge).
 
 | PR | Title | Date |
 |---|---|---|
+| #731 | chore(state): SESSION_STATE.md — Pillar 3 merged (PR #730, closes #719); all pre-session gates closed | 2026-06-04 |
 | #730 | docs(ux): Pillar 3 session provenance standard and component vocabulary — M11.5 (closes #719) | 2026-06-04 |
 | #727 | docs(ux): Pillar 2 cold-start usability audit methodology — M11.5 (closes #718) | 2026-06-04 |
 | #724 | feat(usability): Pillar 1 rrweb session recording layer — M11.5 (closes #717) | 2026-06-04 |

--- a/backend/app/api/sessions.py
+++ b/backend/app/api/sessions.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, field_validator
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 
-_SESSIONS_DIR = Path(__file__).parents[3] / "sessions"
+_SESSIONS_DIR = Path(__file__).parents[2] / "sessions"
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 

--- a/docs/ux/usability-sessions/findings/2026-06-04-persona-2-001-findings.md
+++ b/docs/ux/usability-sessions/findings/2026-06-04-persona-2-001-findings.md
@@ -1,0 +1,81 @@
+# Findings — 2026-06-04-persona-2-001
+
+**Session ID:** 2026-06-04-persona-2-001  
+**Session valid:** NO — infrastructure validation run only; cold-start constraint violated  
+**Authors:** UX Designer Agent, PM Agent  
+**Written:** 2026-06-04  
+
+> **Note:** Because this session is invalid, no usability findings are reported here.
+> This document records the infrastructure findings produced during the validation run.
+> Usability findings for Persona 2 (Finance Ministry Negotiator) will appear in the
+> findings document for the next valid session (recommended session ID: `2026-06-04-persona-2-002`).
+
+---
+
+## Infrastructure Finding IF-001
+
+**Session:** 2026-06-04-persona-2-001  
+**Type:** Bug — Path Resolution  
+**Severity:** CRITICAL (blocked all session artifact writes before fix)  
+**Component:** `backend/app/api/sessions.py` line 22  
+**Status:** FIXED (applied before this session run)
+
+**Description:**  
+`_SESSIONS_DIR = Path(__file__).parents[3] / "sessions"` resolved to `/sessions` inside the Docker container (container root, not mounted). The `backend/sessions/` host directory was correctly mounted at `/app/sessions` inside the container, but was never written to.
+
+**Root cause:**  
+Inside the Docker container, `__file__` = `/app/app/api/sessions.py`. `parents[3]` = `/` (filesystem root). The intended path was `parents[2]` = `/app`, giving `/app/sessions` = `backend/sessions/` on the host.
+
+**Fix applied:**  
+Changed `parents[3]` to `parents[2]` in `backend/app/api/sessions.py`. Session artifacts now write correctly to `backend/sessions/<session_id>.json`.
+
+**Evidence:** First run produced no artifact file. After fix, second run produced `2026-06-04-persona-2-001.json` (131,919 bytes, 18 events).
+
+---
+
+## Infrastructure Finding IF-002
+
+**Session:** 2026-06-04-persona-2-001  
+**Type:** Environment — Stale Docker Images  
+**Severity:** HIGH (blocked valid session execution)  
+**Component:** Docker Compose stack  
+**Status:** MITIGATED (resolved manually before session)
+
+**Description:**  
+Two Docker containers were stale before this run:
+1. API container predated PR #724 (Pillar 1). Running `curl http://localhost:8000/api/v1/sessions/recording` returned 404 before rebuild.
+2. Frontend container's node_modules volume predated the rrweb install. `SessionRecordingBanner` was absent from the rendered UI before restart.
+
+**Mitigation:**  
+`docker compose build api && docker compose up -d api` rebuilt the API.  
+`docker compose restart frontend` re-ran `npm install && npm run dev`, picking up rrweb.
+
+**Recommendation:**  
+Add to the session coordinator checklist in `how-to-run-a-session.md`: before any usability session, verify stack currency with `docker compose build && docker compose up -d`. Do not assume a running stack reflects the current codebase.
+
+---
+
+## Infrastructure Confirmation IC-001
+
+**Pillar 1 end-to-end path confirmed functional:**
+
+| Component | Status | Evidence |
+|---|---|---|
+| `zone-session-banner` renders on `?usability_session=` URL param | ✓ | Playwright screenshot 01; `recording-indicator` visible |
+| `zone-session-banner / end-session-btn` visible and clickable | ✓ | Playwright report; `end-session-btn` visible at T+0:04 |
+| POST `/api/v1/sessions/recording` writes artifact | ✓ | `backend/sessions/2026-06-04-persona-2-001.json` exists, 131,919 bytes |
+| Artifact schema conforms to `docs/schema/session_recording.yml` | ✓ | All required fields present: session_id, started_at, ended_at, duration_ms, event_count, metadata, events |
+| Save success banner state | ✓ | Banner text: "Session saved: 2026-06-04-persona-2-001 Artifact written to backend/sessions/" |
+
+---
+
+## Recommendation for Next Session
+
+**Next session ID:** `2026-06-04-persona-2-002`
+
+Requirements for a valid Persona 2 session:
+1. Fresh agent context — new Claude Code invocation with no WorldSim prior context in the conversation window
+2. Greece 2010–2015 scenario pre-built in the database (provides populated instrument cluster for the agent to explore)
+3. Agent receives only the Persona 2 task prompt from `pillar-2-methodology.md §Appendix A`, the session URL, and their persona role description — no architectural context
+4. Coordinator observes silently; intervenes only if the agent becomes blocked for >5 minutes with no progress
+5. Session runs to `[CONCLUDED: ...]` marker or 45-minute time limit

--- a/docs/ux/usability-sessions/manifests/2026-06-04-persona-2-001-manifest.md
+++ b/docs/ux/usability-sessions/manifests/2026-06-04-persona-2-001-manifest.md
@@ -1,0 +1,63 @@
+```yaml
+# Session manifest — Pillar 3 provenance record
+# Standard version: 1.0
+# File: docs/ux/usability-sessions/manifests/2026-06-04-persona-2-001-manifest.md
+
+session_id: "2026-06-04-persona-2-001"
+manifest_version: "1.0"
+
+## Application state
+
+app_version: "v0.11.0"
+git_commit: "8bcd4c9"
+active_modules: []
+active_fixtures: []
+
+## Agent configuration
+
+agent_id: "claude-sonnet-4-6"
+persona_id: "persona-2"
+persona_name: "Finance Ministry Negotiator — Eleni Papadopoulos"
+canonical_use_case: "IMF loan evaluation"
+task_prompt_version: "pillar-2-methodology.md §Appendix A / Persona 2 / v1.0"
+cold_start: false
+orientation_provided: "Full WorldSim architecture and all Pillar 1/2/3 implementation context. Agent authored the session recording infrastructure, the pillar-2-methodology, the pillar-3-provenance standard, and the semantic component vocabulary in this Claude Code session. Agent has complete project context. Cold-start constraint is violated — this is an infrastructure validation run, not a genuine usability session."
+
+## Environmental conditions
+
+viewport_width: 1440
+viewport_height: 900
+browser: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/148.0.0.0 Safari/537.36"
+frontend_url: "http://localhost:5173"
+backend_url: "http://localhost:8000"
+session_url: "http://localhost:5173/?usability_session=2026-06-04-persona-2-001&persona=persona-2&use_case=IMF+loan+evaluation"
+
+## Session timing
+
+session_started_at: "2026-06-04T20:24:46.728Z"
+session_ended_at: "2026-06-04T20:24:50.880Z"
+duration_ms: 4152
+ended_by: "coordinator"
+
+## Outcome (completed after session)
+
+task_completed: false
+concluded_marker_present: false
+think_aloud_markers_count:
+  LOOKING_FOR: 0
+  EXPECTED: 0
+  FOUND: 0
+  CONFUSED: 0
+  GAVE_UP_ON: 0
+  TRIED: 0
+  CONCLUDED: 0
+session_valid: false
+invalidity_reason: "Cold-start constraint violated. Agent (coordinator) has full WorldSim implementation context from this Claude Code session — authored Pillar 1/2/3 infrastructure in this session. Session is an automated Playwright infrastructure validation run, not a genuine think-aloud usability session. No scenario was loaded; no instrument cluster was exercised; no think-aloud markers were emitted. Session establishes that Pillar 1 end-to-end infrastructure functions correctly (recording banner, End Session, artifact write to backend/sessions/). A genuine cold-start session requires a fresh agent context with no prior WorldSim knowledge."
+
+## Artifact links
+
+interaction_trace: "backend/sessions/2026-06-04-persona-2-001.json"
+transcript: "docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-transcript.md"
+field_notes: "docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-field-notes.md"
+findings: "docs/ux/usability-sessions/findings/2026-06-04-persona-2-001-findings.md"
+```

--- a/docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-field-notes.md
+++ b/docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-field-notes.md
@@ -1,0 +1,48 @@
+# Coordinator Field Notes — 2026-06-04-persona-2-001
+
+**Session ID:** 2026-06-04-persona-2-001  
+**Coordinator:** Claude Code session (agent: claude-sonnet-4-6)  
+**Written:** 2026-06-04T20:30 UTC (immediately after session)  
+
+---
+
+## Pre-session setup
+
+- Docker stack confirmed up before run: `worldsim-api` (port 8000), `worldsim-frontend` (port 5173), `worldsim-db` (port 5432)
+- Two infrastructure fixes were required before a successful run:
+  1. API container was stale (previous build predated PR #724 Pillar 1 changes). Rebuilt with `docker compose build api && docker compose up -d api`.
+  2. Frontend container was missing rrweb (volume-mounted node_modules predated rrweb install). Restarted with `docker compose restart frontend`.
+  3. Sessions path bug fixed: `backend/app/api/sessions.py` line 22 `parents[3]` → `parents[2]`. Without this fix, the artifact was written to `/sessions` inside the container (unmounted), not to `backend/sessions/` on the host.
+- After all three fixes, a first run produced no artifact. A second run (this session) produced the artifact successfully.
+- Script: `frontend/scripts/run-session.cjs` — Playwright headless Chrome, 8 screenshots, automated navigation
+
+## Session observations
+
+- Recording banner appeared immediately on page load with correct session ID
+- Save success confirmation displayed after End Session click
+- Session artifact written to `backend/sessions/2026-06-04-persona-2-001.json` (131,919 bytes, 18 rrweb events)
+- Duration: 4,152 ms (very short — automated script, no human navigation)
+
+## Invalidity assessment
+
+This session does not satisfy the cold-start requirement defined in `pillar-3-provenance.md §2.2` and `pillar-2-methodology.md §2`. The agent conducting this run authored the WorldSim usability infrastructure in this Claude Code session. Cold-start requires a fresh agent with no prior WorldSim knowledge.
+
+Additionally, no scenario was loaded during the session — the instrument cluster was never exercised.
+
+**Session validity:** INVALID  
+**Reason:** Cold-start constraint violated; no scenario exercised; automated walkthrough only.
+
+## Infrastructure status after session
+
+All three Pillar 1 end-to-end components confirmed functional:
+- Frontend recording hook (`useSessionRecording`) ✓
+- Session Recording Banner component ✓  
+- Backend sessions router (POST/GET endpoints) ✓
+
+## What's needed next
+
+A genuine Persona 2 session requires:
+1. Fresh agent context (new Claude Code session, no WorldSim context)
+2. A scenario pre-loaded in the database (Greece 2010–2015 fixture recommended)
+3. Coordinator silence during session
+4. Session ID: `2026-06-04-persona-2-002` (sequence 002 since 001 is invalid)

--- a/docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-transcript.md
+++ b/docs/ux/usability-sessions/transcripts/2026-06-04-persona-2-001-transcript.md
@@ -1,0 +1,78 @@
+# Session Transcript — 2026-06-04-persona-2-001
+
+**Session ID:** 2026-06-04-persona-2-001  
+**Persona:** Finance Ministry Negotiator — Eleni Papadopoulos (persona-2)  
+**Use case:** IMF loan evaluation  
+**Session type:** Infrastructure validation (automated Playwright walkthrough)  
+**Session valid:** NO — cold-start constraint violated; see manifest invalidity_reason  
+**Duration:** 4,152 ms  
+
+---
+
+## Infrastructure Validation Walkthrough Narration
+
+*This transcript documents an automated Playwright walkthrough of the WorldSim interface conducted by the session coordinator. It is not a genuine think-aloud session — no cold-start condition was met and no human or fresh-agent was present. Narration below reconstructs what a Persona 2 user would observe at each stage of the walkthrough. Think-aloud markers are NOT present because this is not a valid session.*
+
+---
+
+**[T+0:01] Landing page — zone-scenario-list**
+
+The Playwright browser navigated to the session URL with `?usability_session=2026-06-04-persona-2-001&persona=persona-2&use_case=IMF+loan+evaluation`. 
+
+The `zone-session-banner` was immediately visible: a red recording indicator dot with the session ID text, and an "End Session" button at the right. The session recording infrastructure (Pillar 1) activated correctly on URL parameter detection.
+
+The scenario list zone (`zone-scenario-list`) was rendered in the landing state. No scenarios existed in the database. The instrument cluster (`zone-1a`, `zone-1b`, `zone-1c`, `zone-1d`) was not visible — correct, as no scenario is loaded.
+
+**[T+0:02] Instrument cluster check**
+
+The script checked visibility of:
+- `zone-1a / trajectory-chart`: not visible (no scenario loaded — expected)
+- `zone-1b / alert-list`: not visible (no scenario loaded — expected)
+- `zone-1c / pmm-value`: not visible (no scenario loaded — expected)
+- `zone-1d / framework-row`: not visible (no scenario loaded — expected)
+- `zone-scenario-controls / advance-step-btn`: not visible (no scenario loaded — expected)
+
+All absences are expected given the no-scenario landing state.
+
+**[T+0:03] Zone 2 scroll**
+
+The script scrolled toward Zone 2. No Zone 2 content was visible because no scenario was loaded.
+
+**[T+0:04] Final Zone 1 state**
+
+`zone-session-banner / end-session-btn` was visible: `true`. The End Session button was present and accessible.
+
+**[T+0:07] End Session**
+
+The script clicked `zone-session-banner / end-session-btn`. The banner text changed to:  
+`"● Session saved: 2026-06-04-persona-2-001  Artifact written to backend/sessions/ —"`
+
+The save success state was confirmed.
+
+---
+
+## Infrastructure Findings (non-finding — validation only)
+
+The Pillar 1 end-to-end path is functional:
+
+1. Recording banner activates on `?usability_session=` URL parameter ✓
+2. `zone-session-banner / recording-indicator` displays session ID ✓  
+3. `zone-session-banner / end-session-btn` is visible and clickable ✓
+4. POST `/api/v1/sessions/recording` saves artifact to `backend/sessions/` ✓
+5. Artifact schema conforms to `docs/schema/session_recording.yml` ✓
+6. Save success state displays after successful write ✓
+
+**Bug found and fixed during this run:**  
+`backend/app/api/sessions.py` line 22: `Path(__file__).parents[3]` resolved to `/` inside the Docker container (writing to unmounted `/sessions/`). Corrected to `parents[2]` which resolves to `/app/sessions` = `backend/sessions/` on the host. Fix was applied before this run.
+
+---
+
+## Limitations of This Run
+
+- No scenario was loaded or exercised
+- No instrument cluster instruments were visible or interactive
+- No genuine user navigation occurred
+- No think-aloud protocol was followed
+- This run cannot produce usability findings
+
+Genuine usability findings for Persona 2 require a fresh agent with no WorldSim context. See `docs/ux/usability-sessions/findings/2026-06-04-persona-2-001-findings.md` for infrastructure findings only.

--- a/frontend/scripts/run-session.cjs
+++ b/frontend/scripts/run-session.cjs
@@ -1,0 +1,133 @@
+/**
+ * M11.5 Pillar 2 session runner — infrastructure validation
+ * Navigates the session URL, takes screenshots at key moments, ends the session.
+ * Usage: node scripts/run-session.js <session_id>
+ */
+const { chromium } = require("playwright");
+const path = require("path");
+const fs = require("fs");
+
+const SESSION_ID = process.argv[2] || "2026-06-04-persona-2-001";
+const PERSONA = "persona-2";
+const USE_CASE = "IMF+loan+evaluation";
+const SESSION_URL = `http://localhost:5173/?usability_session=${SESSION_ID}&persona=${PERSONA}&use_case=${USE_CASE}`;
+const SCREENSHOT_DIR = path.join(__dirname, "../session-screenshots");
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+async function screenshot(page, name, label) {
+  const file = path.join(SCREENSHOT_DIR, `${SESSION_ID}-${String(name).padStart(2, "0")}-${label}.png`);
+  await page.screenshot({ path: file, fullPage: false });
+  console.log(`[screenshot] ${file}`);
+  return file;
+}
+
+async function elapsed(startMs) {
+  const s = Math.floor((Date.now() - startMs) / 1000);
+  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true, channel: "chrome" });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+
+  console.log(`\nSession: ${SESSION_ID}`);
+  console.log(`URL: ${SESSION_URL}\n`);
+
+  const startMs = Date.now();
+
+  // Step 1 — Land on session URL
+  await page.goto(SESSION_URL, { waitUntil: "networkidle", timeout: 15000 });
+  await screenshot(page, 1, "landing");
+  console.log(`[${await elapsed(startMs)}] Landing page loaded`);
+
+  // Step 2 — Check recording banner is visible
+  const banner = await page.locator('[data-testid="session-recording-banner"]').isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Recording banner visible: ${banner}`);
+
+  // Step 3 — Look at the scenario list
+  await page.waitForTimeout(1500);
+  await screenshot(page, 2, "scenario-list");
+  console.log(`[${await elapsed(startMs)}] Scenario list state captured`);
+
+  // Step 4 — Find a Greece-related scenario and click it
+  const greeceCard = page.locator("text=Greece").first();
+  const greeceVisible = await greeceCard.isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Greece scenario visible: ${greeceVisible}`);
+
+  if (greeceVisible) {
+    await greeceCard.click();
+    await page.waitForTimeout(2000);
+    await screenshot(page, 3, "after-greece-click");
+    console.log(`[${await elapsed(startMs)}] Clicked Greece scenario`);
+  }
+
+  // Step 5 — Look for instrument cluster / Zone 1A
+  const zone1a = await page.locator('[data-testid="zone-1a-trajectory"]').isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Zone 1A trajectory visible: ${zone1a}`);
+  await screenshot(page, 4, "instrument-cluster");
+
+  // Step 6 — Look for MDA alerts in Zone 1B
+  const zone1b = await page.locator('[data-testid="zone-1b-mda-alerts"]').isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Zone 1B MDA alerts visible: ${zone1b}`);
+
+  // Step 7 — Look for PMM in Zone 1C
+  const pmmValue = await page.locator('[data-testid="pmm-value"]').isVisible().catch(() => false);
+  const pmmBreached = await page.locator('[data-testid="pmm-breached-note"]').isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] PMM value visible: ${pmmValue}, breached note: ${pmmBreached}`);
+
+  // Step 8 — Look for Zone 1D framework scores
+  const zone1d = await page.locator('[data-testid="zone-1d-error"]').isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Zone 1D error state: ${zone1d}`);
+
+  // Step 9 — Try to advance a step if the button is available
+  const advanceBtn = page.locator('[data-testid="advance-step-btn"]');
+  const advanceVisible = await advanceBtn.isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] Advance step button visible: ${advanceVisible}`);
+
+  if (advanceVisible) {
+    const disabled = await advanceBtn.isDisabled().catch(() => true);
+    console.log(`[${await elapsed(startMs)}] Advance step button disabled: ${disabled}`);
+    if (!disabled) {
+      await advanceBtn.click();
+      await page.waitForTimeout(3000);
+      await screenshot(page, 5, "after-advance");
+      console.log(`[${await elapsed(startMs)}] Advanced one step`);
+    }
+  }
+
+  // Step 10 — Scroll down to look for Zone 2 content
+  await page.evaluate(() => window.scrollBy(0, 400));
+  await page.waitForTimeout(1000);
+  await screenshot(page, 6, "zone2-scroll");
+  console.log(`[${await elapsed(startMs)}] Scrolled to Zone 2`);
+
+  // Step 11 — Scroll back up, capture final Zone 1 state
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.waitForTimeout(500);
+  await screenshot(page, 7, "final-zone1-state");
+  console.log(`[${await elapsed(startMs)}] Final Zone 1 state captured`);
+
+  // Step 12 — Click End Session
+  const endBtn = page.locator('[data-testid="end-session-btn"]');
+  const endVisible = await endBtn.isVisible().catch(() => false);
+  console.log(`[${await elapsed(startMs)}] End Session button visible: ${endVisible}`);
+
+  if (endVisible) {
+    await endBtn.click();
+    await page.waitForTimeout(3000);
+    await screenshot(page, 8, "after-end-session");
+    console.log(`[${await elapsed(startMs)}] End Session clicked`);
+  }
+
+  // Step 13 — Check banner turned green
+  const bannerText = await page.locator('[data-testid="session-recording-banner"]').textContent().catch(() => "");
+  console.log(`[${await elapsed(startMs)}] Banner text after end: "${bannerText.trim().slice(0, 80)}"`);
+
+  const durationMs = Date.now() - startMs;
+  console.log(`\nSession complete. Duration: ${Math.round(durationMs / 1000)}s`);
+  console.log(`Screenshots: ${SCREENSHOT_DIR}`);
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary

- Fixes `backend/app/api/sessions.py` sessions path bug: `parents[3]` resolved to `/` inside Docker, writing artifacts to unmounted `/sessions/`. Changed to `parents[2]` (`/app/sessions` = `backend/sessions/` on host).
- Adds `frontend/scripts/run-session.cjs` — Playwright headless session runner for coordinator-operated infrastructure checks and future session replay validation.
- Produces all four Pillar 3 provenance artifacts for session `2026-06-04-persona-2-001` (manifest, think-aloud transcript, coordinator field notes, findings).

**Session verdict:** INVALID — cold-start constraint violated. The coordinator (this Claude Code session) authored the Pillar 1/2/3 infrastructure and cannot serve as a cold-start agent. Session establishes that the Pillar 1 recording stack is functional end-to-end; it produces no usability findings. Genuine Persona 2 session recommended as `2026-06-04-persona-2-002` with a fresh agent context.

## Closes

- Partially closes #716 (M11.5 — Session 1 infra validation complete; genuine cold-start sessions remain)

## Infrastructure findings

| Finding | Status |
|---|---|
| Recording banner activates on URL param | ✓ Confirmed |
| End Session button visible and functional | ✓ Confirmed |
| POST `/api/v1/sessions/recording` writes artifact | ✓ Confirmed (after path fix) |
| Artifact schema conforms to `session_recording.yml` | ✓ Confirmed |
| Save success state displays | ✓ Confirmed |

## Test plan

- [ ] Merge and confirm CI green
- [ ] Pull main; confirm `backend/sessions/` receives artifact when running session script against live stack
- [ ] Confirm the four provenance artifacts render correctly in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)