### PR TITLE
docs(standards): Tier 5 null sentinel — uncertainty_range_pct, HCL standards, Zone 1A ruling

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -2296,3 +2296,39 @@ def test_no_sensitive_source_has_committed_url() -> None:
 ```
 
 This test runs in CI after every commit that touches the source registry.
+
+---
+
+## Human Development Indicator Standards
+
+Every module that emits a Human Cost Ledger (HCL) output must include these
+five fields on each record:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `indicator_key` | `str` | Unique indicator identifier (e.g. `"hdi"`, `"gini"`) |
+| `value` | `Decimal` | Computed value |
+| `unit` | `str` | Unit string (e.g. `"index"`, `"ratio"`, `"years"`) |
+| `cohort_id` | `str \| None` | Demographic cohort this indicator applies to; `None` = aggregate |
+| `confidence_tier` | `int` | 1–5 per the Confidence Tier System |
+
+### Effect Size Thresholds
+
+HCL outputs must report effect size relative to baseline. A change is
+**material** when the absolute delta exceeds these thresholds:
+
+| Indicator class | Materiality threshold |
+|---|---|
+| Index indicators (HDI, GINI) | ≥ 0.02 (2 index points) |
+| Ratio indicators (mortality rate, literacy rate) | ≥ 0.005 (0.5 percentage points) |
+| Year-based indicators (life expectancy, schooling) | ≥ 0.1 years |
+| Population counts | ≥ 1 % of reference population |
+
+### HCL Test Requirements
+
+Every module that writes HCL outputs must have tests that verify:
+
+1. All five required fields are present on every HCL record.
+2. `confidence_tier` matches the source tier of the input data.
+3. At least one cohort-disaggregated record is produced when cohort data is available.
+4. Effect size thresholds are correctly computed (delta vs. baseline step).

--- a/docs/DATA_STANDARDS.md
+++ b/docs/DATA_STANDARDS.md
@@ -817,7 +817,28 @@ Confidence intervals in simulation outputs widen as input data tier decreases.
 This relationship is quantified, not qualitative — a Tier 4 input produces
 wider output uncertainty bands than a Tier 2 input by a documented multiplier.
 
+The `uncertainty_range_pct` field on `Quantity` (type `float | None`) encodes
+this relationship as a machine-readable bound. The lookup table below is the
+authoritative mapping:
+
+| Tier | `uncertainty_range_pct` bound | Display label |
+|------|-------------------------------|---------------|
+| 1 | ≤ 5 % | High confidence |
+| 2 | ≤ 15 % | Moderate confidence |
+| 3 | ≤ 30 % | Research estimate |
+| 4 | ≤ 50 % | Model estimate |
+| 5 | `None` (distribution unknown) | Directional only |
+
+### Propagation Taint Rule
+
+If any input Quantity has `uncertainty_range_pct = None`, the composite output
+also has `uncertainty_range_pct = None`. A None value taints all downstream
+computations. The taint propagates until a new Tier 1–4 source overrides the
+field.
+
 ### Tier 1 — Primary Official Statistics
+
+**Quantitative bound:** uncertainty_range_pct ≤ 5 %
 
 **Definition:** Directly measured data published by authoritative primary
 sources with published methodology.
@@ -833,6 +854,8 @@ finalized and audited.
 
 ### Tier 2 — Derived Official Statistics
 
+**Quantitative bound:** uncertainty_range_pct ≤ 15 %
+
 **Definition:** Calculated from Tier 1 sources by reputable institutions
 using documented, reproducible methodology.
 
@@ -847,6 +870,8 @@ were combined, how.
 
 ### Tier 3 — Research Estimates
 
+**Quantitative bound:** uncertainty_range_pct ≤ 30 %
+
 **Definition:** Published estimates from peer-reviewed academic sources or
 major research institutions with documented methodology and uncertainty ranges.
 
@@ -856,6 +881,8 @@ analysis, GDELT project coded events, Uppsala Conflict Data Program.
 **Weight in simulation:** Weighted by stated uncertainty. Flagged in outputs.
 
 ### Tier 4 — Model Estimates
+
+**Quantitative bound:** uncertainty_range_pct ≤ 50 %
 
 **Definition:** Values produced by other simulation models, including
 WorldSim's own projections. Forward projections. Extrapolations beyond
@@ -870,6 +897,8 @@ and user notification. This prevents circular reasoning from being laundered
 through the tool.
 
 ### Tier 5 — Gap-Filled Values
+
+**Quantitative bound:** uncertainty_range_pct = None — distribution unknown, directional output only
 
 **Definition:** Values produced by interpolation, extrapolation, or regional
 averaging where no source data exists.

--- a/docs/ux/information-hierarchy.md
+++ b/docs/ux/information-hierarchy.md
@@ -348,6 +348,25 @@ The DeltaChoropleth has no role in Mode 3 comparisons. The comparison in
 active control is always temporal (baseline trajectory vs. live modified
 trajectory), not geographic.
 
+### Zone 1A — Confidence Display
+
+**Binding ruling (DP-1, 2026-06-06):** The confidence band displayed in Zone 1A
+is derived from `uncertainty_range_pct` on the composite Quantity. Rendering rules:
+
+| `uncertainty_range_pct` | Band rendered | Label |
+|---|---|---|
+| ≤ 5 % (Tier 1) | Full opacity confidence band | High confidence |
+| ≤ 15 % (Tier 2) | Full opacity confidence band | Moderate confidence |
+| ≤ 30 % (Tier 3) | Reduced opacity confidence band | Research estimate |
+| ≤ 50 % (Tier 4) | Reduced opacity confidence band | Model estimate |
+| `None` (Tier 5) | **No confidence band rendered** | Directional only — uncertainty not quantified |
+
+When `uncertainty_range_pct = None`:
+- No confidence band is rendered.
+- The trajectory line is rendered with `strokeDasharray="8 3"` (dashed).
+- The label "Directional only — uncertainty not quantified" appears in Zone 1A.
+- The trajectory remains visible (not hidden) — directional information is preserved.
+
 ---
 
 ## Control Plane Reserved Zone


### PR DESCRIPTION
## Summary

- **`docs/DATA_STANDARDS.md`** — adds `uncertainty_range_pct` lookup table to the Data Quality Tier System, documents the Propagation Taint Rule (None taints all downstream composites), and inserts a **Quantitative bound:** line into each of the five tier definitions (closes #43).
- **`docs/CODING_STANDARDS.md`** — adds the **Human Development Indicator Standards** section: five required HCL output fields, effect size materiality thresholds by indicator class, and HCL test requirements (closes #45).
- **`docs/ux/information-hierarchy.md`** — adds **Zone 1A — Confidence Display** subsection in the COMPARE_VIEW block, capturing the DP-1 binding ruling (2026-06-06): rendering rules for confidence bands derived from `uncertainty_range_pct`, including the dashed-line treatment and label when the value is `None`.

Closes #43
Closes #45

## Test plan

- [ ] Verify `uncertainty_range_pct` lookup table renders correctly in the DATA_STANDARDS.md Tier System section.
- [ ] Verify all five tier definitions now include a **Quantitative bound:** line.
- [ ] Verify Propagation Taint Rule section appears after the lookup table.
- [ ] Verify HCL Standards section appears at end of CODING_STANDARDS.md with all four subsections (field table, effect size thresholds, test requirements).
- [ ] Verify Zone 1A — Confidence Display subsection appears in information-hierarchy.md COMPARE_VIEW block, before Control Plane Reserved Zone.
- [ ] No Python or TypeScript files modified — no pre-push gates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)