### PR TITLE
fix(ci): trigger CI on release/m* PRs — NM-035

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: WorldSim CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/m* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/m* ]
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -1887,6 +1887,37 @@ PM Agent HORIZON sweep Step 5 (file authority audit) during M12 kickoff ceremony
 
 ---
 
+## NM-035 — CI Workflow Not Triggered for PRs Targeting Release Branches (Reactive)
+
+**Date:** 2026-06-05
+**Milestone:** M12 — Active Control and External Sector
+**Detected by:** Engineering Lead spot-check of PR #767 CI run 2026-06-05
+**Severity:** Critical
+
+### What happened
+
+The CI workflow (`ci.yml`) had `pull_request: branches: [ main ]` — it only fired for PRs targeting `main`. The M12 release branch workflow (introduced in CLAUDE.md at M12 kickoff) routes all feature work through PRs targeting `release/m12`. As a result, every G1–G7 PR during M12 merged without CI running (no test-backend, no lint, no compliance-scan, no playwright-e2e jobs triggered).
+
+The pre-push gate (mandatory local `ruff check` + `mypy` + `pytest` before push) provided partial compensation, but CI provides a second independent verification and catches environment differences between local and runner.
+
+**Filing note:** This entry was filed by the implementing agent (not PI Agent) under direct EL direction and urgency. NM-034's PI Agent activation requirement applies; this entry is flagged for PI Agent review before the PR merges.
+
+### What was at risk
+
+All M12 code merged without automated CI verification. Any test failures, lint errors, or import errors introduced after the local pre-push gate would have silently passed through CI. The matrix engine production migration (G4) tests in particular had a pre-existing API breakage (`runner.tick()` → `runner.advance_timestep()`) that was caught only by manual test execution during G5, not by CI.
+
+### What caught it
+
+Engineering Lead spot-check of PR #767 CI run. The detection was ad hoc — no process mechanism would have surfaced this without manual inspection of a specific CI run URL.
+
+### Process improvement
+
+1. `ci.yml` amended — `pull_request: branches` updated from `[ main ]` to `[ main, release/m* ]`; `push: branches` updated from `[ main, develop ]` to `[ main, develop, release/m* ]`. Fixed in this PR.
+2. **Sprint planning SOP must be updated** to include a CI trigger verification step at milestone kickoff: when a new release branch is created, confirm that the CI workflow's `pull_request: branches` pattern covers the new branch before any feature PRs are opened. This check belongs in `docs/process/sprint-planning-sop.md` §Kickoff Gate.
+3. **M12 retroactive assessment required:** EL to determine whether any G1–G7 PRs should have their test suites re-run against `release/m12` head to confirm no silent failures are present. The pre-push gate provides reasonable confidence, but CI was not the second line of defense it was intended to be.
+
+---
+
 ## Registry Maintenance
 
 ### How to add an entry

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -139,9 +139,10 @@ The sprint plan and the release branch are created at the same time, at mileston
 
 When the sprint plan is approved:
 1. PM Agent creates `release/m{N}` from `main`
-2. Feature branches are cut from `release/m{N}`
-3. Groups are worked in wave order
-4. EL does one admin bypass at milestone close: `release/m{N}` → `main`
+2. **CI trigger verification (mandatory):** Confirm that `.github/workflows/ci.yml` `pull_request: branches` includes `release/m*` (or the specific release branch pattern). If the CI workflow does not cover the new release branch, update it before opening any feature PRs. Root cause: NM-035 — M12 ran 7 groups without CI triggering because this check did not exist.
+3. Feature branches are cut from `release/m{N}`
+4. Groups are worked in wave order
+5. EL does one admin bypass at milestone close: `release/m{N}` → `main`
 
 ---
 


### PR DESCRIPTION
## Summary

- **Root cause:** `ci.yml` `pull_request: branches` was `[ main ]` only — PRs targeting `release/m12` did not trigger CI. All G1–G7 PRs in M12 merged without CI running.
- **Fix:** Updated `pull_request: branches` to `[ main, release/m* ]` and `push: branches` to include `release/m* ` pattern.
- **Process improvement:** Added mandatory CI trigger verification step to sprint-planning-sop.md §Relationship to Release Branch kickoff gate.
- **Near-miss filed:** NM-035 in `docs/process/near-miss-registry.md`.

## Severity

**Critical** — automated test gate was absent for all M12 feature merges. Local pre-push gates (`ruff check` + `mypy` + `pytest`) provided partial compensation, but CI was not providing independent verification.

## Retroactive assessment required

EL to determine whether any G1–G7 work needs re-verification against current `release/m12` head. The pre-push gate gives reasonable confidence no silent failures exist, but CI was not the second line of defense it was intended to be.

## NM-034 protocol note

NM-035 was filed by the implementing agent directly under EL direction and urgency. PI Agent activation is required per NM-034's process improvement. This entry is flagged for PI Agent review.

## Test plan

- [ ] Confirm this PR itself triggers CI (the fix is self-validating — if CI runs on this PR, the fix works)
- [ ] Confirm G5 PR (to follow) triggers CI on `release/m12`
- [ ] EL retroactive assessment: review G1–G7 test coverage confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)