### PR TITLE
feat(ui): G1 — scenario identity header + Zone 1A cohort disaggregation (#744, #747)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import DeltaChoropleth from "./components/DeltaChoropleth";
 import EntityDetailDrawer from "./components/EntityDetailDrawer";
 import FidelityDashboard from "./components/FidelityDashboard";
 import { ModeIndicator } from "./components/ModeIndicator";
+import { ScenarioIdentityHeader } from "./components/ScenarioIdentityHeader";
 import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
 import ScenarioControls from "./components/ScenarioControls";
 import ScenarioPanel from "./components/ScenarioPanel";
@@ -83,6 +84,8 @@ export default function App() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [fidelityOpen, setFidelityOpen] = useState(false);
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  // Primary entity for the active scenario — used by ScenarioIdentityHeader and choropleth highlight (#744)
+  const [activeEntityId, setActiveEntityId] = useState<string | null>(null);
   // Incremented on every advance — ScenarioPanel watches this to refresh the list.
   const [scenarioListVersion, setScenarioListVersion] = useState(0);
 
@@ -99,6 +102,7 @@ export default function App() {
     setSelectedScenarioSteps(totalSteps);
     setCurrentStep(null);
     setSelectedEntityId(null);
+    setActiveEntityId(null);
     writeStoredScenario({ id, name, totalSteps });
   };
 
@@ -151,9 +155,8 @@ export default function App() {
       setAttributeName(key);
   }, [setSelectedEntityId, setAttributeName]);
 
-  // When a scenario is selected, check if it's already completed and fast-forward
-  // currentStep to its final step — ScenarioControls won't emit onStepChange for
-  // a scenario that was completed before this session.
+  // When a scenario is selected: fast-forward currentStep if already completed,
+  // and extract the primary entity for the identity header + choropleth highlight (#744).
   useEffect(() => {
     if (!selectedScenarioId) return;
 
@@ -165,9 +168,12 @@ export default function App() {
         if (detail.status === "completed") {
           setCurrentStep(detail.configuration.n_steps);
         }
+        // Set primary entity for identity header and choropleth highlight
+        const primaryEntity = detail.configuration.entities?.[0] ?? null;
+        setActiveEntityId(primaryEntity);
       })
       .catch(() => {
-        // Non-fatal — currentStep stays at whatever handleSelectScenario set
+        // Non-fatal — currentStep and activeEntityId stay at previous values
       });
 
     return () => {
@@ -235,6 +241,16 @@ export default function App() {
       {fidelityOpen && <FidelityDashboard />}
 
       <main className="app-main" style={{ position: "relative" }}>
+        {/* Scenario identity header — always visible when scenario active (Issue #744, GAP-02) */}
+        {selectedScenarioId && selectedScenarioName && (
+          <ScenarioIdentityHeader
+            scenarioName={selectedScenarioName}
+            entityId={activeEntityId}
+            currentStep={currentStep}
+            totalSteps={selectedScenarioSteps}
+          />
+        )}
+
         {/* Instrument cluster — primary viewport when a scenario is active (CLAUDE.md UX commitment 1) */}
         {selectedScenarioId && (
           <div style={{ overflowX: "auto", background: "#fafafa", borderBottom: "1px solid #e8e8e8" }}>
@@ -261,6 +277,7 @@ export default function App() {
             scenarioId={selectedScenarioId}
             currentStep={currentStep}
             onEntityClick={selectedScenarioId ? handleEntityClick : undefined}
+            activeEntityId={activeEntityId}
           />
         )}
 

--- a/frontend/src/components/ChoroplethMap.tsx
+++ b/frontend/src/components/ChoroplethMap.tsx
@@ -8,6 +8,7 @@ const API_BASE = "http://localhost:8000/api/v1";
 const SOURCE_ID = "worldsim-choropleth";
 const FILL_LAYER_ID = "choropleth-fill";
 const LINE_LAYER_ID = "choropleth-line";
+const HIGHLIGHT_LAYER_ID = "choropleth-active-entity";
 const MAP_STYLE = "https://demotiles.maplibre.org/style.json";
 
 interface Props {
@@ -16,6 +17,8 @@ interface Props {
   scenarioId?: string | null;
   currentStep?: number | null;
   onEntityClick?: (entityId: string) => void;
+  /** Active scenario entity — highlighted with a distinct border (Issue #744). */
+  activeEntityId?: string | null;
 }
 
 // INTENT: Compute five breakpoints [p0, p25, p50, p75, p100] from feature
@@ -75,7 +78,7 @@ function computeSteps(features: GeoJSONFeatureCollection["features"]): number[] 
   return raw;
 }
 
-export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick }: Props) {
+export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick, activeEntityId }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -169,6 +172,20 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
           },
         });
 
