### PR TITLE
docs(process): sprint plan — near-term backlog execution plan + panel decision record (EL-endorsed 2026-06-06)

### DIFF
--- a/docs/process/sprint-plans/m12-sprint-plan.md
+++ b/docs/process/sprint-plans/m12-sprint-plan.md
@@ -7,10 +7,19 @@ authored-by: PM Agent
 authored-date: 2026-06-05
 el-approved: 2026-06-05
 consulted:
-  - Business Product Owner (value prioritization)
+  - Business Product Owner (value prioritization; DP-3 panel)
   - Frontend Architect (file area grouping)
-  - Chief Engineer (dependency sequencing)
-  - Architect (ADR prerequisites)
+  - Chief Engineer (dependency sequencing; NB-3 CE constraint)
+  - Architect (ADR prerequisites; DP-1 panel; DP-2 panel; DP-3 panel)
+  - Data Architect (DP-1 panel)
+  - QA Lead (DP-1 panel)
+  - UX Designer (DP-1 panel; DP-3 panel)
+  - Chief Methodologist (NB-1 pre-analysis; DP-2 panel)
+  - Development Economist (NB-3 pre-analysis)
+  - Customer Agent (DP-3 panel)
+  - PM Agent (DP-3 panel)
+near-term-backlog-plan-date: 2026-06-06
+near-term-backlog-el-endorsed: 2026-06-06
 sop: docs/process/sprint-planning-sop.md
 ---
 
@@ -281,6 +290,367 @@ All four Wave 1 groups can be worked and merged in any order. No group depends o
 | #99 | API — trajectory comparison endpoint | Attribute values at all steps for two scenarios in one call; standalone backend PR |
 | #259 | Docs — CTO legibility metrics dashboard | Process/standards documentation |
 | #451 | UX — Mode 1 COMPARE_VIEW entry point spec | Comparable-case comparison spec; feeds Mode 1 analytical depth |
