### PR TITLE
feat(engine): G6a multi-country scenario backend — relationship loading, threshold overlay, entity header (closes #754, #153)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -193,6 +193,10 @@ def _validate_create_request(req: ScenarioCreateRequest) -> None:
     if not req.name.strip():
         errors.append("name must not be empty.")
 
+    n_entities = len(req.configuration.entities)
+    if n_entities < 1 or n_entities > 5:
+        errors.append(f"entities must contain 1–5 entity IDs (got {n_entities}).")
+
     n = req.configuration.n_steps
     if n < 1 or n > 100:
         errors.append(f"n_steps must be between 1 and 100 (got {n}).")
@@ -394,7 +398,13 @@ async def list_scenarios(
 # ---------------------------------------------------------------------------
 
 
-def _compute_delta(value_a: str, value_b: str, tier_a: int, tier_b: int) -> DeltaRecord:
+def _compute_delta(
+    value_a: str,
+    value_b: str,
+    tier_a: int,
+    tier_b: int,
+    threshold_value: str | None = None,
+) -> DeltaRecord:
     from decimal import Decimal  # noqa: PLC0415
 
     dec_a = Decimal(value_a)
@@ -406,12 +416,19 @@ def _compute_delta(value_a: str, value_b: str, tier_a: int, tier_b: int) -> Delt
         direction = "decrease"
     else:
         direction = "unchanged"
+
+    threshold_crossed: bool | None = None
+    if threshold_value is not None:
+        thr = Decimal(threshold_value)
+        threshold_crossed = (dec_a < thr) != (dec_b < thr)
+
     return DeltaRecord(
         value_a=value_a,
         value_b=value_b,
         delta=str(delta),
         direction=direction,
         confidence_tier=max(tier_a, tier_b),
+        threshold_crossed=threshold_crossed,
     )
 
 
@@ -422,6 +439,7 @@ async def compare_scenarios(
     scenario_b: str,
     attr: str | None = None,
     step: int | None = None,
+    threshold_value: str | None = None,
 ) -> CompareResponse:
     """Return attribute deltas between two scenarios.
 
@@ -432,6 +450,10 @@ async def compare_scenarios(
     `step` — when provided, both scenarios must have a snapshot at exactly
     that step. Returns 404 identifying which scenario is missing the step.
     When omitted, compares the final (highest-step) snapshot of each scenario.
+
+    `threshold_value` — when provided (as a numeric string), each DeltaRecord
+    includes `threshold_crossed: bool` indicating whether the delta crossed this
+    absolute value boundary (value_a and value_b on opposite sides). Issue #153.
 
     Returns 404 if either scenario is not found.
     Returns 404 if `step` is provided and either scenario has no snapshot at
@@ -532,6 +554,7 @@ async def compare_scenarios(
                     val_b,
                     int(a_env.get("confidence_tier", 5)),
                     int(b_env.get("confidence_tier", 5)),
+                    threshold_value=threshold_value,
                 )
             except Exception:  # noqa: BLE001 S112
                 continue

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -514,6 +514,9 @@ class DeltaRecord(BaseModel):
     `delta` = str(Decimal(value_b) - Decimal(value_a)).
     `direction` is 'increase', 'decrease', or 'unchanged'.
     `confidence_tier` is max(tier_a, tier_b) — lower-of-two rule.
+    `threshold_crossed` is True when the delta crosses a caller-supplied absolute
+    threshold (i.e. value_a is on one side and value_b is on the other), None when
+    no threshold was requested (Issue #153, G6a rider).
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -523,6 +526,7 @@ class DeltaRecord(BaseModel):
     delta: str
     direction: str
     confidence_tier: int
+    threshold_crossed: bool | None = None
 
 
 class CompareResponse(BaseModel):

--- a/backend/app/simulation/repositories/state_repository.py
+++ b/backend/app/simulation/repositories/state_repository.py
@@ -4,9 +4,11 @@ ADR-004 Decision 2. Reads simulation_entities rows and converts JSONB attribute
 envelopes to Quantity objects (SA-09 format), building a SimulationState for the
 ScenarioRunner.
 
-For M3, relationships are not loaded (empty list). The engine propagation graph
-operates on whatever relationships are present — an empty list means no propagation
-across entities, which is correct for single-entity Greece backtesting scenarios.
+Relationship loading (G6a, Issue #754): when multiple entities are in scope, all
+directed edges between them are loaded from the `relationships` table. For each
+ordered pair of distinct entities with no real edge, a synthetic Tier 4 "trade"
+relationship is injected (weight=0.1, attributes["confidence_tier"]=4,
+attributes["synthetic"]=True) so propagation can occur at low confidence.
 
 Follows the asyncpg direct-query pattern from ADR-003 Decision 2.
 """
@@ -19,12 +21,16 @@ from typing import Any
 import asyncpg  # noqa: TCH002 — used in method signatures at runtime
 
 from app.simulation.engine.models import (
+    Relationship,
     ResolutionConfig,
     ScenarioConfig,
     SimulationEntity,
     SimulationState,
 )
 from app.simulation.repositories.quantity_serde import quantity_from_jsonb
+
+_SYNTHETIC_RELATIONSHIP_WEIGHT: float = 0.1
+_SYNTHETIC_RELATIONSHIP_TYPE: str = "trade"
 
 
 class SimulationStateRepository:
@@ -90,11 +96,13 @@ class SimulationStateRepository:
             end_date=timestep,
         )
 
+        relationships = await _load_relationships(conn, entity_ids)
+
         return SimulationState(
             timestep=timestep,
             resolution=ResolutionConfig(),
             entities=entities,
-            relationships=[],
+            relationships=relationships,
             events=[],
             scenario_config=scenario_config,
         )
@@ -132,6 +140,64 @@ def _build_entity(row: Any) -> SimulationEntity:  # noqa: ANN401 — asyncpg Rec
         attributes=attributes,
         metadata=meta_raw if isinstance(meta_raw, dict) else {},
     )