+        // Active entity highlight layer — amber border on the scenario's primary country (#744)
+        if (map.getLayer(HIGHLIGHT_LAYER_ID)) map.removeLayer(HIGHLIGHT_LAYER_ID);
+        map.addLayer({
+          id: HIGHLIGHT_LAYER_ID,
+          type: "line",
+          source: SOURCE_ID,
+          filter: ["==", ["get", "entity_id"], activeEntityId ?? ""],
+          paint: {
+            "line-color": "#f59e0b",
+            "line-width": 3,
+            "line-opacity": 1,
+          },
+        });
+
         // Hover popup
         popupRef.current?.remove();
         const popup = new maplibregl.Popup({
@@ -222,6 +239,15 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
       setError(`Failed to fetch data for "${attributeName}".`);
     });
   }, [attributeName, title, scenarioId, currentStep]);
+
+  // Update active-entity highlight filter when activeEntityId changes independently
+  // of a data reload (e.g. user selects a different scenario without changing attribute).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    if (!map.getLayer(HIGHLIGHT_LAYER_ID)) return;
+    map.setFilter(HIGHLIGHT_LAYER_ID, ["==", ["get", "entity_id"], activeEntityId ?? ""]);
+  }, [activeEntityId]);
 
   return (
     <div

--- a/frontend/src/components/CohortIndicatorsPanel.tsx
+++ b/frontend/src/components/CohortIndicatorsPanel.tsx
@@ -1,0 +1,183 @@
+/**
+ * CohortIndicatorsPanel — Zone 1A human cost ledger strip.
+ *
+ * Shows the four highest-priority human development indicators below the
+ * trajectory chart. Addresses GAP-04 (M11.5): both task-oriented Priority A
+ * personas (P2 Finance Ministry Negotiator, P1 Programme Analyst) found the
+ * primary analytical question — which cohorts are affected, by how much, at
+ * which steps — unanswerable from composite scores alone.
+ *
+ * CLAUDE.md first principle: "The Human Cost Ledger is Primary." This panel
+ * fulfils that commitment at the use-case level for Zone 1.
+ *
+ * Priority indicator order matches the M12 sprint plan acceptance criteria.
+ * Indicators not present in the measurement output render as "—" without error.
+ *
+ * Implements: Issue #747, M11.5 Priority A synthesis GAP-04 (cross-session).
+ */
+import type { QuantitySchema } from "../types";
+import { getIndicatorDisplayName } from "../lib/indicatorDisplayNames";
+
+// ---------------------------------------------------------------------------
+// Cohort indicator configuration
+// ---------------------------------------------------------------------------
+
+interface IndicatorConfig {
+  key: string;
+  direction: "higher_better" | "lower_better";
+}
+
+/** Priority order matches #747 acceptance criteria. */
+const PRIORITY_INDICATORS: IndicatorConfig[] = [
+  { key: "unemployment_rate",       direction: "lower_better"  },
+  { key: "poverty_headcount_ratio", direction: "lower_better"  },
+  { key: "income_share_q1",         direction: "higher_better" },
+  { key: "access_to_healthcare",    direction: "higher_better" },
+];
+
+// ---------------------------------------------------------------------------
+// Pure functions — exported for unit tests
+// ---------------------------------------------------------------------------
+
+type Direction = "up" | "down" | null;
+
+/** Derive movement direction from current vs previous Decimal-string values. */
+export function computeDirection(
+  current: QuantitySchema | undefined,
+  prev: QuantitySchema | undefined,
+): Direction {
+  if (!current || !prev) return null;
+  const curr = parseFloat(current.value);
+  const prevVal = parseFloat(prev.value);
+  if (!isFinite(curr) || !isFinite(prevVal)) return null;
+  if (curr > prevVal) return "up";
+  if (curr < prevVal) return "down";
+  return null;
+}
+
+/** Arrow character + colour for a direction + polarity pair. */
+export function directionGlyph(
+  direction: Direction,
+  polarity: "higher_better" | "lower_better",
+): { symbol: string; color: string } | null {
+  if (direction === null) return null;
+  const isGood =
+    (direction === "up" && polarity === "higher_better") ||
+    (direction === "down" && polarity === "lower_better");
+  return {
+    symbol: direction === "up" ? "↑" : "↓",
+    color: isGood ? "#2e7d32" : "#c62828",
+  };
+}
+
+/** Format a Decimal-string value for display. */
+export function formatIndicatorValue(qty: QuantitySchema | undefined): string {
+  if (!qty) return "—";
+  const n = parseFloat(qty.value);
+  if (!isFinite(n)) return "—";
+  // Percentages: multiply by 100 when value ≤ 1 and unit suggests a fraction
+  const unit = qty.unit?.toLowerCase() ?? "";
+  if ((unit === "fraction" || unit === "ratio" || unit === "index") && n <= 1.0 && n >= 0) {
+    return `${(n * 100).toFixed(1)}%`;
+  }
+  if (n >= 1000) return n.toFixed(0);
+  return n.toFixed(2);
+}
+
+// ---------------------------------------------------------------------------
+// CohortIndicatorsPanel
+// ---------------------------------------------------------------------------
+
+interface Props {
+  /** Current step's human_development framework indicators. */
+  indicators: Record<string, QuantitySchema> | null;
+  /** Previous step's human_development framework indicators (for direction). */
+  prevIndicators: Record<string, QuantitySchema> | null;
+}
+
+export function CohortIndicatorsPanel({ indicators, prevIndicators }: Props) {
+  const hasData = indicators !== null;
+
+  return (
+    <div
+      data-testid="cohort-indicators-panel"
+      style={{
+        borderTop: "1px solid #e8e8e8",
+        padding: "6px 8px 4px",
+        background: "#fdfdfd",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 9,
+          fontWeight: 600,
+          color: "#888",
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        Human Cost Ledger
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          columnGap: 8,
+          rowGap: 3,
+        }}
+      >
+        {PRIORITY_INDICATORS.map(({ key, direction: polarity }) => {
+          const current = indicators?.[key];
+          const prev = prevIndicators?.[key];
+          const dir = computeDirection(current, prev);
+          const glyph = directionGlyph(dir, polarity);
+          const tier = current?.confidence_tier ?? null;
+          const label = getIndicatorDisplayName("human_development", key);
+          const shortLabel = label.replace(" Rate", "").replace(" Ratio", "").replace(" Headcount", "").replace("Secondary ", "");
+
+          return (
+            <div
+              key={key}
+              data-testid={`cohort-indicator-${key}`}
+              style={{ display: "flex", alignItems: "baseline", gap: 3 }}
+            >
+              <span style={{ fontSize: 10, color: "#555", flexShrink: 0, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 90 }}>
+                {shortLabel}
+              </span>
+              <span
+                data-testid={`cohort-value-${key}`}
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: hasData ? "#1a1a2e" : "#bbb",
+                  fontVariantNumeric: "tabular-nums",
+                  flexShrink: 0,
+                }}
+              >
+                {formatIndicatorValue(current)}
+              </span>
+              {glyph && (
+                <span
+                  data-testid={`cohort-direction-${key}`}
+                  style={{ fontSize: 10, color: glyph.color, fontWeight: 700, flexShrink: 0 }}
+                >
+                  {glyph.symbol}
+                </span>
+              )}
+              {tier !== null && (
+                <span
+                  data-testid={`cohort-tier-${key}`}
+                  style={{ fontSize: 8, color: "#aaa", flexShrink: 0 }}
+                >
+                  T{tier}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -36,6 +36,8 @@ interface InstrumentClusterProps {
   mdaPanel?: React.ReactNode;
   pmmWidget?: React.ReactNode;
   fourFramework?: React.ReactNode;
+  /** Human cost ledger strip rendered below Zone 1A trajectory chart (Issue #747). */
+  cohortPanel?: React.ReactNode;
   /** Entity ISO codes for multi-case Mode 1 tick format (UD-R2). */
   entityIds?: string[];
 }
@@ -44,6 +46,7 @@ export function InstrumentCluster({
   mdaPanel,
   pmmWidget,
   fourFramework,
+  cohortPanel,
   entityIds,
 }: InstrumentClusterProps) {
   const { mode } = useScenarioStepStore();
@@ -62,16 +65,17 @@ export function InstrumentCluster({
         overflow: "hidden",
       }}
     >
-      {/* Zone 1A — Trajectory View */}
+      {/* Zone 1A — Trajectory View + Human Cost Ledger strip (Issue #747) */}
       <div
         data-testid="zone-1a-trajectory-container"
-        style={{ gridColumn: 1, gridRow: 1, minWidth: layout.trajectory }}
+        style={{ gridColumn: 1, gridRow: 1, minWidth: layout.trajectory, display: "flex", flexDirection: "column" }}
       >
         <TrajectoryView
           width={layout.trajectory}
           entityIds={entityIds}
           data-testid="zone-1a-trajectory"
         />
+        {cohortPanel}
       </div>
 
       {/* Zone 1B/1C/1D — Co-primary cluster */}

--- a/frontend/src/components/ScenarioIdentityHeader.tsx
+++ b/frontend/src/components/ScenarioIdentityHeader.tsx
@@ -1,0 +1,54 @@
+/**
+ * ScenarioIdentityHeader — Zone 0 persistent scenario identity strip.
+ *
+ * Always visible in the main viewport above the instrument cluster.
+ * Addresses GAP-02 (M11.5): every Priority A cold-start session failed to
+ * confirm which scenario was loaded. A Board member citing a finding from
+ * this tool is asserting "this is data for Greece" — this element makes
+ * that assertion verifiable without coordinator guidance.
+ *
+ * Implements: Issue #744, M11.5 Priority A synthesis GAP-02 (universal).
+ */
+
+interface Props {
+  scenarioName: string;
+  entityId: string | null;
+  currentStep: number | null;
+  totalSteps: number;
+}
+
+/** Status segment displayed at the right of the identity strip. */
+export function formatStatus(currentStep: number | null, totalSteps: number): string {
+  if (currentStep === null || currentStep === 0) return "Ready";
+  if (currentStep >= totalSteps) return `Complete (${totalSteps} steps)`;
+  return `Step ${currentStep} of ${totalSteps}`;
+}
+
+export function ScenarioIdentityHeader({ scenarioName, entityId, currentStep, totalSteps }: Props) {
+  const parts: string[] = [
+    `Scenario: ${scenarioName}`,
+    entityId ? `Entity: ${entityId}` : "",
+    `Status: ${formatStatus(currentStep, totalSteps)}`,
+  ].filter(Boolean);
+
+  return (
+    <div
+      data-testid="scenario-identity-header"
+      style={{
+        background: "#1a1a2e",
+        color: "#c8cce0",
+        fontFamily: "monospace",
+        fontSize: 12,
+        padding: "5px 16px",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        letterSpacing: "0.02em",
+        borderBottom: "2px solid #2d3561",
+        flexShrink: 0,
+      }}
+    >
+      {parts.join("  /  ")}
+    </div>
+  );
+}

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -26,8 +26,10 @@ import { InstrumentCluster, LAYOUT, useViewportBreakpoint } from "./InstrumentCl
 import { MDAAlertPanelZone1B } from "./MDAAlertPanelZone1B";
 import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
 import { FourFrameworkZone1D } from "./FourFrameworkZone1D";
+import { CohortIndicatorsPanel } from "./CohortIndicatorsPanel";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 import type { TrajectoryResponse, TrajectoryFrameworkPoint, Zone1BAlert } from "../store/scenarioStepStore";
+import type { QuantitySchema } from "../types";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
@@ -191,6 +193,13 @@ export function ScenarioInstrumentCluster({
   const [trajectoryLoading, setTrajectoryLoading] = useState(false);
   const [trajectoryError, setTrajectoryError] = useState(false);
 
+  // Human development indicators for CohortIndicatorsPanel (Issue #747).
+  // Single state object ensures current→prev swap is atomic (avoids stale closure).
+  const [hdState, setHdState] = useState<{
+    current: Record<string, QuantitySchema> | null;
+    prev: Record<string, QuantitySchema> | null;
+  }>({ current: null, prev: null });
+
   // Initialise store when scenario changes
   useEffect(() => {
     store.setScenario(scenarioId, stepCount, "MODE_1");
@@ -264,9 +273,29 @@ export function ScenarioInstrumentCluster({
       .then((raw) => {
         if (cancelled || !raw) return;
         store.setMdaAlerts(parseMdaAlerts(raw));
+
+        // Extract human development indicators for cohort panel (Issue #747).
+        // indicators is Record<string, QuantitySchema | Record<string, QuantitySchema>>;
+        // only flat (non-nested) entries are QuantitySchema — nested cohort objects are skipped.
+        const hdOutput = raw.outputs["human_development"];
+        if (hdOutput) {
+          const flat: Record<string, QuantitySchema> = {};
+          for (const [k, v] of Object.entries(hdOutput.indicators)) {
+            if (
+              v !== null &&
+              typeof v === "object" &&
+              "value" in v &&
+              typeof (v as { value: unknown }).value === "string"
+            ) {
+              flat[k] = v as QuantitySchema;
+            }
+          }
+          // Atomic current→prev swap via functional updater — avoids stale closure
+          setHdState((s) => ({ prev: s.current, current: flat }));
+        }
       })
       .catch(() => {
-        // Non-fatal — Zone 1B remains in previous state
+        // Non-fatal — Zone 1B and cohort panel remain in previous state
       });
 
     return () => {
@@ -283,6 +312,12 @@ export function ScenarioInstrumentCluster({
         <FourFrameworkZone1D
           isLoading={trajectoryLoading}
           isError={trajectoryError}
+        />
+      }
+      cohortPanel={
+        <CohortIndicatorsPanel
+          indicators={hdState.current}
+          prevIndicators={hdState.prev}
         />
       }
     />

--- a/frontend/src/components/__tests__/CohortIndicatorsPanel.test.ts
+++ b/frontend/src/components/__tests__/CohortIndicatorsPanel.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Vitest: CohortIndicatorsPanel — unit tests.
+ *
+ * Covers:
+ *   #747 — Zone 1A cohort disaggregation; pure functions for direction,
+ *           glyph rendering, and value formatting
+ *
+ * These are unit tests of pure functions exported from CohortIndicatorsPanel.tsx.
+ * Playwright E2E tests covering DOM assertions live in tests/e2e/.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeDirection,
+  directionGlyph,
+  formatIndicatorValue,
+} from "../CohortIndicatorsPanel";
+import type { QuantitySchema } from "../../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function qty(value: string, unit?: string, confidence_tier?: number): QuantitySchema {
+  return {
+    value,
+    unit: unit ?? "fraction",
+    variable_type: "stock",
+    confidence_tier: confidence_tier ?? 2,
+    observation_date: null,
+    source_id: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeDirection
+// ---------------------------------------------------------------------------
+
+describe("computeDirection", () => {
+  it("returns null when current is undefined", () => {
+    expect(computeDirection(undefined, qty("0.5"))).toBeNull();
+  });
+
+  it("returns null when prev is undefined", () => {
+    expect(computeDirection(qty("0.5"), undefined)).toBeNull();
+  });
+
+  it("returns null when both are undefined", () => {
+    expect(computeDirection(undefined, undefined)).toBeNull();
+  });
+
+  it("returns 'up' when current > prev", () => {
+    expect(computeDirection(qty("0.6"), qty("0.4"))).toBe("up");
+  });
+
+  it("returns 'down' when current < prev", () => {
+    expect(computeDirection(qty("0.3"), qty("0.5"))).toBe("down");
+  });
+
+  it("returns null when current === prev", () => {
+    expect(computeDirection(qty("0.5"), qty("0.5"))).toBeNull();
+  });
+
+  it("returns null when value is non-finite", () => {
+    expect(computeDirection(qty("NaN"), qty("0.5"))).toBeNull();
+    expect(computeDirection(qty("0.5"), qty("Infinity"))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// directionGlyph
+// ---------------------------------------------------------------------------
+
+describe("directionGlyph", () => {
+  it("returns null when direction is null", () => {
+    expect(directionGlyph(null, "higher_better")).toBeNull();
+    expect(directionGlyph(null, "lower_better")).toBeNull();
+  });
+
+  it("up + higher_better → green arrow up (good)", () => {
+    const g = directionGlyph("up", "higher_better");
+    expect(g).not.toBeNull();
+    expect(g!.symbol).toBe("↑");
+    expect(g!.color).toBe("#2e7d32");
+  });
+
+  it("down + lower_better → green arrow down (good)", () => {
+    const g = directionGlyph("down", "lower_better");
+    expect(g).not.toBeNull();
+    expect(g!.symbol).toBe("↓");
+    expect(g!.color).toBe("#2e7d32");
+  });
+
+  it("up + lower_better → red arrow up (bad)", () => {
+    const g = directionGlyph("up", "lower_better");
+    expect(g).not.toBeNull();
+    expect(g!.symbol).toBe("↑");
+    expect(g!.color).toBe("#c62828");
+  });
+
+  it("down + higher_better → red arrow down (bad)", () => {
+    const g = directionGlyph("down", "higher_better");
+    expect(g).not.toBeNull();
+    expect(g!.symbol).toBe("↓");
+    expect(g!.color).toBe("#c62828");
+  });
+
+  it("good and bad states produce different colors", () => {
+    const good = directionGlyph("up", "higher_better");
+    const bad = directionGlyph("up", "lower_better");
+    expect(good!.color).not.toBe(bad!.color);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatIndicatorValue
+// ---------------------------------------------------------------------------
+
+describe("formatIndicatorValue", () => {
+  it("returns '—' for undefined", () => {
+    expect(formatIndicatorValue(undefined)).toBe("—");
+  });
+
+  it("returns '—' for non-finite value", () => {
+    expect(formatIndicatorValue(qty("NaN"))).toBe("—");
+  });
+
+  it("fraction unit ≤ 1.0 → percentage string", () => {
+    expect(formatIndicatorValue(qty("0.05", "fraction"))).toBe("5.0%");
+    expect(formatIndicatorValue(qty("0.123", "fraction"))).toBe("12.3%");
+  });
+
+  it("ratio unit ≤ 1.0 → percentage string", () => {
+    expect(formatIndicatorValue(qty("0.25", "ratio"))).toBe("25.0%");
+  });
+
+  it("index unit ≤ 1.0 → percentage string", () => {
+    expect(formatIndicatorValue(qty("0.8", "index"))).toBe("80.0%");
+  });
+
+  it("large value (≥ 1000) → no decimal places", () => {
+    expect(formatIndicatorValue(qty("12345", "count"))).toBe("12345");
+  });
+
+  it("small non-fraction value → two decimal places", () => {
+    expect(formatIndicatorValue(qty("3.14159", "count"))).toBe("3.14");
+  });
+
+  it("fraction > 1.0 is NOT converted to percentage", () => {
+    // value > 1 is not in the fraction conversion range
+    const result = formatIndicatorValue(qty("1.5", "fraction"));
+    expect(result).not.toContain("%");
+  });
+});

--- a/frontend/src/components/__tests__/ScenarioIdentityHeader.test.ts
+++ b/frontend/src/components/__tests__/ScenarioIdentityHeader.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Vitest: ScenarioIdentityHeader — unit tests.
+ *
+ * Covers:
+ *   #744 — persistent scenario identity header; formatStatus pure function
+ *
+ * These are unit tests of the pure function exported from ScenarioIdentityHeader.tsx.
+ * Playwright E2E tests covering DOM assertions live in tests/e2e/.
+ */
+import { describe, it, expect } from "vitest";
+import { formatStatus } from "../ScenarioIdentityHeader";
+
+// ---------------------------------------------------------------------------
+// formatStatus — step-to-label mapping
+// ---------------------------------------------------------------------------
+
+describe("formatStatus", () => {
+  it("null step → 'Ready'", () => {
+    expect(formatStatus(null, 3)).toBe("Ready");
+  });
+
+  it("step 0 → 'Ready'", () => {
+    expect(formatStatus(0, 3)).toBe("Ready");
+  });
+
+  it("mid-scenario step → 'Step N of M'", () => {
+    expect(formatStatus(1, 3)).toBe("Step 1 of 3");
+    expect(formatStatus(2, 3)).toBe("Step 2 of 3");
+  });
+
+  it("step equals totalSteps → 'Complete (M steps)'", () => {
+    expect(formatStatus(3, 3)).toBe("Complete (3 steps)");
+  });
+
+  it("step exceeds totalSteps → 'Complete (M steps)'", () => {
+    expect(formatStatus(5, 3)).toBe("Complete (3 steps)");
+  });
+
+  it("single-step scenario complete → 'Complete (1 steps)'", () => {
+    expect(formatStatus(1, 1)).toBe("Complete (1 steps)");
+  });
+
+  it("does not include raw null in output", () => {
+    const s = formatStatus(null, 5);
+    expect(s).not.toContain("null");
+  });
+});


### PR DESCRIPTION
## Summary

- **ScenarioIdentityHeader** (GAP-02, #744): persistent Zone 0 banner — `Scenario: [name] / Entity: [id] / Status: [Ready|Step N of M|Complete]`. Wired in App.tsx with `activeEntityId` from scenario detail response.
- **CohortIndicatorsPanel** (GAP-04, #747): Zone 1A strip below TrajectoryView; four HD indicators (`unemployment_rate`, `poverty_headcount_ratio`, `income_share_q1`, `access_to_healthcare`) with polarity-aware direction arrows, confidence tier badges, and atomic `hdState` to prevent stale-closure on current→prev swap.
- **ChoroplethMap** (#744): amber highlight layer on active scenario entity; filter updated via dedicated `useEffect` on `activeEntityId` changes without full data reload.
- 28 unit tests covering all exported pure functions.

## Files changed

- `frontend/src/components/ScenarioIdentityHeader.tsx` (new)
- `frontend/src/components/CohortIndicatorsPanel.tsx` (new)
- `frontend/src/components/__tests__/ScenarioIdentityHeader.test.ts` (new)
- `frontend/src/components/__tests__/CohortIndicatorsPanel.test.ts` (new)
- `frontend/src/components/InstrumentCluster.tsx` (cohortPanel slot + flex column Zone 1A)
- `frontend/src/components/ScenarioInstrumentCluster.tsx` (hdState, measurement-output HD extraction, CohortIndicatorsPanel wired)
- `frontend/src/App.tsx` (ScenarioIdentityHeader, activeEntityId state, choropleth highlight prop)
- `frontend/src/components/ChoroplethMap.tsx` (HIGHLIGHT_LAYER_ID, activeEntityId prop, highlight layer + filter useEffect)

## Test plan

- [x] 28 unit tests pass (`npm run test`)
- [x] Frontend build gate passes (`npm run build`)
- [ ] E2E: `data-testid="scenario-identity-header"` visible after scenario select
- [ ] E2E: `data-testid="cohort-indicators-panel"` visible after first step advance
- [ ] E2E: cohort direction arrows appear at step 2+ with correct polarity coloring
- [ ] E2E: choropleth amber highlight on scenario primary entity

Closes #744, #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)