+
+---
+
+## Near-Term Backlog — Execution Plan
+
+**Authored by:** PM Agent (in-session 2026-06-06)  
+**Consulted:** Chief Engineer, Development Economist, Chief Methodologist (pre-group analysis); Architect, Data Architect, QA Lead, UX Designer, Business PO, Customer Agent (decision panels — see §Near-Term Backlog — Panel Decision Record)  
+**EL endorsed:** 2026-06-06
+
+The 14 near-term backlog items are grouped by shared file areas, dependency chains, and risk profile. Each group is one PR unless noted. Tests ship with code in the same PR.
+
+### Issue Classification
+
+| # | Title (short) | Type | Weight |
+|---|---|---|---|
+| #725 | mypy pin | chore / one-liner | XS |
+| #13 | Dataclass Attributes: sections | compliance / docs refactor | S |
+| #43 | confidence_tier + uncertainty table | standards docs | S |
+| #45 | HCL output fields + effect sizes | standards docs | S |
+| #95 | Ecological backtesting case planning | pure docs | S |
+| #259 | CTO legibility metrics dashboard | docs + CI step | M |
+| #30 | Stock vs. flow AttributeType enum | backend model | M |
+| #28 | Cohort disaggregation stubs | backend model | M |
+| #34 | Investment climate state variables | backend model + seed data | L |
+| #90 | Multi-attribute comparison endpoint | API | M |
+| #99 | Trajectory comparison endpoint | API | M |
+| #644 | ESLint exhaustive-deps audit | frontend tooling | M |
+| #451 | Mode 1 COMPARE_VIEW spec + user story | UX spec + backend design | M |
+| #394 | Multi-scenario comparison (>2) | full-stack feature | L |
+
+### Group Definitions
+
+#### NB-1 — Standards Foundation *(docs only, zero code risk)*
+
+**Issues:** #43 + #45  
+**Why together:** Both amend `CODING_STANDARDS.md` and `DATA_STANDARDS.md`. Neither touches code. Closing them first means subsequent code PRs (NB-3, NB-4) can be documented against the finalized standard rather than a draft.  
+**Scope addition (EL-endorsed, panel decision DP-1):** `information-hierarchy.md` Zone 1A confidence display ruling added in this PR — not as a follow-up. The display contract for `uncertainty_range_pct = None` ("Directional only — uncertainty not quantified"; no confidence band) must be a binding UX ruling before the backend implements the field.  
+**ADR prerequisite:** None — docs only.  
+**Gate before starting:** Chief Methodologist Tier 5 null-sentinel clause adopted (see Panel Decision DP-1).
+
+#### NB-2 — Quick Riders *(one PR, minimal diff)*
+
+**Issues:** #725 + #13  
+**Why together:** Both are tiny, low-risk backend-only changes. `pyproject.toml` one-liner (#725) and Google-style `Attributes:` section reformatting across six dataclasses in `models.py` (#13). Single PR closes two open compliance/environment items.  
+**No dependencies** on NB-1 or any other group.
+
+#### NB-3 — Entity Attribute Model Foundation
+
+**Issues:** #30 + #28  
+**Sequencing within PR:** `AttributeType` enum (#30) defined first; `CohortProfile` type (#28) references it. Both ship in one PR.  
+**ADR prerequisite (EL-endorsed, panel decision DP-2):** ADR-001 Amendment required in this PR — documents `CohortProfile` structure, cohort key convention (`"Q1"`–`"Q5"` for income quintiles, `"youth_15_24"` for age bands), and `confidence_tier` inheritance rule for cohort attributes. Not a separate PR; not a follow-up.  
+**Seed requirement (EL-endorsed, panel decision DP-2):** Greece entity receives two populated `CohortProfile` entries — Q1 and Q5 poverty headcount from Eurostat EU-SILC 2010 (Tier 2), plus Q1 unemployment rate from Eurostat LFS 2010 (Tier 2). Stub without real seed data is not acceptable.  
+**Storage model (EL-endorsed, panel decision DP-2):** `cohort_profiles: dict[str, CohortProfile] | None = None` on `SimulationEntity`; stored inside `state_data` JSONB envelope; no new database column; no migration.  
+**Schema update:** `simulation_state.yml` updated with `CohortProfile` sub-schema in same PR.  
+**CE constraint:** All new fields `Optional` with `None` defaults — no existing seed script may require modification.  
+**Prerequisite:** NB-1 merged (so new attribute definitions are documented against finalized confidence tier standard).
+
+#### NB-4 — Investment Climate State Variables
+
+**Issues:** #34  
+**Why separate from NB-3:** Requires sourcing real seed data from World Bank/IMF IFS for ten demo entities, a ContingentInput example, and a documented feedback relationship narrative. Heavier than pure type-stub work.  
+**Prerequisite:** NB-3 merged (so new attributes are typed with `AttributeType` from #30).  
+**AttributeType tagging:** All four new attributes (`sovereign_risk_premium`, `fdi_stock_pct_gdp`, `portfolio_flow_velocity`, `credit_rating_score`) tagged at definition with the `AttributeType` enum from #30.
+
+#### NB-5 — Comparison API Pair
+
+**Issues:** #90 + #99  
+**Why together:** Both extend `GET /api/v1/scenarios/compare`. The multi-attribute endpoint (#90) and trajectory comparison endpoint (#99) share DB query patterns and are the API foundation that NB-7 (#451 spec) and eventually NB-8 (#394) need.  
+**No prerequisite** on NB-1–4 (API-only; no entity model dependency).  
+**Schema update:** `api_contracts.yml` updated in same PR with both new endpoint shapes.
+
+#### NB-6 — Frontend Tooling Gate
+
+**Issues:** #644  
+**Scope:** Enable `react-hooks/exhaustive-deps` in ESLint config; audit all `useEffect`, `useCallback`, `useMemo` hooks across `ScenarioInstrumentCluster.tsx`, `FourFrameworkZone1D.tsx`, `MDAAlertPanelZone1B.tsx`, and any other file with hooks; fix or explicitly suppress with justification comment each violation.  
+**Why before NB-8:** NB-8 (#394) is a large frontend feature with new hooks. Better to have `exhaustive-deps` enforced before writing new code than to inherit a hook debt from NB-8's implementation.  
+**No hard prerequisite**, but sequence before NB-8.
+
+#### NB-7 — Mode 1 Comparison Spec
+
+**Issues:** #451  
+**What it is:** UX spec document (`information-hierarchy.md §COMPARE_VIEW` Mode 1 block completed), backend extension design decision (single API call vs. dual call — resolves the open question in the issue body), and one user story in the Andreas Stefanidis (Persona 3) format. **Not an implementation PR.**  
+**Prerequisite:** NB-5 merged — the "single call or dual call" API design decision in #451 requires knowing what NB-5 (#90 + #99) built so the spec does not contradict the implementation.  
+**EL-endorsed scope (panel decision DP-3):** #451 ships in M12 as spec only. #394 (implementation) defers to M13. #451 is the specification prerequisite for M13's NB-8 implementation.
+
+#### NB-8 — Multi-Scenario Comparison (>2) — DEFERRED TO M13
+
+**Issues:** #394  
+**Status:** Deferred by unanimous panel recommendation (DP-3), EL-endorsed 2026-06-06.  
+**Why deferred:** Demo 4 (G8) has no acceptance gate requiring N>2 scenario comparison. The feature serves TC-3 (Kenya budget planning, Persona 1) which is not the Demo 4 demonstration target. The three required pre-implementation gates do not exist in M12: (1) UX Designer N>2 ruling (zone hierarchy for N curves, color/style vocabulary, cognitive load boundary), (2) Customer Agent AUDIT (Layer 3 legibility of N concurrent trajectories for Persona 2 in 90-second Reactive entry state), (3) #451 spec accepted. None of these can be completed before G8 without risk to Demo 4 timeline.  
+**M13 gates (must all be met before implementation begins):**
+- #451 spec accepted (NB-7 above)
+- UX Designer: N>2 UX ruling issued (zone hierarchy for N curves, style vocabulary that does not collide with ghost baseline or confidence-degraded dashes, cognitive load ceiling on N)
+- Customer Agent: AUDIT complete for Persona 2 (90-second gate) and Persona 5 (5-minute gate) against the N>2 UX ruling
+
+#### NB-9 — Pure Docs *(can run in any wave)*
+
+**Issues:** #95 + #259  
+**#95 (ecological backtesting case planning):** Standalone documentation — identify the historical ecological case (Brazil Amazon deforestation 2000–2010; Ethiopia drought 2002–2004; Philippines Hainan 2013–2015 are candidates), specify data sources, initial state ecological attributes, fidelity thresholds, and ControlInput sequence. Ecological Economist consultation recommended before authoring. Produces a GitHub Issue for the ecological backtesting case implementation in a later milestone.  
+**#259 (CTO legibility metrics dashboard):** All four prerequisites confirmed CLOSED (#255 ✅ #256 ✅ #257 ✅ #258 ✅). Can proceed. Requires a new CI step computing radon/sonarjs Tier 1 metrics — test on free-tier runner before committing. Produces a CI step and legibility section in the milestone exit checklist.  
+**No prerequisites** on any other NB group.
+
+### Execution Wave Sequence
+
+```
+Wave A (parallel — start immediately):
+  NB-1  Standards foundation (#43 + #45) — blocks NB-3
+  NB-2  Quick riders (#725 + #13)
+  NB-5  Comparison API (#90 + #99) — blocks NB-7
+  NB-9  Pure docs (#95 + #259)
+
+Wave B (after NB-1 merged):
+  NB-3  Entity attribute model (#30 + #28 + ADR-001 Amendment + Greece cohort seed)
+
+Wave C (after NB-3 merged; NB-5 and NB-6 independent):
+  NB-4  Investment climate state variables (#34)
+  NB-6  ESLint audit (#644)         ← can also run in Wave A if preferred
+  NB-7  Mode 1 spec (#451)          ← after NB-5 merged
+
+Wave D (after NB-5 + NB-6 + NB-7 all merged):
+  NB-8  DEFERRED TO M13
+
+→ G8 (Demo 4) after all NB groups complete
+```
+
+**Critical path through near-term backlog:** NB-1 → NB-3 → NB-4 (for entity model completeness); NB-5 → NB-7 (for comparison spec). G8 can proceed once all Wave A/B/C groups are merged. NB-8 does not block G8.
+
+---
+
+## Near-Term Backlog — Panel Decision Record
+
+**Session date:** 2026-06-06  
+**Status:** EL-endorsed  
+**Panels convened for three decision points identified during backlog analysis.**
+
+---
+
+### Decision Point DP-1: NB-1 (#43) — Tier 5 `uncertainty_range_pct`: numeric bound or null sentinel?
+
+**Panel:** Architect Agent · Data Architect Agent · QA Lead Agent · UX Designer Agent
+
+---
+
+**Architect Agent: REVIEW — #43 `uncertainty_range_pct` schema contract for Tier 5**
+
+The question is whether a numeric upper bound on `uncertainty_range_pct` for Tier 5 is semantically defensible. It is not. A Tier 5 gap-filled value is gap-filled precisely because the distribution is unknown. Writing `uncertainty_range_pct > 50%` into the standard claims we know the lower bound on our ignorance. We do not. That is a self-referential precision claim about uncertainty — and it violates the "No False Precision" founding principle more directly than the original under-specified standard.
+
+The correct schema contract: `uncertainty_range_pct: float | None`, where `None` is a first-class value meaning "distribution unknown; directional use only." This is architecturally clean: the field has a defined sentinel, every call site can branch on it, and the display layer has an unambiguous instruction. A null is not a missing value — it is a meaningful signal.
+
+Checking `simulation_state.yml` will show `confidence_tier` is already an integer 1–5 on `QuantitySchema`. The `uncertainty_range_pct` addition is additive; it should be `Optional[float]` with `None` as default, so existing Quantities that predate #43 are valid without migration.
+
+**Recommended amendment to #43:** Remove the `>50%` bound from Tier 5. Replace with: `None — distribution unknown; render as directional range, never as a value with an error bar.`
+
+---
+
+**Data Architect Agent: REVIEW — schema implications of nullable `uncertainty_range_pct` on Quantity**
+
+`QuantitySchema` in `simulation_state.yml` currently has: `confidence_tier: int`. Adding `uncertainty_range_pct: float | None` requires:
+
+1. `simulation_state.yml` updated with `uncertainty_range_pct: float | null` in the `QuantitySchema` block.
+2. `quantity_serde.py` (`quantity_to_schema` / `quantity_from_schema`) updated to serialize/deserialize the field — with `None` as default for backward compatibility.
+3. `database.yml` — `state_data` JSONB in `scenario_snapshots` does not need a column migration because `uncertainty_range_pct` lives inside the Quantity sub-object. But the key must be registered in the JSONB key table so future queries do not silently miss it.
+4. The `max()` confidence tier propagation rule in `DATA_STANDARDS.md` must be extended: when combining Quantities, `uncertainty_range_pct` aggregates as `None if any input is None, else max(values)` — because a Tier 5 input taints the composite's uncertainty to "distribution unknown" regardless of other inputs.
+
+All four schema files must be updated in the same PR as the standards documents. No exceptions. The name-collision pattern this prevents: a future query that treats `uncertainty_range_pct is None` as missing data rather than as the Tier 5 sentinel would silently produce wrong confidence bands.
+
+---
+
+**QA Lead Agent: VALIDATE — is `uncertainty_range_pct` as specified testable? Does null sentinel improve testability?**
+
+The entire motivation for #43 is testability. The current standard uses qualitative descriptors ("moderate reliability from established institutions") that no test can verify mechanically.
+
+With quantitative thresholds and a null sentinel, testability is clear:
+- `assert quantity.uncertainty_range_pct <= 0.05` for Tier 1 — passes or fails, no interpretation required
+- `assert quantity.uncertainty_range_pct is None` for Tier 5 — exact, unambiguous
+
+A numeric bound for Tier 5 (`> 50%`) would produce: `assert quantity.uncertainty_range_pct > 0.50`. This test passes for a value of `0.51` and also for `50.0` — neither tells you the distribution is actually unknown. The null sentinel produces the only test that correctly states the epistemic condition: "we do not have a numeric bound."
+
+Two test requirements to add to #43's acceptance criteria, beyond what is listed in the issue:
+- A Tier 5 Quantity with `uncertainty_range_pct is None` must cause any aggregation that includes it to propagate `None` (the taint rule the Data Architect described above).
+- A rendering test must assert that `uncertainty_range_pct is None` produces a "directional range" label, never a numeric confidence band.
+
+---
+
+**UX Designer Agent: REVIEW — display contract for null `uncertainty_range_pct` in Zone 1 trajectory view**
+
+This directly affects the trajectory curves in Zone 1A. Today the existing `confidence_tier`-based display already uses `strokeDasharray="8 3"` for confidence-degraded data (Tier 4/5, per G6b). But `strokeDasharray` alone is not enough if the confidence band is suppressed for Tier 5 — users need to know *why* there is no band, not just that the curve looks different.
+
+My ruling: when `uncertainty_range_pct is None`, Zone 1A must render:
+- No confidence band (no shaded fill around the curve)
+- A label annotation: "Directional only — uncertainty not quantified"
+- The `strokeDasharray="8 3"` pattern (already standard for Tier 4/5)
+
+This is a display contract, not an implementation detail. It must be written into `information-hierarchy.md §Zone 1A Confidence Display` as part of NB-1, so the implementation agent has a binding ruling rather than an interpretation problem.
+
+**The `information-hierarchy.md` update is in scope for NB-1** — otherwise the standard exists in DATA_STANDARDS.md with no UX contract, and the next frontend developer makes a rendering decision without authority.
+
+---
+
+**DP-1 Panel Recommendation (unanimous):**
+
+| Decision | Specifics |
+|---|---|
+| `uncertainty_range_pct` type | `float \| None` — `None` = distribution unknown |
+| Tier 1–4 | Numeric bounds as proposed in #43 issue body |
+| Tier 5 | `None` (remove `>50%` bound from issue body) |
+| Propagation rule | `None` taints any composite — any input `None` → composite `None` |
+| Display contract | `None` → "Directional only — uncertainty not quantified"; no confidence band; `strokeDasharray="8 3"` |
+| Schema files | `simulation_state.yml` + `database.yml` JSONB key registry updated in same PR |
+| `information-hierarchy.md` | Zone 1A confidence display ruling added in same NB-1 PR |
+
+---
+
+### Decision Point DP-2: NB-3 (#28) — Cohort stub with or without Greece seed data?
+
+**Panel:** Chief Methodologist Agent · Architect Agent
+
+---
+
+**Chief Methodologist: VALIDATE — methodological adequacy of a schema stub with no seeded cohort data**
+
+A type definition that is `None` in every entity is not a Human Cost Ledger capability. It is infrastructure for a future capability, and it must be represented honestly. The acceptance criteria for #28 say "at minimum one cohort-level attribute seeded for a test entity to validate the schema" — that requirement was written correctly and must not be weakened.
+
+The Greece 2010 data exists at the cohort level in published sources. Eurostat EU-SILC provides poverty headcount by income quintile for Greece at the national level. The values to use:
+
+| Cohort | Indicator | Value | Source | Confidence Tier |
+|---|---|---|---|---|
+| Bottom quintile (Q1) | poverty_headcount | 0.201 | Eurostat EU-SILC 2010 | Tier 2 |
+| Top quintile (Q5) | poverty_headcount | 0.065 | Eurostat EU-SILC 2010 | Tier 2 |
+| Bottom quintile (Q1) | unemployment_rate | 0.18 | Eurostat LFS 2010 | Tier 2 |
+
+This is sufficient to validate that the `CohortProfile` schema is correct, that the seeding pipeline handles cohort sub-entities, and that a future module can read cohort-level attributes from the state snapshot. The MDA thresholds already reference "bottom quintile" as a cohort scope — without a seeded value at that cohort level, the MDA system is testing a code path that will never fire in backtesting.
+
+**The minimum viable seed is two cohort profiles on the Greece entity — Q1 and Q5 poverty headcount, Tier 2.** Not a synthetic approximation; the data exists and is Tier 2.
+
+---
+
+**Architect Agent: REVIEW — storage and API surface for CohortProfile in SimulationEntity**
+
+Two architectural questions for #28:
+
+**1. Where does `CohortProfile` live in the storage model?**
+
+It must live inside the `state_data` JSONB envelope in `scenario_snapshots`, not as a separate column. The `SimulationEntity.attributes` dict already maps `str → Quantity`. `cohort_profiles` should be a parallel optional dict: `cohort_profiles: dict[str, CohortProfile] | None = None`, where the key is the cohort identifier (e.g., `"Q1"`, `"Q5"`, `"youth_15_24"`) and `CohortProfile` is a typed container with its own `attributes: dict[str, Quantity]`.
+
+This is consistent with how `SimulationEntity.attributes` works today and requires no DB migration — the JSONB envelope already accepts arbitrary sub-structure.
+
+**2. Does this require an ADR?**
+
+#28's acceptance criteria say "ADR updated or new ADR drafted: cohort disaggregation architecture." Looking at existing ADRs: ADR-001 defines the entity model, ADR-005 defines multi-framework measurement. Neither covers cohort sub-entities explicitly. An **ADR-001 Amendment** is the right vehicle — the cohort profile is an extension of the entity model, not a new architectural decision. The amendment must document: (a) `CohortProfile` as the cohort-level entity sub-structure, (b) the key convention (`"Q1"` through `"Q5"` for income quintiles, `"youth_15_24"` for age bands), (c) the rule that cohort `confidence_tier` inherits from its source data and is tracked independently from the parent entity's aggregate tier.
+
+This amendment is lightweight but mandatory per CLAUDE.md §ADR policy. It ships in the same PR as NB-3 implementation — not as a follow-up.
+
+**Boundary condition:** all new fields must be `Optional` with `None` defaults. Existing seed scripts must continue to work without modification. Only the Greece seed script is updated to populate two `CohortProfile` entries; all other entity seed scripts produce `cohort_profiles=None`.
+
+---
+
+**DP-2 Panel Recommendation (unanimous):**
+
+| Decision | Specifics |
+|---|---|
+| Cohort seed | Greece entity: Q1 + Q5 poverty_headcount (Eurostat EU-SILC 2010, Tier 2) + Q1 unemployment_rate (Eurostat LFS 2010, Tier 2) |
+| Storage model | `state_data` JSONB sub-key; `cohort_profiles: dict[str, CohortProfile] \| None = None` on `SimulationEntity`; no new DB column; no schema migration |
+| ADR | ADR-001 Amendment in same NB-3 PR — documents CohortProfile structure, key convention, confidence_tier inheritance rule |
+| Schema file | `simulation_state.yml` updated with `CohortProfile` sub-schema in same PR |
+| Minimum test gate | Assert that `GRC.cohort_profiles["Q1"].attributes["poverty_headcount"]` returns a Quantity with `value ≈ 0.201` and `confidence_tier == 2` |
+
+---
+
+### Decision Point DP-3: NB-8 (#394) — Multi-scenario comparison (>2): before or after G8 (Demo 4)?
+
+**Panel:** PM Agent · Business PO Agent · UX Designer Agent · Customer Agent
+
+---
+
+**PM Agent: FOCUS — sequencing #394 relative to G8 Demo 4**
+
+Reading the Demo 4 acceptance gates in full:
+
+> Jordan fixture seeds cleanly; synthetic indicators flagged  
+> Hormuz scenario advances 8 steps without hitting irreversible thresholds before step 4  
+> Mode 3 parameter adjustment demonstrably changes the trajectory  
+> Human cost indicators show non-zero response to commodity shock within 2 steps  
+> Demo runs end-to-end on ProBook within performance budget  
+> Narration document reviewed against NARRATION-RULING-1  
+> IR stakeholder review artifact in `docs/demo/m12/reviews/`
+
+Zero mention of N>2 scenario comparison. The Demo 4 value proposition is Mode 3 active control under Hormuz crisis conditions — branching from a baseline and demonstrating that the human cost trajectory diverges with intervention vs. without. That is a two-scenario comparison (baseline + branch), which G6b already delivers.
+
+The sprint plan explicitly tags #394 as "treat as Wave 3 if capacity allows." With the near-term backlog consuming Wave 3 capacity, there is no slack for #394 before G8 without risk of delay. The sequencing cost of #394 is not just its own implementation — it includes the UX ruling that must precede it and the Customer Agent AUDIT that must gate it. Those are two additional sequential steps before a line of implementation code is written.
+
+**PM position: #394 defers to M13. It is the anchor issue for M13's comparison mode track.**
+
+---
+
+**Business PO Agent: PRIORITIZE — user-value impact of #394 deferral to M13**
+
+TC-3 (Kenya budget planning — three competing proposals) is a legitimate and important marquee case. It serves Persona 1 (Lucas Ferreira — the programme analyst who needs to run sensitivity analysis across three fiscal consolidation paths).
+
+But Demo 4 serves Persona 5 (Aicha Mbaye — Institutional Decision-Maker) and Persona 2 (Eleni Papadimitriou — Finance Ministry Negotiator). These are the two personas with the most urgent near-term adoption pathway — they are the target of the Demo 4 stakeholder session. Persona 1 is better served after the platform has proven its value to Persona 5, because institutional adoption flows from the top down.
+
+The value proposition for Demo 4 is: a finance minister under crisis conditions can use WorldSim to understand whether a policy intervention changes the human cost trajectory within the time available for a cabinet decision. #394 adds nothing to that demonstration. Its deferral to M13 does not degrade a single Demo 4 acceptance gate.
+
+**PO position: Defer #394 to M13. Priority in M12 near-term is the spec (#451), not the implementation.**
+
+---
+
+**UX Designer Agent: REVIEW — can #394 ship without a UX ruling?**
+
+No. N>2 comparison is a qualitatively different surface from two-scenario comparison. The information hierarchy has no ruling for it. `information-hierarchy.md §COMPARE_VIEW` specifies Mode 2 comparison for two scenarios (single-entity and multi-entity). Three or more concurrent trajectories in Zone 1A — with distinct line styles, a three-item legend, and per-scenario MDA panels — requires:
+
+1. A zone hierarchy ruling: does each scenario get its own Zone 1B panel, or does a unified comparative panel replace them?
+2. A color/style vocabulary ruling: Mode 3 already uses ghost baseline (`strokeDasharray="4 2"`) and G6b uses confidence-degraded dashes (`"8 3"`). N>2 needs a third visual register that does not collide with either.
+3. A cognitive load ruling: at what N does the trajectory view stop serving comprehension and start producing noise? Three is probably acceptable; five may not be.
+
+None of these rulings exist. #451 produces the spec for Mode 1 two-scenario comparison — it does not produce N>2 rulings. #394 cannot begin implementation until I produce those rulings, and I cannot produce them without the N>2 UX research that the M11.5 sessions began to surface.
+
+**UX position: #394 implementation must not begin in M12. #451 (Mode 1 spec) ships in M12 as a prerequisite. N>2 UX ruling is M13 pre-implementation work for #394.**
+
+---
+
+**Customer Agent: AUDIT — Layer 3 legibility risk of N>2 scenario comparison for Persona 2 and Persona 5**
+
+Applying the 90-second retrieval gate to N=3 concurrent scenario comparison:
+
+Persona 2 (Eleni, Finance Ministry Negotiator, Reactive entry state): She has 90 seconds and needs one finding. Three concurrent trajectory curves with three legends and three MDA panels will exceed the cognitive processing budget for a Reactive entry state user. She will not be able to determine which of the three curves is the "better" option without analyst mediation. This fails the gate.
+
+The N>2 surface is viable only if the design answers "which scenario wins?" without requiring the user to trace three curves, read three legends, and cross-reference three alert panels. That design does not exist yet. The M11.5 usability sessions showed that even two-scenario comparison with explicit labeling caused orientation failures for Persona 2 (S003-FINDING-01: non-interactive alerts; FINDING-03: no cohort visibility). Adding a third scenario without solving the two-scenario orientation problem would compound the failure.
+
+**Customer Agent position: A Layer 3 AUDIT is a required gate on #394 before implementation — not after. This cannot be skipped. The audit requires a prototype or a spec detailed enough to evaluate zone load; neither exists today.**
+
+---
+
+**DP-3 Panel Recommendation (unanimous):**
+
+| Decision | Specifics |
+|---|---|
+| #394 in M12 | Deferred — no implementation this milestone |
+| #394 in M13 | First item on M13 board; requires three gates before implementation: (1) #451 spec accepted, (2) UX Designer N>2 ruling issued, (3) Customer Agent AUDIT complete for Persona 2 and Persona 5 |
+| #451 in M12 | Ships as planned (NB-7) — UX spec + backend design decision + one Andreas Stefanidis user story. Not an implementation PR |
+| Demo 4 impact | Zero — #394 appears in no Demo 4 acceptance gate |
+
+---
+
+### EL Endorsement
+
+**Engineering Lead:** @PublicEnemage  
+**Endorsement date:** 2026-06-06  
+**Form:** Verbal in-session endorsement of all three panel recommendations
+
+| DP | Question | Panel verdict | EL decision |
+|---|---|---|---|
+| DP-1a | Tier 5 `uncertainty_range_pct` — null or numeric? | Unanimous: null sentinel | **Adopted** — `float \| None`; `None` = distribution unknown |
+| DP-1b | Display contract for null `uncertainty_range_pct`? | Unanimous: binding ruling required | **Adopted** — "Directional only" label + no confidence band; added to `information-hierarchy.md` in NB-1 PR |
+| DP-1c | Propagation rule for `uncertainty_range_pct`? | Unanimous: null taints | **Adopted** — any input `None` → composite `None` |
+| DP-2a | Greece cohort seed — real data or empty stub? | Unanimous: real data required | **Adopted** — EU-SILC Q1/Q5 poverty headcount + Q1 unemployment, Tier 2; stub alone is not acceptable |
+| DP-2b | Storage model for `CohortProfile`? | Unanimous: JSONB sub-key | **Adopted** — `state_data` JSONB; no new DB column; no migration |
+| DP-2c | ADR required for #28? | Unanimous: ADR-001 Amendment | **Adopted** — ships in same NB-3 PR |
+| DP-3 | #394 before or after G8? | Unanimous: defer to M13 | **Adopted** — #451 spec ships M12; #394 implementation is M13 with three stated gates |
+
+All decisions are binding. The NB-1 implementation agent must implement the null-sentinel clause and `information-hierarchy.md` ruling before implementation begins. The NB-3 implementation agent must seed Greece cohort data and include ADR-001 Amendment in the same PR. #394 implementation is blocked until all three M13 gates are met.
 
 ---
 


### PR DESCRIPTION
Adds the NB-1 through NB-9 execution plan and the full DP-1/DP-2/DP-3 panel decision record to the M12 sprint plan. All three decisions EL-endorsed in-session 2026-06-06. Sprint plan only — no code changes.