+
+
+async def _load_relationships(
+    conn: asyncpg.Connection,
+    entity_ids: list[str],
+) -> list[Relationship]:
+    """Load directed edges between scenario entities; inject synthetics for missing pairs.
+
+    Queries the `relationships` table for all edges where both source and target
+    are in entity_ids. For each ordered pair (a, b) with a ≠ b that has no real
+    edge in either direction, a synthetic Tier 4 trade relationship is created in
+    both directions (a→b and b→a) at weight 0.1.
+
+    Single-entity scenarios return an empty list (no pairs to fill).
+    """
+    if len(entity_ids) < 2:
+        return []
+
+    rows = await conn.fetch(
+        """
+        SELECT source_id, target_id, relationship_type, weight, attributes
+        FROM relationships
+        WHERE source_id = ANY($1::text[]) AND target_id = ANY($1::text[])
+        """,
+        entity_ids,
+    )
+
+    real: list[Relationship] = []
+    real_pairs: set[tuple[str, str]] = set()
+    for row in rows:
+        attrs_raw = row["attributes"]
+        if isinstance(attrs_raw, str):
+            import json as _json  # noqa: PLC0415
+            attrs_raw = _json.loads(attrs_raw)
+        real.append(Relationship(
+            source_id=row["source_id"],
+            target_id=row["target_id"],
+            relationship_type=row["relationship_type"],
+            weight=float(row["weight"]),
+            attributes=attrs_raw if isinstance(attrs_raw, dict) else {},
+        ))
+        real_pairs.add((row["source_id"], row["target_id"]))
+
+    synthetic: list[Relationship] = []
+    for src in entity_ids:
+        for tgt in entity_ids:
+            if src == tgt:
+                continue
+            if (src, tgt) not in real_pairs:
+                synthetic.append(Relationship(
+                    source_id=src,
+                    target_id=tgt,
+                    relationship_type=_SYNTHETIC_RELATIONSHIP_TYPE,
+                    weight=_SYNTHETIC_RELATIONSHIP_WEIGHT,
+                    attributes={"confidence_tier": 4, "synthetic": True},
+                ))
+
+    return real + synthetic
 
 
 def _default_timestep() -> datetime:

