### PR TITLE
process(raci): NM registry — no delegation; PI activation required before filing

### DIFF
--- a/docs/process/agent-raci.md
+++ b/docs/process/agent-raci.md
@@ -548,7 +548,7 @@ finalized — not afterward.
 | `.github/` | EL | Ar | CI/CD pipeline changes require Architect review |
 | `docs/process/agents.md` | PM | EL | Agent persona definitions; EL approves new agent additions |
 | `docs/process/agent-raci.md` | PM | EL, Ar | RACI matrix; Architect consulted when decision-type grounding changes. Any addition to or change of decision-type grounding text (rows in the RACI matrix) triggers Required C (Ar) — "addition" qualifies, not only "change." (NM-021) |
-| `docs/process/near-miss-registry.md` | PI | EL | PI files entries; EL informed of High severity entries; PM informed of all entries (I) |
+| `docs/process/near-miss-registry.md` | PI | EL | PI files entries; EL informed of High severity entries; PM informed of all entries (I). **No delegation:** PM Agent does not have authority to file NM entries without PI Agent activation — PI Agent must be activated before any entry is written, regardless of severity. EL decision 2026-06-05. |
 | `docs/process/known-issues-registry.md` | PI | EL | PI files entries; EL informed of Medium/High severity entries; PM informed of all entries (I) |
 | `docs/schema/api_contracts.yml` | DA | Ar | Ar consulted when response shape changes (API response shape is Architect territory) |
 | `docs/schema/database.yml` | DA | Ar, QA | Ar consulted on schema shape; QA consulted on CI enforcement gates |


### PR DESCRIPTION
## Summary

Amends the file ownership table entry for `docs/process/near-miss-registry.md` to make explicit:

> PM Agent does not have authority to file NM entries without PI Agent activation — PI Agent must be activated before any entry is written, regardless of severity.

## Rationale

EL decision 2026-06-05 (option b from HORIZON sweep finding). The delegation ambiguity was identified retroactively: NM-033 in PR #736 was filed by the coordinator/PM Agent role without PI activation. The rule was not explicit in the file ownership table, so no violation was clearly committed — but the ambiguity needed resolution. EL chose the stricter interpretation: no delegation.

## What this does not do

This PR does not file the near-miss entry about the historical delegation pattern (NM-033 in PR #736 + prior occurrences). That entry must be filed by PI Agent, which requires PI activation. This PR establishes the rule; PI activation is the next step.

## Test plan

- [ ] `docs/process/agent-raci.md` file ownership row for NM registry updated with no-delegation clause and EL decision date
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)