### PR TITLE
chore(settings): add Bash(command *) to allowedTools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,7 @@
     "Bash(python3 *)",
     "Bash(python *)",
     "Bash(source *)",
+    "Bash(command *)",
     "Bash(/opt/homebrew/bin/python3* *)",
     "Bash(/usr/local/bin/python3* *)"
   ]


### PR DESCRIPTION
Adds missing pattern from G2 approval prompt capture. Note: Write tool prompts (settings.json overwrite) cannot be pre-approved via allowedTools. 🤖 Generated with [Claude Code](https://claude.com/claude-code)