--- a/backend/tests/unit/test_g6a_multi_country.py
+++ b/backend/tests/unit/test_g6a_multi_country.py
@@ -1,0 +1,238 @@
+"""
+G6a — Multi-country scenario backend unit tests (Issue #754, #153).
+
+Tests:
+  - _load_relationships: real DB edges loaded; synthetic Tier 4 injected for missing pairs
+  - _validate_create_request: entities list 1–5 enforcement
+  - _compute_delta threshold_crossed field
+  - ScenarioIdentityHeader entityIds → single "Entity:" vs plural "Entities:"
+  - DeltaRecord threshold_crossed schema field
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.scenarios import _compute_delta, _validate_create_request
+from app.schemas import DeltaRecord, ScenarioConfigSchema, ScenarioCreateRequest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**kwargs: object) -> ScenarioConfigSchema:
+    defaults: dict[str, object] = {
+        "entities": ["GRC"],
+        "n_steps": 5,
+        "timestep_label": "annual",
+    }
+    defaults.update(kwargs)
+    return ScenarioConfigSchema(**defaults)  # type: ignore[arg-type]
+
+
+def _make_request(entities: list[str]) -> ScenarioCreateRequest:
+    return ScenarioCreateRequest(
+        name="test",
+        configuration=_make_config(entities=entities),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. _validate_create_request — entity count gate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_one_entity() -> None:
+    _validate_create_request(_make_request(["GRC"]))  # no exception
+
+
+def test_validate_accepts_five_entities() -> None:
+    _validate_create_request(_make_request(["GRC", "DEU", "FRA", "ITA", "ESP"]))
+
+
+def test_validate_rejects_zero_entities() -> None:
+    from fastapi import HTTPException  # noqa: PLC0415
+    with pytest.raises(HTTPException) as exc:
+        _validate_create_request(_make_request([]))
+    assert "1–5" in str(exc.value.detail)
+
+
+def test_validate_rejects_six_entities() -> None:
+    from fastapi import HTTPException  # noqa: PLC0415
+    with pytest.raises(HTTPException) as exc:
+        _validate_create_request(_make_request(["A", "B", "C", "D", "E", "F"]))
+    assert "1–5" in str(exc.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# 2. _compute_delta — threshold_crossed field (Issue #153)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_delta_no_threshold_returns_none() -> None:
+    record = _compute_delta("0.85", "0.92", 1, 1)
+    assert record.threshold_crossed is None
+
+
+def test_compute_delta_threshold_not_crossed() -> None:
+    record = _compute_delta("0.85", "0.92", 1, 1, threshold_value="0.80")
+    assert record.threshold_crossed is False  # both above 0.80
+
+
+def test_compute_delta_threshold_crossed_upward() -> None:
+    record = _compute_delta("0.75", "0.85", 1, 1, threshold_value="0.80")
+    assert record.threshold_crossed is True  # crosses 0.80 upward
+
+
+def test_compute_delta_threshold_crossed_downward() -> None:
+    record = _compute_delta("0.85", "0.75", 1, 1, threshold_value="0.80")
+    assert record.threshold_crossed is True  # crosses 0.80 downward
+
+
+def test_compute_delta_threshold_at_boundary_not_crossed() -> None:
+    # value_a exactly at threshold — dec_a < thr is False on both sides
+    record = _compute_delta("0.80", "0.90", 1, 1, threshold_value="0.80")
+    assert record.threshold_crossed is False
+
+
+def test_compute_delta_threshold_crossed_preserves_direction() -> None:
+    record = _compute_delta("0.75", "0.85", 1, 1, threshold_value="0.80")
+    assert record.direction == "increase"
+    assert record.threshold_crossed is True
+
+
+# ---------------------------------------------------------------------------
+# 3. DeltaRecord schema — threshold_crossed is optional None by default
+# ---------------------------------------------------------------------------
+
+
+def test_delta_record_threshold_crossed_defaults_none() -> None:
+    r = DeltaRecord(
+        value_a="1.0", value_b="2.0", delta="1.0",
+        direction="increase", confidence_tier=1,
+    )
+    assert r.threshold_crossed is None
+
+
+def test_delta_record_threshold_crossed_can_be_set() -> None:
+    r = DeltaRecord(
+        value_a="1.0", value_b="2.0", delta="1.0",
+        direction="increase", confidence_tier=1,
+        threshold_crossed=True,
+    )
+    assert r.threshold_crossed is True
+
+
+# ---------------------------------------------------------------------------
+# 4. _load_relationships — relationship loading logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_single_entity_returns_empty() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+    conn = AsyncMock()
+    result = await _load_relationships(conn, ["GRC"])
+    assert result == []
+    conn.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_real_edges_loaded() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+
+    mock_row = {
+        "source_id": "GRC",
+        "target_id": "DEU",
+        "relationship_type": "trade",
+        "weight": 0.6,
+        "attributes": "{}",
+    }
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[mock_row])
+
+    result = await _load_relationships(conn, ["GRC", "DEU"])
+
+    real = [r for r in result if not r.attributes.get("synthetic")]
+    assert len(real) == 1
+    assert real[0].source_id == "GRC"
+    assert real[0].target_id == "DEU"
+    assert real[0].weight == pytest.approx(0.6)
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_synthetic_injected_for_missing_pair() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])  # no real edges
+
+    result = await _load_relationships(conn, ["GRC", "DEU"])
+
+    synthetic = [r for r in result if r.attributes.get("synthetic")]
+    # Both directions: GRC→DEU and DEU→GRC
+    assert len(synthetic) == 2
+    pairs = {(r.source_id, r.target_id) for r in synthetic}
+    assert ("GRC", "DEU") in pairs
+    assert ("DEU", "GRC") in pairs
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_synthetic_confidence_tier_4() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await _load_relationships(conn, ["GRC", "DEU"])
+
+    for rel in result:
+        assert rel.attributes.get("confidence_tier") == 4
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_real_pair_not_duplicated_by_synthetic() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+
+    mock_row = {
+        "source_id": "GRC",
+        "target_id": "DEU",
+        "relationship_type": "trade",
+        "weight": 0.5,
+        "attributes": "{}",
+    }
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[mock_row])
+
+    result = await _load_relationships(conn, ["GRC", "DEU"])
+
+    # Real GRC→DEU exists — no synthetic for that direction
+    grc_deu = [r for r in result if r.source_id == "GRC" and r.target_id == "DEU"]
+    assert len(grc_deu) == 1
+    assert not grc_deu[0].attributes.get("synthetic")
+
+    # Reverse DEU→GRC has no real edge — synthetic injected
+    deu_grc = [r for r in result if r.source_id == "DEU" and r.target_id == "GRC"]
+    assert len(deu_grc) == 1
+    assert deu_grc[0].attributes.get("synthetic")
+
+
+@pytest.mark.asyncio
+async def test_load_relationships_three_entities_all_pairs_covered() -> None:
+    from app.simulation.repositories.state_repository import _load_relationships  # noqa: PLC0415
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    result = await _load_relationships(conn, ["A", "B", "C"])
+
+    # 3 entities → 3×2=6 ordered pairs, all synthetic
+    assert len(result) == 6
+    pairs = {(r.source_id, r.target_id) for r in result}
+    assert ("A", "B") in pairs
+    assert ("B", "A") in pairs
+    assert ("A", "C") in pairs
+    assert ("C", "A") in pairs
+    assert ("B", "C") in pairs
+    assert ("C", "B") in pairs

--- a/docs/architecture/multi-country-validation-suite-design.md
+++ b/docs/architecture/multi-country-validation-suite-design.md
@@ -1,0 +1,150 @@
+# Multi-Country Validation Suite Design
+
+**Issue:** #103
+**Finding:** ARCH-REVIEW-002 BI2-N-12
+**Date:** 2026-06-05
+**Ships with:** G6a — multi-country scenario backend (PR targeting release/m12)
+
+---
+
+## Problem Statement
+
+The Greece 2010–2012 backtesting case produces two data points (step 1, step 2). Under a null (uncalibrated) model, the probability of passing both DIRECTION_ONLY thresholds by chance is 25% — two independent sign checks, each with p=0.5. A 25% false-positive rate means one in four random models would pass the M3 backtesting gate.
+
+The current backtesting architecture must be understood as a **plausibility check**, not an empirical validation. Statistical validity requires either: (a) a longer time series (same country, more steps), (b) multiple countries with the same crisis pattern, or (c) both.
+
+This document specifies the multi-country extension plan to bring the backtesting suite to statistical significance.
+
+---
+
+## Statistical Validity Requirement
+
+A directional pass across N independent data points has probability (0.5)^N of occurring by chance. To reach a false-positive rate of ≤ 5%:
+
+| Data points required | Max false-positive rate |
+|---|---|
+| 1 | 50% |
+| 2 (current) | 25% |
+| 5 | 3.1% |
+| 7 | 0.8% |
+
+**Minimum target:** 5 independent directional checks. This can be achieved through any combination of:
+- Additional steps in the Greece case (longer time series)
+- Additional sovereign debt crisis cases (same crisis pattern, different countries)
+- Both
+
+The preferred approach is both — additional cases improve generalizability, while additional steps within each case improve temporal fidelity.
+
+---
+
+## Candidate Extension Cases
+
+The following sovereign debt crisis cases have the same structural pattern as Greece (fiscal stress → external financing shock → austerity programme → social cost cascade) with documented IMF programme timelines and WEO actuals:
+
+### Case 1 — Ireland 2010–2012
+
+| Field | Value |
+|---|---|
+| Crisis trigger | Banking sector collapse → sovereign guarantees → fiscal shock |
+| Programme start | November 2010 (EU/IMF/EFSF) |
+| Programme end | December 2013 |
+| Available steps | 3 annual steps (2010, 2011, 2012) |
+| IMF WEO data | Readily available; WEO database October 2010 vintage |
+| Pattern match to Greece | High — same external adjustment, same fiscal consolidation pressure, same unemployment response |
+| Differentiator | Banking channel dominates (vs. debt issuance in Greece); GDP contraction earlier |
+
+**ControlInput sequence:** Fiscal shock 2010 (banking guarantee → primary balance deterioration); structural adjustment 2011–2012 (banking recapitalisation → growth recovery path).
+
+### Case 2 — Portugal 2011–2014
+
+| Field | Value |
+|---|---|
+| Crisis trigger | Sovereign spreads → market access loss → IMF request |
+| Programme start | May 2011 (EU/IMF) |
+| Programme end | May 2014 |
+| Available steps | 3 annual steps (2011, 2012, 2013) |
+| IMF WEO data | WEO April 2011 vintage for baseline; WEO October 2012/2013 for actuals |
+| Pattern match to Greece | Very high — same crisis mechanism, same EU/IMF programme structure |
+| Differentiator | Faster external adjustment; less severe social cost cascade than Greece |
+
+**ControlInput sequence:** Fiscal shock 2011 (market access loss → austerity programme); structural adjustment 2012–2013; social stabilisation 2014.
+
+### Case 3 — Cyprus 2012–2013
+
+| Field | Value |
+|---|---|
+| Crisis trigger | Banking sector (overexposure to Greek sovereign debt) → deposit bail-in |
+| Programme start | March 2013 (EU/IMF) |
+| Programme end | March 2016 |
+| Available steps | 2 annual steps (2013, 2014) — shorter timeline |
+| IMF WEO data | WEO April 2013 vintage; deposit haircut parameters from troika programme documentation |
+| Pattern match to Greece | Moderate — bank channel dominant; deposit bail-in is distinct from Greece |
+| Differentiator | Deposit freeze creates unique distributional effects not in the base Greece model |
+| Fit for multi-country suite | Conditional — valuable for the banking channel coverage, but the deposit bail-in mechanism may require a new ControlInput type |
+
+**ControlInput sequence:** Bilateral financial shock 2013 (banking sector → sovereign); structural adjustment 2013–2014.
+
+---
+
+## Priority Order
+
+| Priority | Case | Rationale |
+|---|---|---|
+| 1 | Ireland 2010–2012 | Best pattern match; 3 steps; data readily available; no new ControlInput types needed |
+| 2 | Portugal 2011–2014 | Very high pattern match; 3 additional steps; validates the same programme mechanism |
+| 3 | Cyprus 2012–2013 | Adds banking channel; may require new ControlInput type — scope as a separate issue |
+
+Ireland + Portugal alone add 6 directional data points to the 2 from Greece — bringing the suite to 8 total, well above the ≤5% false-positive threshold (0.5^8 = 0.4%).
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Ireland case (Target: M12 or M13)
+
+1. Acquire IMF WEO actuals for Ireland 2010–2012 (WEO April 2011, October 2011, October 2012 vintages)
+2. Define ControlInput sequence for the banking channel shock (see above)
+3. Write fixture: `backend/tests/fixtures/ireland_2010_fixture.py`
+4. Write backtesting case: `backend/tests/backtesting/test_ireland_backtesting.py`
+5. Set DIRECTION_ONLY thresholds for Ireland — do not reuse Greece thresholds without validation
+6. Add Ireland case to CI backtesting job in `ci.yml`
+
+### Phase 2 — Portugal case (Target: M13)
+
+1. Acquire IMF WEO actuals for Portugal 2011–2013
+2. Write fixture and backtesting case following the Ireland pattern
+3. Add Portugal case to CI backtesting job
+
+### Phase 3 — Statistical reporting (Target: M14)
+
+1. Add a backtesting summary report that computes the false-positive rate across all active cases
+2. Report: "N directional checks across M cases; probability of passing by chance: P%"
+3. Set a minimum threshold: CI fails if the suite's aggregate false-positive rate exceeds 10% (not yet at 5% target)
+
+---
+
+## Data Requirements
+
+All backtesting fixtures must comply with `docs/DATA_STANDARDS.md`:
+
+| Requirement | Detail |
+|---|---|
+| Vintage dating | Each fixture must record the WEO vintage used for actuals (e.g. "WEO October 2012") |
+| Confidence tier | IMF WEO actuals are Tier 1 where available; model-derived interpolations are Tier 3 |
+| Territorial declarations | No contested territories in the Ireland/Portugal/Cyprus cases — standard ISO 3166-1 |
+| Open-licensed data | IMF WEO data is publicly available; no proprietary data in fixture files |
+
+---
+
+## Relationship to G6a
+
+This document ships in the same PR as G6a (multi-country scenario backend). The multi-country backend is the prerequisite infrastructure for running multi-entity backtesting scenarios — Ireland and Portugal cases will use the multi-entity path added in G6a to simultaneously run the crisis country alongside a commodity reference entity for external sector shocks.
+
+---
+
+## References
+
+- ARCH-REVIEW-002 BI2-N-12: `docs/architecture/reviews/ARCH-REVIEW-002-milestone2.md`
+- Greece backtesting case: `backend/tests/backtesting/`
+- DATA_STANDARDS.md §Confidence Tier System
+- IMF WEO database: publicly accessible at imf.org/external/datamapper

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,8 +84,8 @@ export default function App() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [fidelityOpen, setFidelityOpen] = useState(false);
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
-  // Primary entity for the active scenario — used by ScenarioIdentityHeader and choropleth highlight (#744)
-  const [activeEntityId, setActiveEntityId] = useState<string | null>(null);
+  // All active entities for the scenario — used by ScenarioIdentityHeader and choropleth highlight (#754)
+  const [activeEntityIds, setActiveEntityIds] = useState<string[]>([]);
   // Incremented on every advance — ScenarioPanel watches this to refresh the list.
   const [scenarioListVersion, setScenarioListVersion] = useState(0);
   // Mode 2 fiscal multiplier for the active scenario (Issue #746)
@@ -104,7 +104,7 @@ export default function App() {
     setSelectedScenarioSteps(totalSteps);
     setCurrentStep(null);
     setSelectedEntityId(null);
-    setActiveEntityId(null);
+    setActiveEntityIds([]);
     setActiveFiscalMultiplier(null);
     writeStoredScenario({ id, name, totalSteps });
   };
@@ -171,9 +171,8 @@ export default function App() {
         if (detail.status === "completed") {
           setCurrentStep(detail.configuration.n_steps);
         }
-        // Set primary entity for identity header and choropleth highlight
-        const primaryEntity = detail.configuration.entities?.[0] ?? null;
-        setActiveEntityId(primaryEntity);
+        // Set all active entities for identity header and choropleth highlight (#754)
+        setActiveEntityIds(detail.configuration.entities ?? []);
         // Extract fiscal multiplier for Mode 2 display (Issue #746)
         setActiveFiscalMultiplier(detail.configuration.fiscal_multiplier ?? null);
       })
@@ -250,7 +249,7 @@ export default function App() {
         {selectedScenarioId && selectedScenarioName && (
           <ScenarioIdentityHeader
             scenarioName={selectedScenarioName}
-            entityId={activeEntityId}
+            entityIds={activeEntityIds}
             currentStep={currentStep}
             totalSteps={selectedScenarioSteps}
             fiscalMultiplier={activeFiscalMultiplier}
@@ -285,7 +284,7 @@ export default function App() {
             scenarioId={selectedScenarioId}
             currentStep={currentStep}
             onEntityClick={selectedScenarioId ? handleEntityClick : undefined}
-            activeEntityId={activeEntityId}
+            activeEntityIds={activeEntityIds}
           />
         )}
 

--- a/frontend/src/components/ChoroplethMap.tsx
+++ b/frontend/src/components/ChoroplethMap.tsx
@@ -17,8 +17,8 @@ interface Props {
   scenarioId?: string | null;
   currentStep?: number | null;
   onEntityClick?: (entityId: string) => void;
-  /** Active scenario entity — highlighted with a distinct border (Issue #744). */
-  activeEntityId?: string | null;
+  /** All active scenario entities — highlighted with distinct borders (Issue #754). */
+  activeEntityIds?: string[];
 }
 
 // INTENT: Compute five breakpoints [p0, p25, p50, p75, p100] from feature
@@ -78,7 +78,7 @@ function computeSteps(features: GeoJSONFeatureCollection["features"]): number[] 
   return raw;
 }
 
-export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick, activeEntityId }: Props) {
+export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick, activeEntityIds = [] }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -172,13 +172,15 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
           },
         });
 
-        // Active entity highlight layer — amber border on the scenario's primary country (#744)
+        // Active entity highlight layer — amber border on all scenario entities (#754)
         if (map.getLayer(HIGHLIGHT_LAYER_ID)) map.removeLayer(HIGHLIGHT_LAYER_ID);
         map.addLayer({
           id: HIGHLIGHT_LAYER_ID,
           type: "line",
           source: SOURCE_ID,
-          filter: ["==", ["get", "entity_id"], activeEntityId ?? ""],
+          filter: activeEntityIds.length > 0
+            ? ["in", ["get", "entity_id"], ["literal", activeEntityIds]]
+            : ["==", ["get", "entity_id"], ""],
           paint: {
             "line-color": "#f59e0b",
             "line-width": 3,
@@ -240,14 +242,19 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
     });
   }, [attributeName, title, scenarioId, currentStep]);
 
-  // Update active-entity highlight filter when activeEntityId changes independently
+  // Update active-entity highlight filter when activeEntityIds changes independently
   // of a data reload (e.g. user selects a different scenario without changing attribute).
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !map.isStyleLoaded()) return;
     if (!map.getLayer(HIGHLIGHT_LAYER_ID)) return;
-    map.setFilter(HIGHLIGHT_LAYER_ID, ["==", ["get", "entity_id"], activeEntityId ?? ""]);
-  }, [activeEntityId]);
+    map.setFilter(
+      HIGHLIGHT_LAYER_ID,
+      activeEntityIds.length > 0
+        ? ["in", ["get", "entity_id"], ["literal", activeEntityIds]]
+        : ["==", ["get", "entity_id"], ""],
+    );
+  }, [activeEntityIds]);
 
   return (
     <div

--- a/frontend/src/components/ScenarioIdentityHeader.tsx
+++ b/frontend/src/components/ScenarioIdentityHeader.tsx
@@ -12,7 +12,8 @@
 
 interface Props {
   scenarioName: string;
-  entityId: string | null;
+  /** All active entity IDs for the scenario (Issue #754). Replaces single entityId. */
+  entityIds: string[];
   currentStep: number | null;
   totalSteps: number;
   /** Mode 2 fiscal multiplier override (Issue #746). Shown when present and ≠ 1.0. */
@@ -26,17 +27,25 @@ export function formatStatus(currentStep: number | null, totalSteps: number): st
   return `Step ${currentStep} of ${totalSteps}`;
 }
 
+/** Returns the entity label segment for the header strip (Issue #754). */
+export function formatEntityLabel(entityIds: string[]): string {
+  if (entityIds.length === 0) return "";
+  if (entityIds.length === 1) return `Entity: ${entityIds[0]}`;
+  return `Entities: ${entityIds.join(", ")}`;
+}
+
 /** Returns the multiplier label string for the header strip, or null when no override is active. */
 export function formatMultiplierLabel(fiscalMultiplier: number | null | undefined): string | null {
   if (fiscalMultiplier == null || fiscalMultiplier === 1.0) return null;
   return `Fiscal ×${fiscalMultiplier.toFixed(1)}`;
 }
 
-export function ScenarioIdentityHeader({ scenarioName, entityId, currentStep, totalSteps, fiscalMultiplier }: Props) {
+export function ScenarioIdentityHeader({ scenarioName, entityIds, currentStep, totalSteps, fiscalMultiplier }: Props) {
   const multiplierLabel = formatMultiplierLabel(fiscalMultiplier);
+  const entityLabel = formatEntityLabel(entityIds);
   const parts: string[] = [
     `Scenario: ${scenarioName}`,
-    entityId ? `Entity: ${entityId}` : "",
+    entityLabel,
     multiplierLabel ? `Mode: 2 (${multiplierLabel})` : "",
     `Status: ${formatStatus(currentStep, totalSteps)}`,
   ].filter(Boolean);

--- a/frontend/src/components/__tests__/ScenarioIdentityHeader.test.ts
+++ b/frontend/src/components/__tests__/ScenarioIdentityHeader.test.ts
@@ -9,7 +9,7 @@
  * Playwright E2E tests covering DOM assertions live in tests/e2e/.
  */
 import { describe, it, expect } from "vitest";
-import { formatStatus, formatMultiplierLabel } from "../ScenarioIdentityHeader";
+import { formatStatus, formatMultiplierLabel, formatEntityLabel } from "../ScenarioIdentityHeader";
 
 // ---------------------------------------------------------------------------
 // formatStatus — step-to-label mapping
@@ -84,5 +84,39 @@ describe("formatMultiplierLabel", () => {
     const label = formatMultiplierLabel(1.5);
     expect(label).toContain("×1.5");
     expect(label).not.toContain("×1.50");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatEntityLabel — multi-entity identity display (#754)
+// ---------------------------------------------------------------------------
+
+describe("formatEntityLabel", () => {
+  it("empty array → empty string", () => {
+    expect(formatEntityLabel([])).toBe("");
+  });
+
+  it("single entity → 'Entity: GRC'", () => {
+    expect(formatEntityLabel(["GRC"])).toBe("Entity: GRC");
+  });
+
+  it("two entities → 'Entities: JOR, SAU'", () => {
+    expect(formatEntityLabel(["JOR", "SAU"])).toBe("Entities: JOR, SAU");
+  });
+
+  it("three entities → plural label with all IDs", () => {
+    const label = formatEntityLabel(["GRC", "DEU", "FRA"]);
+    expect(label).toMatch(/^Entities:/);
+    expect(label).toContain("GRC");
+    expect(label).toContain("DEU");
+    expect(label).toContain("FRA");
+  });
+
+  it("single entity uses singular 'Entity:' not 'Entities:'", () => {
+    expect(formatEntityLabel(["GRC"])).not.toContain("Entities:");
+  });
+
+  it("two entities uses plural 'Entities:' not 'Entity:'", () => {
+    expect(formatEntityLabel(["GRC", "DEU"])).not.toMatch(/^Entity:/);
   });
 });

--- a/frontend/tests/e2e/scenario-advance.spec.ts
+++ b/frontend/tests/e2e/scenario-advance.spec.ts
@@ -48,7 +48,7 @@ test("create → advance to completion → entity drawer shows measurement outpu
 
   await nextStepBtn.click();
   await expect(page.getByText("Step 3 / 3")).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText(/Complete/)).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(/— Complete/)).toBeVisible({ timeout: 10_000 });
 
   // Advance button must be disabled after completion.
   await expect(nextStepBtn).toBeDisabled();

--- a/frontend/tests/e2e/scenario-reselect.spec.ts
+++ b/frontend/tests/e2e/scenario-reselect.spec.ts
@@ -42,7 +42,7 @@ test("re-select completed scenario → drawer shows output without advance click
     await nextStepBtn.click();
     await expect(page.getByText(`Step ${step} / 3`)).toBeVisible({ timeout: 15_000 });
   }
-  await expect(page.getByText(/Complete/)).toBeVisible();
+  await expect(page.getByText(/— Complete/)).toBeVisible();
 
   // ── Create scenario B and select it ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

First half of G6 — backend-heavy PR enabling multi-entity scenarios with relationship graph seeding and choropleth multi-entity highlight.

**Backend:**
- **`state_repository.py`** — `load_initial_state` now queries the `relationships` table for directed edges between all scenario entities. Missing ordered pairs receive synthetic Tier 4 trade relationships (`weight=0.1`, `confidence_tier=4`, `synthetic=True`) so propagation can occur at low confidence — no silent zero-propagation on unknown bilateral pairs (#754)
- **`scenarios.py`** — `_validate_create_request` enforces `entities` list 1–5; `_compute_delta` gains optional `threshold_value` param; `/scenarios/compare` accepts `threshold_value` query param (#153)
- **`schemas.py`** — `DeltaRecord` gains `threshold_crossed: bool | None = None` — `True` when delta crosses the absolute threshold boundary (#153)

**Frontend:**
- **`ScenarioIdentityHeader.tsx`** — `entityId → entityIds: string[]`; new `formatEntityLabel()` exported pure function: "Entity: GRC" (single) vs "Entities: JOR, SAU" (multi) (#754)
- **`ChoroplethMap.tsx`** — `activeEntityId → activeEntityIds: string[]`; MapLibre filter updated to `["in", ["get", "entity_id"], ["literal", ids]]` — all scenario entities highlighted in amber (#754)
- **`App.tsx`** — extracts all entities from scenario config (not just `[0]`), resets to `[]` on scenario deselect

**Rider #103 — Multi-country validation suite design:** `docs/architecture/multi-country-validation-suite-design.md` — Ireland 2010–2012 (priority 1) and Portugal 2011–2014 (priority 2) extend the backtesting suite to 8 directional checks (0.5^8 = 0.4% false-positive rate vs. 25% current)

## Closes
- Closes #754 (multi-country scenario configuration)
- Closes #153 (absolute threshold overlay in DeltaChoropleth — API side)

## Riders
- #103 (multi-country validation suite design)

## No ADR prerequisite
Multi-entity support extends existing ScenarioConfigSchema `entities` field (already `list[str]`). No new module boundary — within existing ADR-004 Decision 2 scope.

## Test plan
- [ ] 18 new backend unit tests in `test_g6a_multi_country.py` — all passing
- [ ] 6 new frontend unit tests (`formatEntityLabel` in `ScenarioIdentityHeader.test.ts`) — 183 total passing
- [ ] Full backend suite: 1126 passed
- [ ] `ruff check .` — clean
- [ ] `mypy app/` — clean (54 source files)
- [ ] `npm run build` — clean
- [ ] `npm run test` — 183 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)