### PR TITLE
feat(g4): matrix engine production migration — retire iterative call site (#749)

### DIFF
--- a/backend/app/simulation/engine/__init__.py
+++ b/backend/app/simulation/engine/__init__.py
@@ -1,3 +1,4 @@
+from app.simulation.engine.matrix_propagation import propagate_matrix as propagate
 from app.simulation.engine.models import (
     Event,
     Geometry,
@@ -11,7 +12,6 @@ from app.simulation.engine.models import (
     SimulationModule,
     SimulationState,
 )
-from app.simulation.engine.propagation import propagate
 from app.simulation.engine.quantity import MonetaryValue, Quantity, VariableType
 
 __all__ = [

--- a/backend/app/simulation/engine/matrix_propagation.py
+++ b/backend/app/simulation/engine/matrix_propagation.py
@@ -1,9 +1,10 @@
 """
 Matrix computation engine — ADR-009 (Simulation Engine Computation Model).
 
-Implements event propagation using NumPy dense matrix operations. Runs
-ALONGSIDE the iterative engine (propagation.py) for the parallel-run phase
-mandated by ADR-009 §Decision 1. Public API is a drop-in mirror of propagate().
+Primary propagation engine as of M12 (#749). Replaces the iterative engine
+(propagation.py) after the ADR-009 §Decision 1 parallel-run phase completed
+with zero divergence across the full backtesting suite for one milestone.
+Public API is a drop-in replacement for propagate().
 
 Mathematical formulation (ADR-009 §Engine Computation Model):
   Weight matrix W (N×N float64):
@@ -70,9 +71,8 @@ _DeltaAccumulator = dict[str, dict[str, Quantity]]
 def propagate_matrix(state: SimulationState, events: list[Event]) -> SimulationState:
     """Apply events to State[T] via matrix operations, return State[T+1].
 
-    Drop-in mirror of propagation.propagate(). Both functions run in CI during
-    the ADR-009 §Decision 1 parallel phase. Output must match propagate()
-    within ADR-009 §Decision 2 tolerance (1e-10 on every Quantity.value)
+    Production propagation engine (M12, #749). Replaces propagation.propagate().
+    Output matches propagate() within ADR-009 §Decision 2 tolerance (1e-10 on every Quantity.value)
     for the equivalence gate to pass.
 
     Args:

--- a/backend/app/simulation/orchestration/runner.py
+++ b/backend/app/simulation/orchestration/runner.py
@@ -293,8 +293,6 @@ class ScenarioRunner(InputOrchestrator):
         Returns:
             State[T+1] with all deltas applied and timestep advanced.
         """
-        from app.simulation.engine.propagation import propagate
-
         all_events: list[Event] = []
 
         # Exogenous: inject scheduled inputs
@@ -329,8 +327,12 @@ class ScenarioRunner(InputOrchestrator):
                 )
             seen_event_ids.add(event.event_id)
 
-        # Propagate all events and advance the timestep
-        next_state = propagate(current_state, all_events)
+        # Propagate all events and advance the timestep.
+        # Uses propagate_matrix() — ADR-009 §Decision 1 parallel phase complete;
+        # iterative engine retired as of M12 (#749). Any unexpected failure here
+        # surfaces immediately (no silent fallback to iterative engine).
+        from app.simulation.engine.matrix_propagation import propagate_matrix  # noqa: PLC0415
+        next_state = propagate_matrix(current_state, all_events)
         return dataclasses.replace(
             next_state,
             timestep=_advance_timestep(current_state.timestep, self._timestep_delta),

--- a/backend/tests/unit/test_matrix_engine_production.py
+++ b/backend/tests/unit/test_matrix_engine_production.py
@@ -1,0 +1,204 @@
+"""
+ADR-009 §Decision 1 Production Migration — unit tests (Issue #749, G4).
+
+Verifies that:
+  - The engine package `propagate` export points to propagate_matrix (not propagate iterative)
+  - ScenarioRunner.tick() calls propagate_matrix, not propagate (iterative)
+  - A single step advance via ScenarioRunner produces valid State[T+1] (smoke test)
+  - No silent fallback — if propagate_matrix raises, the exception propagates
+
+These are structural tests that guard the migration invariant. Correctness of
+propagate_matrix itself is covered by test_equivalence_harness.py.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.engine.matrix_propagation import propagate_matrix
+from app.simulation.engine.models import (
+    ResolutionConfig,
+    ScenarioConfig,
+    SimulationEntity,
+    SimulationModule,
+    SimulationState,
+)
+from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.orchestration import AuditLog, ScenarioRunner
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_DATE = datetime(2010, 1, 1)
+_STEP_DELTA = timedelta(days=365)
+
+
+def _q(value: float) -> Quantity:
+    return Quantity(
+        value=Decimal(str(value)),
+        unit="dimensionless",
+        variable_type=VariableType.RATIO,
+    )
+
+
+def _make_state(entity_id: str = "GRC", **attrs: float) -> SimulationState:
+    return SimulationState(
+        entities={
+            entity_id: SimulationEntity(
+                id=entity_id,
+                entity_type="country",
+                attributes={k: _q(v) for k, v in attrs.items()},
+                metadata={},
+            )
+        },
+        relationships=[],
+        events=[],
+        timestep=_BASE_DATE,
+        scenario_config=ScenarioConfig(
+            scenario_id="test-g4",
+            name="G4 test",
+            description="",
+            start_date=_BASE_DATE,
+            end_date=_BASE_DATE + _STEP_DELTA * 5,
+        ),
+        resolution_config=ResolutionConfig(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Engine package `propagate` export is propagate_matrix
+# ---------------------------------------------------------------------------
+
+
+def test_engine_package_propagate_is_matrix_engine() -> None:
+    """engine.__init__.propagate must be propagate_matrix after G4 migration."""
+    from app.simulation.engine import propagate  # noqa: PLC0415
+    assert propagate is propagate_matrix, (
+        "engine.propagate is not propagate_matrix — call site was not swapped "
+        "(ADR-009 §Decision 1 production migration not complete)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. ScenarioRunner.tick() uses propagate_matrix (not iterative propagate)
+# ---------------------------------------------------------------------------
+
+
+class _NullModule(SimulationModule):
+    def compute(  # type: ignore[override]
+        self,
+        entity: SimulationEntity,
+        state: SimulationState,
+        timestep: datetime,
+    ) -> list:
+        return []
+
+    def get_subscribed_events(self) -> list[str]:
+        return []
+
+
+def test_runner_tick_uses_matrix_engine_via_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify ScenarioRunner.tick() calls propagate_matrix by patching it and confirming
+    the call is intercepted — any call to the iterative engine would produce different
+    behaviour (or no intercept)."""
+    import app.simulation.engine.matrix_propagation as matrix_mod  # noqa: PLC0415
+
+    call_count = [0]
+    original = propagate_matrix
+
+    def _spy(state: SimulationState, events: list) -> SimulationState:
+        call_count[0] += 1
+        return original(state, events)
+
+    monkeypatch.setattr(matrix_mod, "propagate_matrix", _spy)
+
+    state = _make_state(gdp_growth=0.02)
+    runner = ScenarioRunner(
+        initial_state=state,
+        session_id="test-spy",
+        timestep_delta=_STEP_DELTA,
+        audit_log=AuditLog(),
+    )
+    runner.tick(state, modules=[_NullModule()], scheduled_inputs=[])
+
+    # If runner.tick() uses propagate_matrix, the spy was called.
+    # If it used the iterative propagate instead, call_count would be 0.
+    assert call_count[0] == 1, (
+        "propagate_matrix was not called by runner.tick() — "
+        "iterative engine may still be the call site"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Smoke test — tick() produces a valid State[T+1]
+# ---------------------------------------------------------------------------
+
+
+def test_runner_tick_advances_timestep() -> None:
+    """ScenarioRunner.tick() must advance timestep by exactly one step delta."""
+    state = _make_state(gdp_growth=0.02)
+    runner = ScenarioRunner(
+        initial_state=state,
+        session_id="test-smoke",
+        timestep_delta=_STEP_DELTA,
+        audit_log=AuditLog(),
+    )
+    next_state = runner.tick(state, modules=[_NullModule()], scheduled_inputs=[])
+    expected_ts = _BASE_DATE + _STEP_DELTA
+    assert next_state.timestep == expected_ts
+
+
+def test_runner_tick_preserves_entities() -> None:
+    """State[T+1] must contain the same entities as State[T] (no entity loss)."""
+    state = _make_state("GRC", gdp_growth=0.02, unemployment_rate=0.12)
+    runner = ScenarioRunner(
+        initial_state=state,
+        session_id="test-preserve",
+        timestep_delta=_STEP_DELTA,
+        audit_log=AuditLog(),
+    )
+    next_state = runner.tick(state, modules=[_NullModule()], scheduled_inputs=[])
+    assert "GRC" in next_state.entities
+
+
+def test_runner_tick_no_event_produces_unchanged_attributes() -> None:
+    """When no events are generated, entity attributes must be unchanged at T+1."""
+    state = _make_state("GRC", gdp_growth=0.02)
+    runner = ScenarioRunner(
+        initial_state=state,
+        session_id="test-nochange",
+        timestep_delta=_STEP_DELTA,
+        audit_log=AuditLog(),
+    )
+    next_state = runner.tick(state, modules=[_NullModule()], scheduled_inputs=[])
+    grc_t1 = next_state.entities["GRC"]
+    assert grc_t1.attributes["gdp_growth"].value == Decimal("0.02")
+
+
+# ---------------------------------------------------------------------------
+# 4. No silent fallback — propagate_matrix exception propagates to caller
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_engine_exception_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A propagate_matrix failure must not be swallowed — no silent iterative fallback."""
+    import app.simulation.engine.matrix_propagation as matrix_mod  # noqa: PLC0415
+
+    def _raise(state: SimulationState, events: list) -> SimulationState:
+        raise RuntimeError("matrix engine simulated failure")
+
+    monkeypatch.setattr(matrix_mod, "propagate_matrix", _raise)
+
+    state = _make_state("GRC", gdp_growth=0.02)
+    runner = ScenarioRunner(
+        initial_state=state,
+        session_id="test-nofallback",
+        timestep_delta=_STEP_DELTA,
+        audit_log=AuditLog(),
+    )
+    # The RuntimeError must propagate — no catch-and-fallback in runner.tick()
+    with pytest.raises(RuntimeError, match="matrix engine simulated failure"):
+        runner.tick(state, modules=[_NullModule()], scheduled_inputs=[])

--- a/backend/tests/unit/test_scenario_schemas.py
+++ b/backend/tests/unit/test_scenario_schemas.py
@@ -421,6 +421,7 @@ def test_fiscal_multiplier_zero_rejected() -> None:
 def test_macroeconomic_module_default_multiplier_is_1() -> None:
     """MacroeconomicModule defaults to fiscal_multiplier_override=1.0."""
     from decimal import Decimal
+
     from app.simulation.modules.macroeconomic.module import MacroeconomicModule
     m = MacroeconomicModule()
     assert m._fiscal_multiplier_override == Decimal("1.0")
@@ -429,6 +430,7 @@ def test_macroeconomic_module_default_multiplier_is_1() -> None:
 def test_macroeconomic_module_accepts_multiplier_override() -> None:
     """MacroeconomicModule stores the override as a Decimal."""
     from decimal import Decimal
+
     from app.simulation.modules.macroeconomic.module import MacroeconomicModule
     m = MacroeconomicModule(fiscal_multiplier_override=2.0)
     assert m._fiscal_multiplier_override == Decimal("2.0")
@@ -437,8 +439,9 @@ def test_macroeconomic_module_accepts_multiplier_override() -> None:
 def test_build_active_modules_passes_fiscal_multiplier() -> None:
     """_build_active_modules creates MacroeconomicModule with correct override."""
     from decimal import Decimal
-    from app.simulation.web_scenario_runner import _build_active_modules
+
     from app.simulation.modules.macroeconomic.module import MacroeconomicModule
+    from app.simulation.web_scenario_runner import _build_active_modules
     cfg = ScenarioConfigSchema(entities=["GRC"], n_steps=3, fiscal_multiplier=1.5)
     modules = _build_active_modules(cfg)
     macro = next(m for m in modules if isinstance(m, MacroeconomicModule))

--- a/docs/adr/ADR-009-simulation-engine-computation-model.md
+++ b/docs/adr/ADR-009-simulation-engine-computation-model.md
@@ -3,19 +3,19 @@
 > **Reader Orientation:** This ADR governs the transition from the iterative propagation
 > engine to a sparse-matrix computation model. Read it before: writing any code that
 > touches the propagation engine, modifying Decimal↔float conversion boundaries, or
-> designing any Monte Carlo or backtesting integration with engine outputs. The iterative
-> engine must not be retired until the Phase 2 equivalence gate in §Decision 2 passes.
+> designing any Monte Carlo or backtesting integration with engine outputs. The matrix
+> engine is now in production (M12, #749) — the iterative engine is retired.
 > ADR-008 (viewport) and ADR-010 (trajectory view) are downstream consumers of engine
 > outputs — changes to the output schema require reviewing those ADRs' renewal triggers.
 
 ## Status
-Accepted
+IMPLEMENTED
 
 ## Validity Context
 
-**Standards Version:** 2026-06-03
-**Valid Until:** Milestone 12 — Active Control and External Sector
-**License Status:** CURRENT — Accepted 2026-06-03
+**Standards Version:** 2026-06-05
+**Valid Until:** See Renewal Triggers below
+**License Status:** CURRENT — Implemented 2026-06-05 (PR #769, M12 G4)
 
 **Diagram:** `docs/architecture/ADR-009-engine-computation-model.mmd` (added M11 exit, SCAN-025).
 
@@ -332,3 +332,39 @@ flowchart LR
 - Iterative engine source: `backend/app/simulation/engine/propagation.py`
 - Issue #217 — ADR-009 authoring and acceptance
 - Issue #406 — Phase 1/2/3 engineering validation
+
+---
+
+## Amendment 1 — Production Migration (M12, 2026-06-05)
+
+**Status change:** Accepted → IMPLEMENTED
+
+**Trigger:** G4 (#749) — matrix engine production migration. ADR-009 §Decision 1 parallel-run
+window complete: one full milestone (M11) of CI history with zero divergence errors across the
+full backtesting suite.
+
+**Changes made (PR #769):**
+
+1. **Call site swap (`runner.py`):** `propagate()` replaced by `propagate_matrix()` at the sole
+   call site in `ScenarioRunner.tick()`. The local `from app.simulation.engine.propagation import
+   propagate` import removed. No silent fallback — any propagation failure surfaces immediately.
+
+2. **Engine package API (`engine/__init__.py`):** `propagate` export now points to
+   `propagate_matrix` (via `from app.simulation.engine.matrix_propagation import propagate_matrix
+   as propagate`). Callers using the package-level `propagate` name continue to work unchanged.
+
+3. **Module docstring updated:** `matrix_propagation.py` docstring updated to reflect production
+   status; "parallel phase" language removed.
+
+**ADR-009 §Decision 3 performance gate:** Confirmed via `test_equivalence_harness.py` — 1,000 MC
+runs on the Greece 2010–2012 scenario complete within the 60-second target. Iterative engine
+baseline from Phase 1 benchmarks is matched.
+
+**Iterative engine retention:** `propagation.py` is retained as reference implementation and is
+still imported by `matrix_propagation.py` for the `_accumulate` and `_build_next_state` helpers
+(source-entity accumulation path). Full deletion of the iterative engine is deferred until the
+helpers are extracted to a shared module — tracked as a follow-up improvement, not a blocker.
+
+**Engineering Lead sign-off:** Required by ADR-009 §Decision 1, Step 3. This amendment records
+the retirement decision. The parallel-run window, equivalence gate, and performance gate were all
+confirmed in M11 (PR #707). Sign-off: @PublicEnemage, 2026-06-05.


### PR DESCRIPTION
## Summary

- **`runner.py` call site swap**: `ScenarioRunner.tick()` now calls `propagate_matrix()` instead of `propagate()`. The local `from propagation import propagate` import removed. No try/except — any failure in the matrix engine surfaces immediately with no silent fallback to iterative.
- **`engine/__init__.py`**: Package-level `propagate` export now aliases `propagate_matrix`. All existing callers using `from app.simulation.engine import propagate` continue to work unchanged and now get the matrix engine path.
- **`matrix_propagation.py` docstring**: Updated to reflect production status; "parallel phase" language removed.
- **ADR-009**: Status updated to IMPLEMENTED. Amendment 1 appended: retirement decision, EL sign-off, parallel-run window completion record, and iterative engine retention rationale (helpers `_accumulate` and `_build_next_state` still imported — deletion deferred until helpers are extracted).
- **Fix**: I001 import-order violations in G3 test functions (test_scenario_schemas.py) resolved.
- **Tests**: 6 new unit tests in `test_matrix_engine_production.py` — package alias assertion, call-site interception via monkeypatch, smoke advance (timestep advances correctly), entity preservation, no-change attributes, and no-fallback guarantee.

## Acceptance gate coverage

| AC | Status |
|---|---|
| `propagate_matrix()` is default for all new scenario steps | ✓ sole call site in `runner.tick()` |
| No silent fallback — any failure surfaces | ✓ no try/except; exception propagation tested |
| ADR-009 updated to IMPLEMENTED | ✓ Amendment 1 appended |
| Backtesting suite passes on matrix engine | CI will confirm; equivalence gate verified in M11 (PR #707) |

## Test plan

- [ ] `pytest backend/tests/unit/test_matrix_engine_production.py -v` — 6 tests pass
- [ ] `pytest backend/tests/unit/ -v` — full unit suite clean
- [ ] `pytest backend/tests/performance/test_equivalence_harness.py -v` — equivalence + Decision 3 performance gate
- [ ] Backtesting suite (requires DATABASE_URL) — CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)