### PR TITLE
chore(roadmap): M12 kickoff — issue links added per Scope Linkage Requirement (#749–#755)

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-04 (M11.5 formally closed — Issue #720 closed, GitHub Milestone 14 closed. Exit verdict: NOT READY — EVIDENCE COMPLETE. M12 blocking issues filed: #744 #745 #746 #747. Current milestone: M12 — Active Control and External Sector.)**
+**Last updated: 2026-06-05 (M12 kickoff complete — PM Agent HORIZON sweep run. 7 untracked roadmap deliverables filed as issues (#749–#755). Roadmap updated with issue links per Scope Linkage Requirement. Full M12 issue board now tracked.)**
 **Current milestone:** M12 — Active Control and External Sector (GitHub Milestone 13)
 **Previous milestone:** M11.5 — Usability Validation and Experience Audit (formally closed 2026-06-04; Issue #720 closed; GitHub Milestone 14 closed)
 
@@ -102,15 +102,28 @@ No open PRs — board clear as of 2026-06-04 (post PR #742 merge).
 
 ## Open Issues — M12 (Active Control and External Sector)
 
-**GitHub Milestone:** 13 | **M11.5 blocking gaps now in M12 scope:**
+**GitHub Milestone:** 13 | **HORIZON sweep:** 2026-06-05 (milestone creation ceremony)
 
-| Issue | Title | Source |
-|---|---|---|
-| #744 | feat(ux): persistent scenario identity header | M11.5 GAP-02 — universal (all 3 Priority A sessions) |
-| #745 | feat(ux): MDA alert panel interactive | M11.5 GAP-01 — 2 of 3 Priority A sessions |
-| #746 | feat(ux): Mode 2 fiscal multiplier parameter input | M11.5 GAP-03 — P1 NOT MET |
-| #747 | feat(ux): Zone 1 cohort disaggregation | M11.5 GAP-04 — 2 of 3 Priority A sessions |
-| #263 | Milestone 12 Exit Checklist | Blocks M12 closure |
+| Issue | Title | Source | horizon |
+|---|---|---|---|
+| #744 | feat(ux): persistent scenario identity header | M11.5 GAP-02 — universal | immediate |
+| #745 | feat(ux): MDA alert panel interactive | M11.5 GAP-01 — 2 of 3 sessions | immediate |
+| #746 | feat(ux): Mode 2 fiscal multiplier parameter input | M11.5 GAP-03 — P1 NOT MET | immediate |
+| #747 | feat(ux): Zone 1 cohort disaggregation | M11.5 GAP-04 — 2 of 3 sessions | immediate |
+| #749 | feat(engine): matrix engine production migration | M12 roadmap §Matrix engine migration | immediate |
+| #750 | docs(arch): cloud compute path scoping | M12 roadmap §Matrix engine migration | immediate |
+| #751 | feat(engine): bilateral trade shock input type | M12 roadmap §External sector module | immediate |
+| #752 | feat(engine): commodity price shock global parameter | M12 roadmap §External sector module | immediate |
+| #753 | feat(frontend): Mode 3 Active Control | M12 roadmap §Mode 3 active control | immediate |
+| #754 | feat(engine): multi-country scenario configuration | M12 roadmap §Mode 3 active control | immediate |
+| #755 | docs(demo): Demo 4 preparation | M12 roadmap §Demo — compliance gate | immediate |
+| #394 | platform: multi-scenario comparison (>2 scenarios) | M12 roadmap §External sector module | near-term |
+| #263 | Milestone 12 Exit Checklist | Blocks M12 closure | immediate |
+
+**HORIZON sweep findings requiring EL action:**
+- Formally acknowledge #744–#747 as scope additions to M12 (from M11.5 findings, not in original roadmap)
+- #725 (mypy pin) and #644 (ESLint audit) on M12 board but not M12 scope — recommend moving off milestone
+- Near-miss registry filing pattern (NM entries written outside PI Agent role) — clarify delegation or amend file ownership table
 
 ---
 

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -172,19 +172,25 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 **What ships:**
 
 *Matrix engine migration:*
-- Production migration — iterative engine retired after Phase 2 equivalence confirmed across full backtesting suite
-- Cloud compute path scoped — infrastructure design documented, pricing model proposed for high-resolution institutional use cases
+- Production migration — iterative engine retired after Phase 2 equivalence confirmed across full backtesting suite → Issue #749 (horizon:immediate)
+- Cloud compute path scoped — infrastructure design documented, pricing model proposed for high-resolution institutional use cases → Issue #750 (horizon:immediate)
 
 *External sector module:*
-- Bilateral trade shock as standard scheduled input type — enables Canadian steel tariff scenarios and similar trade policy cases
-- Commodity price shock as global parameter propagating through relationship graph — enables Hormuz closure, multi-country cascade scenarios
-- Multi-scenario comparison lifted beyond two-scenario limit — enables Kenya budget planning with three competing proposals
+- Bilateral trade shock as standard scheduled input type — enables Canadian steel tariff scenarios and similar trade policy cases → Issue #751 (horizon:immediate)
+- Commodity price shock as global parameter propagating through relationship graph — enables Hormuz closure, multi-country cascade scenarios → Issue #752 (horizon:immediate)
+- Multi-scenario comparison lifted beyond two-scenario limit — enables Kenya budget planning with three competing proposals → Issue #394 (horizon:near-term)
 
 *Mode 3 active control:*
-- Policy instrument inputs with live trajectory response and automatic A/B comparison
-- Multi-country scenario configuration
+- Policy instrument inputs with live trajectory response and automatic A/B comparison → Issue #753 (horizon:immediate)
+- Multi-country scenario configuration → Issue #754 (horizon:immediate)
 
-**Demo:** Demo 4 at M12 close. A Jordanian finance ministry analyst runs a Strait of Hormuz closure scenario on a standard laptop. The democratization mission made concrete.
+*UX prerequisites (from M11.5 exit findings — added 2026-06-05):*
+- Persistent scenario identity header → Issue #744 (horizon:immediate)
+- Interactive alert panel with drill-in → Issue #745 (horizon:immediate)
+- Mode 2 fiscal multiplier parameter input → Issue #746 (horizon:immediate)
+- Zone 1 cohort disaggregation → Issue #747 (horizon:immediate)
+
+**Demo:** Demo 4 at M12 close. A Jordanian finance ministry analyst runs a Strait of Hormuz closure scenario on a standard laptop. The democratization mission made concrete. → Issue #755 (horizon:immediate)
 
 **Canonical user primarily served:** Persona 2 (Finance Ministry Negotiator) in Mode 3 active control — in a global south context rather than European.
 


### PR DESCRIPTION
## Summary

- Adds GitHub issue links to all M12 roadmap deliverables per the Scope Linkage Requirement (NM-019): "A deliverable named here without a linked issue is a visible scope gap"
- Seven previously untracked deliverables now have issues (#749–#755)
- UX prerequisites from M11.5 exit findings (#744–#747) noted as scope additions in roadmap
- SESSION_STATE.md M12 issue board updated with full tracked scope

## Issues filed (all assigned to M12, horizon:immediate)

| # | Deliverable |
|---|---|
| #749 | Matrix engine production migration |
| #750 | Cloud compute path scoping |
| #751 | Bilateral trade shock input type |
| #752 | Commodity price shock global parameter |
| #753 | Mode 3 Active Control implementation |
| #754 | Multi-country scenario configuration |
| #755 | Demo 4 preparation (compliance gate) |

## HORIZON sweep findings for EL (not blocking this PR)

- #744–#747 are scope additions — EL should formally acknowledge
- #725 and #644 on M12 board but not M12 scope — suggest moving off milestone
- NM registry filing pattern (entries written outside PI role) — delegation rule needs clarification

## Test plan

- [ ] Roadmap issue links resolve to correct issues
- [ ] All 7 new issues assigned to Milestone 12 with horizon:immediate label
- [ ] SESSION_STATE M12 board complete and consistent with issue list

🤖 Generated with [Claude Code](https://claude.com/claude-code)