### PR TITLE
ci: workflow_dispatch + force_backtesting input (NM-035 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main, develop, release/m* ]
   pull_request:
     branches: [ main, release/m* ]
+  workflow_dispatch:
+    inputs:
+      force_backtesting:
+        description: 'Run full PostGIS backtesting suite regardless of changed files'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -47,7 +54,7 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
@@ -94,7 +101,7 @@ jobs:
   backtesting:
     runs-on: ubuntu-latest
     needs: [changes, test-backend]
-    if: needs.changes.outputs.backtesting == 'true'
+    if: needs.changes.outputs.backtesting == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_backtesting == true)
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `ci.yml` with a `force_backtesting: boolean` input
- `test-backend` runs on any `workflow_dispatch` (required by backtesting job as a prerequisite)
- `backtesting` job fires when `force_backtesting=true` regardless of which files changed

## Why

NM-035 revealed that G1–G7 merged without the full PostGIS backtesting suite running because none of the PRs touched `backend/tests/backtesting/` or `backend/tests/fixtures/` — the only paths that trigger the backtesting job. EL decision (2026-06-05): re-verification not required for unit/integration/E2E (covered by PR #775 CI run), but the backtesting gap is not acceptable and needs a path to resolution.

This PR is that path. Once merged, trigger immediately with:

```sh
gh workflow run "WorldSim CI" --ref release/m12 --field force_backtesting=true
```

## What doesn't change

- Normal push/PR behaviour is identical — the paths-filter gate is unchanged
- `lint`, `compliance-scan`, and `playwright-e2e` do not run on `workflow_dispatch` (backtesting-only intent)
- No new secrets or environment variables required

## Test plan

- [ ] Merge this PR
- [ ] Run: `gh workflow run "WorldSim CI" --ref release/m12 --field force_backtesting=true`
- [ ] Confirm backtesting job runs and passes on current release/m12 state

🤖 Generated with [Claude Code](https://claude.com/claude-code)