### PR TITLE
docs(process): ecological backtesting cases plan + legibility metrics

### DIFF
--- a/docs/backtesting/ecological-backtesting-cases.md
+++ b/docs/backtesting/ecological-backtesting-cases.md
@@ -1,0 +1,362 @@
+# Ecological Backtesting Case Planning
+
+> **Status:** Planning document — implementation deferred to post-M12 sprint (see Issue #95)
+> **Origin:** ARCH-REVIEW-002 Finding BI2-N-04 (Ecological Economist Agent)
+> **Purpose:** Define candidate historical cases where ecological dynamics are central
+> and well-documented, so that the ecological framework has testable fidelity thresholds
+> in at least one backtesting run before the framework is considered validated.
+> **Related ADR:** ADR-005 (Ecological Module); `docs/architecture/reviews/ARCH-REVIEW-002-milestone2.md`
+
+---
+
+## Why This Document Exists
+
+The Greece 2010–2012 backtesting case — the first empirical validation of WorldSim —
+tests only financial indicators. No ecological attributes appear in the initial state
+fixture, and no ecological fidelity thresholds appear in `backtesting_runs`. The
+risk identified in ARCH-REVIEW-002 (Finding BI2-N-04) is that a backtesting case
+template without ecological dimensions produces descendants without ecological
+dimensions. The ecological framework remains perpetually unvalidated by default.
+
+This document identifies three candidate cases and specifies — for each — the data
+sources, initial state ecological attributes, fidelity thresholds, and ControlInput
+sequence that would constitute a well-formed ecological backtesting case. One of
+these cases must be implemented as an ecological validation run before the
+simulation's backtesting suite can be described as multi-framework.
+
+---
+
+## Case 1 — Brazil Amazon Deforestation and GDP Impact (2000–2010)
+
+### Geography
+
+| Field | Value |
+|---|---|
+| Entity | Brazil |
+| ISO alpha-3 | BRA |
+| Level | Nation-state (Level 1) |
+| Subnational notes | Deforestation concentrated in Pará, Mato Grosso, Rondônia states; not representable at Level 1 — documented limitation |
+
+### Time Period
+
+**Start:** 2000
+**End:** 2010
+**Timestep:** Annual
+**Steps:** 10
+**Crisis threshold:** Peak deforestation rate in 2004 (~27,000 km²/year); Policy Action Plan for the Prevention and Control of Deforestation in the Legal Amazon (PPCDAm) enacted 2004.
+
+### Rationale for Case Selection
+
+The 2000–2010 period contains a measurable policy intervention (PPCDAm 2004) with
+a documented deforestation response: annual deforestation fell from ~27,000 km² in
+2004 to ~7,000 km² by 2010. GDP continued to grow across the same period. The case
+provides a ControlInput sequence (deforestation regulation policy) with an ecological
+outcome that moved in the expected direction on a documented timeline. The
+agricultural and timber-sector economic feedback loops are partially documented.
+The case is long enough (10 steps) to give the backtesting validation statistical
+credibility beyond the 2-step Greece case.
+
+### Initial State Parameters (Year 2000)
+
+| Attribute | Value | Source | Tier |
+|---|---|---|---|
+| `gdp_growth` | 4.4% (2000) | World Bank WDI | Tier 1 |
+| `debt_gdp_ratio` | 65.0% (2000) | IMF WEO | Tier 1 |
+| `land_use_pressure_index` | 0.72 (estimated from FRA 2000 forest cover vs. safe land-system boundary) | FAO Global Forest Resources Assessment (FRA 2000) | Tier 3 (5-year data; annual interpolation required) |
+| `co2_trajectory` | 1.03 Gt CO2/year (2000, land-use change component) | Global Carbon Project CO2 Budget | Tier 1 |
+| `co2_concentration_ppm` | 369.5 ppm (2000 global atmospheric) | NASA/NOAA Mauna Loa | Tier 1 |
+| `deforestation_rate_km2_yr` | ~19,800 km²/year (2000) | FAO FRA 2000 / INPE PRODES | Tier 2 |
+| `agricultural_gdp_share` | 5.6% of GDP (2000) | World Bank WDI | Tier 1 |
+| `poverty_headcount_ratio` | 31.6% (2001, $5.50/day line) | World Bank PovcalNet | Tier 2 |
+
+**Confidence tier note:** `land_use_pressure_index` is Tier 3 because FAO FRA data
+is published on 5-year cycles. Annual interpolation between FRA 1990, 2000, and 2005
+data points introduces synthetic data uncertainty per `docs/DATA_STANDARDS.md §Confidence Tier System`.
+The synthetic interpolation must be flagged at indicator level, not session level.
+
+### Data Sources
+
+| Source | Category | License | Access |
+|---|---|---|---|
+| FAO Global Forest Resources Assessment (FRA 2000, 2005, 2010) | Ecological | CC BY-NC-SA 3.0 IGO | https://www.fao.org/forest-resources-assessment/en/ |
+| Global Carbon Project — CO2 Budget Data | Ecological | CC BY 4.0 | https://globalcarbonproject.org/carbonbudget/ |
+| NASA/NOAA Mauna Loa CO2 Measurements | Ecological | Public domain (US Gov) | NOAA GML API |
+| Stockholm Resilience Centre Planetary Boundary Calibrations | Ecological | CC BY 4.0 | DOI 10.1126/science.abn2458 |
+| World Bank WDI | Economic | CC BY 4.0 | https://data.worldbank.org/ |
+| IMF World Economic Outlook | Economic | CC BY 4.0 | https://www.imf.org/en/Publications/WEO |
+| INPE PRODES deforestation monitoring | Ecological | Public (Brazil gov) | http://www.obt.inpe.br/OBT/assuntos/programas/amazonia/prodes |
+
+All sources above are registered in the `source_registry` or are candidates for
+registration before data is loaded. INPE PRODES is not yet in `docs/data-sources/approved-sources.md`
+and requires registration before use.
+
+### ControlInput Sequence
+
+| Step (Year) | Input type | Input | Actor |
+|---|---|---|---|
+| 5 (2004) | `StructuralPolicyInput` | `REGULATORY_CHANGE` — PPCDAm policy activation; deforestation monitoring system, enforcement increase | BRA Ministry of Environment |
+| 6 (2005) | `StructuralPolicyInput` | `REGULATORY_CHANGE` — expanded monitoring, Soy Moratorium negotiation | BRA / Industry |
+| 7 (2006) | `StructuralPolicyInput` | `REGULATORY_CHANGE` — Soy Moratorium enacted; cattle ranching embargo added | BRA / Industry |
+
+**Conditionality note:** PPCDAm was a sovereign Brazilian policy, not externally
+coerced. `InputSource` should be recorded as `DOMESTIC_POLICY`, not
+`EXTERNAL_PRESSURE`.
+
+### Fidelity Thresholds
+
+| Step | Attribute | Direction | Threshold type | Calibration tier | Historical basis |
+|---|---|---|---|---|---|
+| 5 (2004) | `deforestation_rate_km2_yr` | UP (peak before policy) | DIRECTION_ONLY | Tier 3 | INPE PRODES; peak ~27,000 km² |
+| 6 (2005) | `deforestation_rate_km2_yr` | DOWN (policy response begins) | DIRECTION_ONLY | Tier 3 | INPE PRODES; drop begins 2005 |
+| 10 (2010) | `deforestation_rate_km2_yr` | DOWN (vs. 2000 baseline) | MAGNITUDE ±40% | Tier 3 | INPE PRODES; ~7,000 km² by 2010 |
+| 10 (2010) | `co2_trajectory` | DOWN (vs. 2004 peak) | DIRECTION_ONLY | Tier 2 | Global Carbon Project; LUC emissions fell with deforestation |
+| 10 (2010) | `gdp_growth` | UP | DIRECTION_ONLY | Tier 1 | World Bank WDI; Brazil maintained positive growth throughout |
+
+**Statistical validity note:** 10 steps, 5 thresholds. This provides substantially
+stronger statistical validation than the 2-step Greece case (see ARCH-REVIEW-002
+Finding BI2-N-12 / Chief Methodologist). DIRECTION_ONLY thresholds on a 10-year
+series with known policy inflection have a false-positive probability significantly
+below 25%.
+
+### Evaluation Criteria
+
+1. Simulation produces increasing `deforestation_rate_km2_yr` at step 5 (pre-policy peak)
+2. Simulation produces decreasing `deforestation_rate_km2_yr` at steps 6–10 following ControlInput
+3. Simulation `co2_trajectory` falls proportionally with deforestation rate reduction
+4. GDP growth remains positive (>0%) across all 10 steps
+5. `land_use_pressure_index` trends down from year 5 onward
+6. No MDA (Minimum Descent Altitude) breach on `land_use_pressure_index` during the run
+7. Backtesting pass/fail determination: 4 of 5 fidelity thresholds must be met (80% pass threshold)
+
+---
+
+## Case 2 — Ethiopia Drought and Food Security Crisis (2002–2004)
+
+### Geography
+
+| Field | Value |
+|---|---|
+| Entity | Ethiopia |
+| ISO alpha-3 | ETH |
+| Level | Nation-state (Level 1) |
+| Subnational notes | Drought most severe in Tigray, Afar, SNNPR; Level 1 averaging masks subnational distribution — documented limitation |
+
+### Time Period
+
+**Start:** 2002
+**End:** 2004
+**Timestep:** Annual
+**Steps:** 3
+**Crisis threshold:** 2002–2003 drought affecting approximately 14 million people, requiring emergency food assistance.
+
+### Rationale for Case Selection
+
+The 2002–2004 Ethiopian drought provides a case where an ecological exogenous shock
+(rainfall deficit) generates documented fiscal, human development, and governance
+consequences on a short, well-bounded timeline. The case tests the simulation's
+ability to model ecological-shock-to-economic-impact transmission. It also requires
+humanitarian aid ControlInputs from external actors — testing the `EXTERNAL_PRESSURE`
+/ multilateral response pathway. The case is deliberately short (3 steps) so that
+it can be implemented as a minimal ecological validation run even with limited
+data availability.
+
+### Initial State Parameters (Year 2002)
+
+| Attribute | Value | Source | Tier |
+|---|---|---|---|
+| `gdp_growth` | 1.6% (2002) | World Bank WDI | Tier 1 |
+| `agricultural_gdp_share` | 47.0% of GDP (2002) | World Bank WDI | Tier 1 |
+| `poverty_headcount_ratio` | 55.3% ($1.90/day, 2000 base year) | World Bank PovcalNet | Tier 2 |
+| `rainfall_anomaly_pct` | −35% vs. 1980–2000 mean (2002 Belg season failure) | ERA5 Reanalysis (Copernicus) | Tier 1 |
+| `food_production_index` | 82 (FAO FPI, 2002; 2014–2016 = 100 baseline) | FAO FAOSTAT | Tier 2 |
+| `aid_dependency_ratio` | 14.8% of GNI (2002) | World Bank WDI | Tier 1 |
+| `co2_concentration_ppm` | 373.2 ppm (2002 global) | NASA/NOAA Mauna Loa | Tier 1 |
+
+**Data availability note:** Ethiopia 2002 subnational food security data is sparse.
+`rainfall_anomaly_pct` uses ERA5 Reanalysis as the primary source; country-level
+averaging masks subnational severity. All sub-national variability is treated as
+Tier 3 synthetic data with scenario bands per the Synthetic Data Framework.
+
+### Data Sources
+
+| Source | Category | License | Access |
+|---|---|---|---|
+| ERA5 Reanalysis (Copernicus) | Climate | Copernicus License (free for research) | https://cds.climate.copernicus.eu/ |
+| FAO FAOSTAT food production index | Economic/Ecological | CC BY-NC-SA 3.0 IGO | https://www.fao.org/faostat/ |
+| World Bank WDI | Economic | CC BY 4.0 | https://data.worldbank.org/ |
+| NASA/NOAA Mauna Loa CO2 | Ecological | Public domain (US Gov) | NOAA GML API |
+| WHO Global Health Observatory | Health | CC BY-NC-SA 3.0 IGO | https://www.who.int/data/gho |
+| NOAA Climate Data Online | Climate | Public domain (US Gov) | https://www.ncdc.noaa.gov/cdo-web/ |
+
+### ControlInput Sequence
+
+| Step (Year) | Input type | Input | Actor |
+|---|---|---|---|
+| 1 (2002) | `EmergencyPolicyInput` | `EMERGENCY_DECLARATION` — drought emergency, international appeal | ETH Government |
+| 2 (2003) | `FiscalPolicyInput` | External humanitarian aid disbursement (World Food Programme, USAID OFDA, EU) | WFP / Multilateral |
+| 3 (2004) | `StructuralPolicyInput` | `REGULATORY_CHANGE` — Productive Safety Net Programme initiation | ETH Government / World Bank |
+
+**Actor note:** Step 2 involves external actors (WFP, USAID) delivering aid. The
+`actor_id` should reference external entity IDs where they exist in the simulation
+database. The `InputSource` for step 2 should be `EXTERNAL_HUMANITARIAN` (a new
+enum value that does not currently exist — see Implementation Note below).
+
+**Implementation note:** `EXTERNAL_HUMANITARIAN` does not yet exist in the
+`InputSource` enum. The implementing team must either add it or use the closest
+existing value and document the limitation. This is a known schema gap for
+humanitarian-actor ControlInputs.
+
+### Fidelity Thresholds
+
+| Step | Attribute | Direction | Threshold type | Calibration tier | Historical basis |
+|---|---|---|---|---|---|
+| 1 (2002) | `gdp_growth` | DOWN (drought shock) | DIRECTION_ONLY | Tier 1 | World Bank WDI; GDP growth fell to 1.6% |
+| 2 (2003) | `food_production_index` | DOWN (continued drought) | DIRECTION_ONLY | Tier 2 | FAO FPI; continued food production deficit |
+| 3 (2004) | `gdp_growth` | UP (recovery begins) | DIRECTION_ONLY | Tier 1 | World Bank WDI; 13.6% GDP growth in 2004 recovery |
+| 3 (2004) | `food_production_index` | UP (recovery with PSNP) | DIRECTION_ONLY | Tier 2 | FAO FPI; production recovery with safety net |
+
+### Evaluation Criteria
+
+1. Simulation `gdp_growth` falls at step 1 (drought shock)
+2. Simulation `food_production_index` falls at step 2 (continued shock)
+3. Simulation shows economic recovery at step 3 following humanitarian aid ControlInput
+4. `food_production_index` rises at step 3 following PSNP structural input
+5. Poverty headcount ratio does not fall during steps 1–2 (drought worsens poverty before recovery)
+6. Backtesting pass/fail: 3 of 4 thresholds must be met (75% pass threshold, reflecting data quality constraints)
+
+---
+
+## Case 3 — Philippines Typhoon Haiyan Economic Impact and Recovery (2013–2015)
+
+### Geography
+
+| Field | Value |
+|---|---|
+| Entity | Philippines |
+| ISO alpha-3 | PHL |
+| Level | Nation-state (Level 1) |
+| Subnational notes | Haiyan impact concentrated in Region VIII (Eastern Visayas), Region VI (Western Visayas); Level 1 dilutes impact severity — documented limitation |
+
+### Time Period
+
+**Start:** 2013
+**End:** 2015
+**Timestep:** Annual
+**Steps:** 3
+**Event:** Typhoon Haiyan landfall November 8, 2013; classified as one of the strongest tropical cyclones ever recorded.
+
+### Rationale for Case Selection
+
+Typhoon Haiyan (2013) provides a sudden-onset ecological shock — distinct from the
+gradual deforestation and drought cases above — with well-documented immediate
+economic damage ($12.9 billion estimated damage) and a documented international
+humanitarian response. The Philippines case tests the simulation's response to
+a high-magnitude, one-step shock followed by reconstruction ControlInputs. It
+also tests whether the ecological-economic transmission pathway works for
+disaster-type events, not just slow-accumulation ecological pressures. The
+3-step timeline is short but the shock magnitude and data quality make it
+tractable.
+
+### Initial State Parameters (Year 2013)
+
+| Attribute | Value | Source | Tier |
+|---|---|---|---|
+| `gdp_growth` | 7.2% (2013, pre-Haiyan full year) | World Bank WDI | Tier 1 |
+| `debt_gdp_ratio` | 36.4% (2013) | IMF WEO | Tier 1 |
+| `disaster_damage_gdp_pct` | 4.3% of GDP (Haiyan damage estimate; mid-range of $12.9B) | World Bank PDNA 2013 | Tier 2 |
+| `agricultural_gdp_share` | 10.1% of GDP (2013) | World Bank WDI | Tier 1 |
+| `poverty_headcount_ratio` | 25.2% ($3.20/day, 2012 base) | World Bank PovcalNet | Tier 2 |
+| `co2_concentration_ppm` | 396.5 ppm (2013 global) | NASA/NOAA Mauna Loa | Tier 1 |
+| `rainfall_anomaly_pct` | Not applicable for typhoon case — see note | ERA5 | — |
+
+**Rainfall note:** Typhoon Haiyan is a discrete extreme weather event, not a
+rainfall anomaly. The triggering ecological condition is best encoded as a
+`disaster_damage_gdp_pct` STOCK shock at step 1, not as a continuous `rainfall_anomaly_pct`
+flow. The implementing team must confirm the appropriate Quantity type and attribute
+key before writing the initial state fixture.
+
+### Data Sources
+
+| Source | Category | License | Access |
+|---|---|---|---|
+| World Bank Post-Disaster Needs Assessment (PDNA) 2013 | Economic/Damage | Public (World Bank) | https://www.worldbank.org/ |
+| ERA5 Reanalysis (Copernicus) | Climate | Copernicus License | https://cds.climate.copernicus.eu/ |
+| NOAA Climate Data Online | Climate | Public domain (US Gov) | https://www.ncdc.noaa.gov/cdo-web/ |
+| World Bank WDI | Economic | CC BY 4.0 | https://data.worldbank.org/ |
+| IMF WEO | Economic | CC BY 4.0 | https://www.imf.org/en/Publications/WEO |
+| OCHA Financial Tracking Service | Humanitarian | Public (UN) | https://fts.unocha.org/ |
+| NASA/NOAA Mauna Loa CO2 | Ecological | Public domain | NOAA GML API |
+
+### ControlInput Sequence
+
+| Step (Year) | Input type | Input | Actor |
+|---|---|---|---|
+| 1 (2013) | `EmergencyPolicyInput` | `EMERGENCY_DECLARATION` — national disaster declaration; state of calamity | PHL Government |
+| 1 (2013) | `FiscalPolicyInput` | `SPENDING_CHANGE` — emergency reconstruction appropriation (PHP 14.6B Yolanda Fund) | PHL Government |
+| 2 (2014) | `FiscalPolicyInput` | `SPENDING_CHANGE` — international aid disbursement ($788M ODA per OCHA FTS) | Multilateral / Bilateral |
+| 2 (2014) | `StructuralPolicyInput` | `REGULATORY_CHANGE` — Comprehensive Rehabilitation and Recovery Plan (CRRP) | PHL Government |
+
+**Actor note:** Step 2 international aid uses `actor_id` for donor entities where
+available. Same `EXTERNAL_HUMANITARIAN` InputSource gap applies as in Case 2.
+
+### Fidelity Thresholds
+
+| Step | Attribute | Direction | Threshold type | Calibration tier | Historical basis |
+|---|---|---|---|---|---|
+| 1 (2013) | `gdp_growth` | DOWN (Haiyan shock — note: shock arrives late in year; full-year GDP may be partially insulated) | DIRECTION_ONLY | Tier 1 | World Bank WDI; growth moderated but Philippines maintained positive growth in 2013 full year |
+| 2 (2014) | `gdp_growth` | UP (reconstruction boom) | DIRECTION_ONLY | Tier 1 | World Bank WDI; 6.3% growth in 2014 with reconstruction spending |
+| 3 (2015) | `gdp_growth` | POSITIVE (≥ 0%) | MAGNITUDE ≥ 0% | Tier 1 | World Bank WDI; Philippines sustained growth trajectory |
+
+**Timing note:** Haiyan made landfall in November 2013. Full-year GDP data for 2013
+(7.2% growth) reflects strong pre-Haiyan momentum. The step-1 threshold is
+DIRECTION_ONLY (not magnitude) because the annual timestep cannot isolate the
+Q4 2013 shock from the Q1–Q3 2013 pre-shock performance. This is a known
+temporal resolution limitation per ARCH-REVIEW-002 Finding BI2-N-07. A fidelity
+threshold based on annual GDP growth for a Q4 event is directionally indicative
+only.
+
+### Evaluation Criteria
+
+1. Simulation produces a GDP growth deceleration at step 1 (relative to trend)
+2. Simulation produces GDP growth recovery at step 2 following reconstruction ControlInputs
+3. Simulation maintains positive GDP growth at step 3
+4. Fiscal balance deteriorates at step 1 (emergency spending)
+5. Backtesting pass/fail: 2 of 3 thresholds must be met (67% pass threshold, reflecting
+   annual-timestep limitations for a Q4 shock event)
+
+---
+
+## Implementation Priority
+
+| Case | Ecological type | Data availability | Statistical strength | Recommended priority |
+|---|---|---|---|---|
+| Case 1 — BRA Amazon deforestation | Slow accumulation (land-use change) | Good — INPE PRODES + FAO FRA | Strong (10 steps, 5 thresholds) | **Highest** |
+| Case 2 — ETH drought 2002–2004 | Climatic shock (drought) | Moderate — ERA5 + FAO FPI | Adequate (3 steps, 4 thresholds) | Medium |
+| Case 3 — PHL Typhoon Haiyan | Sudden onset disaster | Good — World Bank PDNA + WDI | Limited (3 steps, 3 thresholds; timing constraint) | Lower |
+
+**Recommendation:** Implement Case 1 (BRA Amazon) first. It provides the strongest
+statistical validity, the clearest policy intervention timeline, and exercises the
+`land_use_pressure_index` and `co2_trajectory` ecological attributes that the
+ecological module currently supports. Cases 2 and 3 introduce ecological shock types
+(climate drought, disaster) that may require new attribute keys and ControlInput
+enum values; these schema extensions should follow Case 1, not precede it.
+
+---
+
+## Open Schema Questions
+
+Before implementing any case, the following schema questions must be resolved:
+
+1. **`deforestation_rate_km2_yr`** — Does this attribute exist in `docs/schema/simulation_state.yml`? If not, it requires an ADR amendment before use.
+2. **`rainfall_anomaly_pct` and `food_production_index`** — Same question. These are not in the currently approved attribute list.
+3. **`EXTERNAL_HUMANITARIAN` InputSource** — Does not exist in the `InputSource` enum. Must be added or a documented workaround committed.
+4. **`disaster_damage_gdp_pct`** — Novel attribute for typhoon case. Requires schema registration.
+
+Resolving these questions is the first implementation task before writing any fixture
+file. Read `docs/schema/simulation_state.yml` and `docs/schema/database.yml` before
+proceeding.
+
+---
+
+*Planned by PM Agent — Issue #95. See ARCH-REVIEW-002 Finding BI2-N-04 for the
+architectural root cause this document addresses.*

--- a/docs/process/legibility-metrics.md
+++ b/docs/process/legibility-metrics.md
@@ -1,0 +1,360 @@
+# Legibility Metrics Dashboard — Definition and Process
+
+> **Status:** Active — M12 onward
+> **Origin:** Issue #259 (CTO legibility metrics dashboard — ongoing pulse tracking)
+> **Prerequisites:** Issue #255 (baseline capture — complete, M7), Issue #256 (North Star amendment),
+> Issue #257 (blind audit process), Issue #258 (intent blocks)
+> **Related document:** `docs/standards/legibility-baseline-m7.md` (M7 quantitative baseline)
+
+---
+
+## Purpose
+
+Legibility is a property of the codebase that drifts unfavorably under velocity pressure
+in the same way test coverage drifts without enforcement. This document defines the four
+tracked Tier 1 metrics, the Tier 2 semi-automated process metrics, the Tier 3 qualitative
+leading indicators, and the tolerance thresholds reviewed at each milestone exit.
+
+All metrics serve the Legibility North Star (Issue #256): code must be modifiable by an
+intermediate developer without access to authorial context. When metrics drift red, the
+question is not "which rule was violated" but "would an intermediate developer be able to
+safely modify this module?"
+
+---
+
+## Metric Tiers
+
+### Tier 1 — Automated (CI)
+
+These four metrics are computed automatically on every milestone exit as part of the CI
+pipeline and appended to `docs/standards/legibility-baseline-m{N}.md`.
+
+#### Metric 1.1 — Mean Cognitive Complexity per Module (Python)
+
+**Tool:** `radon` (pinned: `radon==6.0.1` in `backend/requirements.txt`)
+**Scope:** `backend/app/` — all `.py` files; exclude `__init__.py` and generated files
+**Command:**
+
+```bash
+cd backend
+radon cc app/ -s -a --min A
+```
+
+**Grade thresholds:**
+
+| Grade | Cyclomatic complexity range | Legibility gate |
+|---|---|---|
+| A | 1–5 | Pass |
+| B | 6–10 | Pass |
+| C | 11–15 | Warning — document in baseline; must not grow |
+| D | 16–24 | Fail — must reduce before milestone exit |
+| E/F | 25+ | Fail — hard block |
+
+**Pass condition:** No D, E, or F grade blocks at milestone exit. C-grade count must
+not increase from the prior milestone baseline.
+
+**Deviation rule:** If a C-grade or above block cannot be reduced before milestone exit,
+the Engineering Lead must document the block by name, file, and complexity score in the
+milestone baseline document with an explanation. Undocumented C+ blocks are a compliance
+finding.
+
+#### Metric 1.2 — p90 Function Length in Lines per Module
+
+**Tool:** `radon raw` (included in same `radon` package)
+**Command:**
+
+```bash
+cd backend
+radon raw app/ -s | grep -A5 "LOC"
+```
+
+**Thresholds:**
+
+| p90 function length | Status |
+|---|---|
+| < 40 lines | Green |
+| 40–60 lines | Yellow — document in baseline |
+| > 60 lines | Red — must be refactored or explicitly deferred |
+
+**Pass condition:** p90 function length below 60 lines across all modules. Functions
+exceeding 60 lines that are not flagged in the prior baseline are a compliance finding.
+
+#### Metric 1.3 — Silent Failure Surface Count
+
+**Tool:** `grep` (scripted in CI step)
+**Scope:** `backend/app/` — exclude `__init__.py`, `test_*`, `*_test.py`
+**Command:**
+
+```bash
+cd backend
+grep -rn "^\s*return \[\]\|return None\|return {}" app/ \
+  --include="*.py" \
+  --exclude="__init__.py" \
+  | grep -v "test_" \
+  | wc -l
+```
+
+**Classification:** Not all bare returns are risky. The CI step counts all occurrences;
+the milestone baseline document must classify each as a legitimate guard clause or a
+higher-risk silent return (no logging, caller may not check). See the M7 baseline
+(`docs/standards/legibility-baseline-m7.md §Category 2`) for the classification
+methodology.
+
+**Thresholds:**
+
+| Higher-risk silent returns (unlogged, unchecked) | Status |
+|---|---|
+| Declining vs. prior milestone | Green |
+| Same as prior milestone | Yellow — stable; document in baseline |
+| Growing vs. prior milestone | Red — each new unlogged silent return requires a filed issue |
+
+#### Metric 1.4 — Test-to-Implementation Line Ratio per Module
+
+**Tool:** `wc -l` (scripted in CI step)
+**Scope:** `backend/app/` implementation vs. `backend/tests/` matching test files
+**Command:**
+
+```bash
+cd backend
+# Implementation lines
+find app/ -name "*.py" -not -name "__init__.py" -exec wc -l {} + | tail -1
+# Test lines
+find tests/ -name "*.py" -not -name "__init__.py" -exec wc -l {} + | tail -1
+```
+
+**Thresholds (overall ratio):**
+
+| Test-to-implementation ratio | Status |
+|---|---|
+| ≥ 1.5 | Green |
+| 1.0–1.5 | Yellow |
+| < 1.0 | Red — test gap; must be addressed before milestone exit |
+
+**Per-module floor:** No individual module may have a test-to-implementation ratio below
+0.40 at milestone exit. The `api` module was 0.45 at M7 baseline — improvement toward
+0.70 is required.
+
+---
+
+### TypeScript Legibility — ESLint Complexity Rule (Frontend)
+
+**Tool:** ESLint with `complexity` rule (included in `frontend/` ESLint configuration)
+**Scope:** `frontend/src/` — all `.ts` and `.tsx` files
+**Configuration (add to `frontend/.eslintrc` or equivalent):**
+
+```json
+{
+  "rules": {
+    "complexity": ["warn", { "max": 10 }]
+  }
+}
+```
+
+**Threshold levels:**
+
+| Cyclomatic complexity | ESLint severity | Legibility gate |
+|---|---|---|
+| ≤ 10 | (no warning) | Pass |
+| 11–15 | `warn` | Warning — must not grow; document in baseline |
+| > 15 | `error` | Fail — blocks CI |
+
+**CI enforcement:** The frontend lint step already runs `npm run lint`. The `complexity`
+rule at `warn` level produces output that is captured in the CI log but does not fail the
+build. At `error` level (> 15), the build fails. The milestone exit checklist requires
+reviewing all `complexity` warnings and confirming no function exceeds 15.
+
+**Command to run locally:**
+
+```bash
+cd frontend
+npm run lint 2>&1 | grep "complexity"
+```
+
+---
+
+## GitHub Actions CI Steps
+
+### Python Legibility Step (Backend CI Job)
+
+Add the following step to the `test-backend` job in `.github/workflows/ci.yml`, after
+the lint step:
+
+```yaml
+- name: Legibility — radon cognitive complexity gate
+  run: |
+    cd backend
+    pip install radon==6.0.1
+    # Fail if any D/E/F grade blocks exist
+    RESULT=$(radon cc app/ -s --min D 2>&1)
+    if [ -n "$RESULT" ]; then
+      echo "LEGIBILITY GATE FAILED — D/E/F grade blocks found:"
+      echo "$RESULT"
+      exit 1
+    fi
+    echo "Legibility gate passed — no D/E/F grade blocks."
+  if: needs.changes.outputs.backend == 'true'
+```
+
+**Scope note:** This step runs only when `backend/` files change (same `if:` condition
+as the existing test steps). It does not run on documentation-only commits.
+
+**Milestone exit supplement:** At milestone exit, run the full complexity report and
+append the output to the milestone legibility baseline document:
+
+```bash
+cd backend
+radon cc app/ -s -a --min A >> docs/standards/legibility-baseline-m{N}.md
+```
+
+### TypeScript Legibility Step (Frontend CI Job)
+
+The existing `npm run lint` step in the frontend CI job enforces the ESLint `complexity`
+rule. No additional CI step is required if the rule is configured in `.eslintrc`.
+
+To make complexity warnings explicit in the CI log, add:
+
+```yaml
+- name: Legibility — TypeScript complexity check
+  run: |
+    cd frontend
+    npm run lint 2>&1 | tee lint-output.txt
+    COMPLEXITY_WARNINGS=$(grep "complexity" lint-output.txt | wc -l)
+    echo "TypeScript complexity warnings: $COMPLEXITY_WARNINGS"
+    if grep -q "complexity.*error" lint-output.txt; then
+      echo "LEGIBILITY GATE FAILED — TypeScript functions exceed complexity 15"
+      exit 1
+    fi
+  if: needs.changes.outputs.frontend == 'true'
+```
+
+---
+
+## Tolerance Thresholds (Summary Table)
+
+| Metric | Green | Yellow | Red |
+|---|---|---|---|
+| Python mean cognitive complexity (radon) | Average grade A; no D/E/F blocks | 1–2 C-grade blocks new vs. prior baseline | Any D/E/F block; C-grade count growing |
+| TypeScript function complexity (ESLint) | All functions ≤ 10 | 1–3 functions 11–15 (warn) | Any function > 15 (error) |
+| Blind audit mean score (Issue #257) | > 3.5 | 2.5–3.5 | < 2.5 |
+| Spec-to-test gap count (Issue #258) | Declining | Flat | Growing |
+| Silent failure surface (higher-risk) | Declining | Flat | Growing |
+| Test-to-implementation ratio (overall) | ≥ 1.5 | 1.0–1.5 | < 1.0 |
+| Test-to-implementation ratio (per module) | ≥ 0.70 | 0.40–0.70 | < 0.40 |
+
+---
+
+## Tier 2 — Semi-Automated (Process)
+
+These metrics require a combination of tooling and manual review. They are checked at
+each milestone exit as part of the exit ceremony.
+
+### Metric 2.1 — Spec-to-Test Gap Count (Issue #258)
+
+**Definition:** Number of intent blocks (Issue #258 format) in implementation files
+that do not have a corresponding test asserting the stated behavior.
+**Process:** Identify all `# INTENT:` blocks in `backend/app/`; cross-reference against
+test files; count gaps.
+**Tracking:** Recorded in the milestone baseline document under "Tier 2 Metrics."
+**Threshold:** Gap count must be declining. A flat or growing gap count requires a filed
+issue before milestone exit is approved.
+
+### Metric 2.2 — Blind Audit Mean Score (Issue #257)
+
+**Definition:** Mean legibility score (1–5 scale) from the blind code audit protocol
+(`docs/process/blind-code-audit-prompt.md`).
+**Process:** Conducted at each milestone exit per Issue #257 protocol.
+**Threshold:** Mean score > 3.5 is green. Score 2.5–3.5 triggers a root cause analysis.
+Score < 2.5 blocks milestone exit until a remediation plan is filed.
+**Tracking:** Recorded in `docs/process/blind-audit-m{N}-baseline.md` (see
+`docs/process/blind-audit-m7-baseline.md` for M7 reference).
+
+---
+
+## Tier 3 — Leading Indicators (Qualitative)
+
+These are tracked in the milestone baseline document as qualitative assessments, not
+automated counts. They are leading indicators: deterioration here predicts Tier 1
+metric deterioration in the next 1–2 milestones.
+
+### Indicator 3.1 — Assumption Documentation Rate
+
+**Definition:** Fraction of non-trivial functions that have documented preconditions
+(either as `# INTENT:` blocks per Issue #258 or as docstring `Args:` / `Raises:` sections).
+**Assessment:** Scan `backend/app/` modules and report the fraction with documented
+preconditions at milestone exit. No automated count — Engineering Lead spot-checks
+five randomly selected non-trivial functions per module.
+
+### Indicator 3.2 — Implicit Dependency Depth
+
+**Definition:** Functions that depend on module-level state, global configuration, or
+database session state that is not declared in the function signature.
+**Assessment:** Flagged by the blind audit (Issue #257) and by Architecture Review.
+Not automated. Qualitative rating: Low / Medium / High per module.
+
+---
+
+## Milestone Exit Checklist Items
+
+The following items must be added to the milestone exit checklist
+(`docs/process/milestone-exit-checklist.md`). They are blocking requirements for
+milestone exit — not optional:
+
+```markdown
+### Legibility Metrics
+
+- [ ] Radon cognitive complexity gate run against `backend/app/` — no D/E/F grade blocks
+- [ ] C-grade block count compared to prior milestone baseline — count must not have grown
+      (if grown, each new C-grade block documented by name in milestone baseline)
+- [ ] p90 function length checked — no module above 60 lines p90
+- [ ] Silent failure surface classified — higher-risk unlogged returns count recorded;
+      any increase vs. prior baseline requires a filed issue
+- [ ] Test-to-implementation ratio computed per module — no module below 0.40
+- [ ] TypeScript ESLint complexity warnings reviewed — zero functions > 15 (error level)
+- [ ] Tier 1 metrics recorded in `docs/standards/legibility-baseline-m{N}.md`
+      (append to file; do not overwrite prior milestones)
+- [ ] Spec-to-test gap count reviewed (Issue #258) — declining or flat with documented plan
+- [ ] Blind code audit completed (Issue #257) — mean score ≥ 2.5 to close milestone;
+      ≥ 3.5 for green status
+- [ ] Engineering Lead reviews legibility dashboard at milestone exit ceremony
+- [ ] Any Red metric documented in SESSION_STATE.md with a filed remediation issue
+```
+
+---
+
+## Dashboard Review Protocol
+
+The Engineering Lead reviews the legibility dashboard at each milestone exit as part of
+the exit ceremony. The review covers:
+
+1. Compare all Tier 1 metrics against the prior milestone baseline
+2. Confirm no metric has moved from Green to Red without a filed issue
+3. Review Tier 2 metrics (blind audit score, spec-to-test gap) — confirm within tolerance
+4. Review Tier 3 qualitative indicators — flag any deterioration as a risk
+5. Confirm the new milestone baseline document has been appended
+   (`docs/standards/legibility-baseline-m{N}.md`)
+
+If any Tier 1 metric is Red, the milestone exit is blocked until either:
+(a) the metric is remediated, or
+(b) the Engineering Lead files a documented exception with a remediation plan
+    and timeline in SESSION_STATE.md.
+
+---
+
+## Relationship to Other Process Documents
+
+| Document | Relationship |
+|---|---|
+| `docs/standards/legibility-baseline-m7.md` | M7 quantitative baseline — the first captured snapshot; all subsequent baselines follow its structure |
+| `docs/process/blind-audit-m7-baseline.md` | M7 blind audit baseline (Tier 2 Metric 2.2) |
+| `docs/process/blind-code-audit-prompt.md` | Protocol for conducting blind code audits |
+| `docs/process/intent-block-author-prompt.md` | Intent block authoring protocol (feeds Tier 2 Metric 2.1) |
+| `docs/CODING_STANDARDS.md` | Authoritative coding style; legibility metrics enforce the quantitative floor |
+| Issue #255 | M7 baseline capture — prerequisite (complete) |
+| Issue #256 | North Star amendment — prerequisite |
+| Issue #257 | Blind audit process — prerequisite |
+| Issue #258 | Intent blocks — prerequisite |
+
+---
+
+*Defined by PM Agent — Issue #259. Metrics reviewed by Engineering Lead at each
+milestone exit beginning M8. Dashboard baseline captured at M7 exit (Issue #255).*


### PR DESCRIPTION
## Summary

- Adds `docs/backtesting/ecological-backtesting-cases.md`: three planned ecological backtesting cases (Brazil Amazon deforestation 2000–2010, Ethiopia drought 2002–2004, Philippines Typhoon Haiyan 2013–2015), each with ISO alpha-3 entity, time period, initial state parameters, approved Tier 1/2/3 data sources, ControlInput sequence, fidelity thresholds, and evaluation criteria. Addresses ARCH-REVIEW-002 Finding BI2-N-04 — closes #95.
- Adds `docs/process/legibility-metrics.md`: CTO-level legibility metrics dashboard defining Tier 1 automated CI metrics (radon cognitive complexity, p90 function length, silent failure surface, test-to-implementation ratio), TypeScript ESLint `complexity` rule configuration, GitHub Actions CI steps for each, tolerance thresholds, and the milestone exit checklist items required from M12 onward — closes #259.

## Test plan

- [ ] Docs-only change — no backend or frontend files modified; `changes` CI job skips all non-doc jobs
- [ ] Verify both files are present at the documented canonical paths
- [ ] Confirm no mid-table insertions in compliance registries (none touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)