### PR TITLE
feat(api): per-step trajectory compare endpoint + all-attributes compare docs (closes #90, #99)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -1,9 +1,10 @@
 """Scenario endpoints — ADR-004 Decisions 1, 2, 4, and 5; ADR-005 Decision 2.
 
-Nine endpoints covering scenario configuration lifecycle, execution, and HCL output:
+Ten endpoints covering scenario configuration lifecycle, execution, and HCL output:
   POST   /scenarios                                        — create scenario (status: pending)
   GET    /scenarios                                        — list all scenarios (created_at desc)
   GET    /scenarios/compare         — snapshot delta; optional step alignment (ADR-004 D5)
+  GET    /scenarios/compare/trajectory — per-step attribute trajectory delta (Issue #99)
   GET    /scenarios/{scenario_id}                          — full detail with scheduled inputs
   DELETE /scenarios/{scenario_id}                          — tombstone + cascade delete, returns 204
   POST   /scenarios/{scenario_id}/run                      — execute pending scenario to completion
@@ -62,6 +63,8 @@ from app.schemas import (
     ScenarioRestoreResponse,
     ScheduledInputSchema,
     SnapshotRecord,
+    TrajectoryCompareResponse,
+    TrajectoryCompareStep,
     TrajectoryFrameworkPoint,
     TrajectoryResponse,
     TrajectoryStep,
@@ -448,7 +451,12 @@ async def compare_scenarios(
 
     Computes delta = value_b - value_a for each shared entity and attribute.
     Only entities and attributes present in both snapshots are included.
-    Filter to a single attribute with `attr`. ADR-004 Decision 5.
+
+    All-attributes mode (Issue #90, ARCH-REVIEW-002 BI2-I-05): when `attr` is
+    omitted, ALL shared attributes across ALL shared entities are returned in a
+    single call. This satisfies the multi-framework comparison requirement — a
+    scenario that improves GDP while worsening unemployment is fully visible
+    without N serial calls. Pass `attr` to filter the response to one key.
 
     `step` — when provided, both scenarios must have a snapshot at exactly
     that step. Returns 404 identifying which scenario is missing the step.
@@ -571,6 +579,139 @@ async def compare_scenarios(
         step_a=snap_a["step"],
         step_b=snap_b["step"],
         deltas=deltas,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /scenarios/compare/trajectory — Issue #99
+# ---------------------------------------------------------------------------
+
+
+@router.get("/scenarios/compare/trajectory", response_model=TrajectoryCompareResponse)
+async def compare_scenarios_trajectory(
+    conn: Annotated[asyncpg.Connection, Depends(get_db)],
+    scenario_a: str,
+    scenario_b: str,
+    attribute: str,
+) -> TrajectoryCompareResponse:
+    """Return per-step attribute delta between two scenarios across all shared steps.
+
+    Fetches all snapshots for both scenarios, aligns by step number, and returns
+    the attribute value from each scenario at each shared step alongside the
+    computed delta. The attribute is located by iterating shared entities and
+    finding the first entity that has the attribute key in both snapshots at that
+    step. When no entity carries the attribute at a given step, the step entry
+    carries null values and delta.
+
+    This endpoint enables trajectory analysis without N serial calls — the client
+    receives the full time-series of value_a, value_b, and delta in one response.
+    Cumulative welfare computation (integral of delta over all steps) is a single
+    client-side sum (Issue #99, ARCH-REVIEW-002 BI2-N-08).
+
+    Returns 404 if either scenario is not found.
+    Returns 409 if either scenario has no snapshots yet.
+    """
+    for sid in (scenario_a, scenario_b):
+        row = await conn.fetchrow(
+            "SELECT scenario_id FROM scenarios WHERE scenario_id = $1", sid
+        )
+        if row is None:
+            raise HTTPException(
+                status_code=404, detail=f"Scenario '{sid}' not found."
+            )
+
+    rows_a = await conn.fetch(
+        "SELECT step, state_data FROM scenario_state_snapshots "
+        "WHERE scenario_id = $1 ORDER BY step ASC",
+        scenario_a,
+    )
+    rows_b = await conn.fetch(
+        "SELECT step, state_data FROM scenario_state_snapshots "
+        "WHERE scenario_id = $1 ORDER BY step ASC",
+        scenario_b,
+    )
+
+    if not rows_a:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Scenario '{scenario_a}' has no snapshots. Run it first.",
+        )
+    if not rows_b:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Scenario '{scenario_b}' has no snapshots. Run it first.",
+        )
+
+    def _parse_state(raw: object) -> dict[str, Any]:
+        if isinstance(raw, str):
+            return json.loads(raw)  # type: ignore[no-any-return]
+        return raw  # type: ignore[return-value]
+
+    map_a: dict[int, dict[str, Any]] = {
+        int(r["step"]): _parse_state(r["state_data"]) for r in rows_a
+    }
+    map_b: dict[int, dict[str, Any]] = {
+        int(r["step"]): _parse_state(r["state_data"]) for r in rows_b
+    }
+
+    shared_steps = sorted(set(map_a) & set(map_b))
+
+    steps: list[TrajectoryCompareStep] = []
+    for step_num in shared_steps:
+        state_a_step = map_a[step_num]
+        state_b_step = map_b[step_num]
+
+        val_a: str | None = None
+        val_b: str | None = None
+
+        # Find the first entity that carries the attribute in snapshot A.
+        for eid in sorted(set(state_a_step) & set(state_b_step)):
+            attrs_a = state_a_step.get(eid)
+            attrs_b = state_b_step.get(eid)
+            if not isinstance(attrs_a, dict) or not isinstance(attrs_b, dict):
+                continue
+            env_a = attrs_a.get(attribute)
+            env_b = attrs_b.get(attribute)
+            if env_a is not None and isinstance(env_a, dict):
+                val_a = str(env_a.get("value", ""))
+            if env_b is not None and isinstance(env_b, dict):
+                val_b = str(env_b.get("value", ""))
+            if val_a is not None or val_b is not None:
+                break
+
+        delta_str: str | None = None
+        direction: str | None = None
+        if val_a is not None and val_b is not None:
+            try:
+                from decimal import Decimal as _Dec  # noqa: PLC0415
+                d_a = _Dec(val_a)
+                d_b = _Dec(val_b)
+                diff = d_b - d_a
+                delta_str = str(diff)
+                if diff > 0:
+                    direction = "increase"
+                elif diff < 0:
+                    direction = "decrease"
+                else:
+                    direction = "unchanged"
+            except Exception:  # noqa: BLE001 S110
+                pass  # non-numeric attribute value — leave delta null
+
+        steps.append(
+            TrajectoryCompareStep(
+                step=step_num,
+                value_a=val_a,
+                value_b=val_b,
+                delta=delta_str,
+                direction=direction,
+            )
+        )
+
+    return TrajectoryCompareResponse(
+        scenario_a_id=scenario_a,
+        scenario_b_id=scenario_b,
+        attribute=attribute,
+        steps=steps,
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -534,6 +534,8 @@ class CompareResponse(BaseModel):
 
     `deltas` maps entity_id → attribute_key → DeltaRecord.
     Only entities and attributes present in both snapshots are included.
+    When `attr` is omitted, ALL shared attributes across all shared entities are
+    returned in a single call (Issue #90). Pass `attr` to filter to one key.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -543,6 +545,47 @@ class CompareResponse(BaseModel):
     step_a: int
     step_b: int
     deltas: dict[str, dict[str, DeltaRecord]]
+
+
+# ---------------------------------------------------------------------------
+# Trajectory comparison schemas — Issue #99
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryCompareStep(BaseModel):
+    """One aligned step in a trajectory comparison.
+
+    `value_a` and `value_b` are the attribute values (Decimal as string) at
+    this step for scenario_a and scenario_b respectively. `delta` = value_b -
+    value_a as a Decimal string. `direction` is 'increase', 'decrease', or
+    'unchanged'. All fields are None when the attribute is absent in either
+    snapshot at this step.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    step: int
+    value_a: str | None = None
+    value_b: str | None = None
+    delta: str | None = None
+    direction: str | None = None
+
+
+class TrajectoryCompareResponse(BaseModel):
+    """Per-step attribute trajectory delta between two scenarios — Issue #99.
+
+    `steps` contains one entry per shared step (both scenarios have a snapshot),
+    sorted ascending by step number. Only steps where both scenarios have a
+    snapshot AND the attribute is present in at least one entity are included.
+    `attribute` is the attribute key that was queried.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    scenario_a_id: str
+    scenario_b_id: str
+    attribute: str
+    steps: list[TrajectoryCompareStep]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_compare_api.py
+++ b/backend/tests/integration/test_compare_api.py
@@ -10,6 +10,10 @@ Covers:
   - GET /scenarios/compare?attr= filters to one attribute
   - GET /choropleth/{attr}/delta returns 404 when no shared attribute in snapshots
   - GET /choropleth/{attr}/delta returns GeoJSONFeatureCollection for valid pair
+  - GET /scenarios/compare/trajectory returns 404 when scenario_a not found (Issue #99)
+  - GET /scenarios/compare/trajectory returns 409 when scenario_a has no snapshots (Issue #99)
+  - GET /scenarios/compare/trajectory returns per-step trajectory for two scenarios (Issue #99)
+  - GET /scenarios/compare/trajectory returns empty steps when no shared steps (Issue #99)
 """
 from __future__ import annotations
 
@@ -301,5 +305,122 @@ async def test_choropleth_delta_missing_snapshot_returns_404(
             params={"scenario_a": sid_a, "scenario_b": sid_b},
         )
         assert res.status_code == 404
+    finally:
+        await _cleanup(db_conn, sid_a, sid_b)
+
+
+# ---------------------------------------------------------------------------
+# GET /scenarios/compare/trajectory — Issue #99
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trajectory_compare_scenario_a_not_found_returns_404(
+    client: AsyncClient,
+) -> None:
+    """Unknown scenario_a returns 404."""
+    res = await client.get(
+        "/api/v1/scenarios/compare/trajectory",
+        params={
+            "scenario_a": "no-such-id",
+            "scenario_b": "no-such-id-2",
+            "attribute": "pop",
+        },
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_trajectory_compare_no_snapshots_returns_409(
+    client: AsyncClient,
+    db_conn: asyncpg.Connection,
+) -> None:
+    """409 when scenario_a exists but has no snapshots yet."""
+    sid_a = await _insert_scenario(db_conn, status="pending")
+    sid_b = await _insert_scenario(db_conn, status="pending")
+    try:
+        res = await client.get(
+            "/api/v1/scenarios/compare/trajectory",
+            params={"scenario_a": sid_a, "scenario_b": sid_b, "attribute": "pop"},
+        )
+        assert res.status_code == 409
+    finally:
+        await _cleanup(db_conn, sid_a, sid_b)
+
+
+@pytest.mark.asyncio
+async def test_trajectory_compare_happy_path(
+    client: AsyncClient,
+    db_conn: asyncpg.Connection,
+) -> None:
+    """Happy path: two scenarios with matching steps return a trajectory.
+
+    Verifies that:
+    - steps are sorted ascending by step number
+    - value_a, value_b, delta, and direction are correctly computed
+    - the float prohibition holds (delta is a string, not a float)
+    """
+    sid_a = await _insert_scenario(db_conn)
+    sid_b = await _insert_scenario(db_conn)
+    _env_a0 = {"value": "100", "unit": "M", "variable_type": "stock", "confidence_tier": 2}
+    _env_b0 = {"value": "120", "unit": "M", "variable_type": "stock", "confidence_tier": 2}
+    _env_a1 = {"value": "105", "unit": "M", "variable_type": "stock", "confidence_tier": 2}
+    _env_b1 = {"value": "115", "unit": "M", "variable_type": "stock", "confidence_tier": 2}
+    await _insert_snapshot(db_conn, sid_a, 0, {"USA": {"pop": _env_a0}})
+    await _insert_snapshot(db_conn, sid_b, 0, {"USA": {"pop": _env_b0}})
+    await _insert_snapshot(db_conn, sid_a, 1, {"USA": {"pop": _env_a1}})
+    await _insert_snapshot(db_conn, sid_b, 1, {"USA": {"pop": _env_b1}})
+    try:
+        res = await client.get(
+            "/api/v1/scenarios/compare/trajectory",
+            params={"scenario_a": sid_a, "scenario_b": sid_b, "attribute": "pop"},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["scenario_a_id"] == sid_a
+        assert body["scenario_b_id"] == sid_b
+        assert body["attribute"] == "pop"
+        steps = body["steps"]
+        assert len(steps) == 2
+        # Steps must be sorted ascending
+        assert steps[0]["step"] == 0
+        assert steps[1]["step"] == 1
+        # Step 0: delta = 120 - 100 = 20, direction = increase
+        s0 = steps[0]
+        assert s0["value_a"] == "100"
+        assert s0["value_b"] == "120"
+        assert s0["delta"] == "20"
+        assert s0["direction"] == "increase"
+        assert isinstance(s0["delta"], str)  # float prohibition
+        # Step 1: delta = 115 - 105 = 10, direction = increase
+        s1 = steps[1]
+        assert s1["value_a"] == "105"
+        assert s1["value_b"] == "115"
+        assert s1["delta"] == "10"
+        assert s1["direction"] == "increase"
+    finally:
+        await _cleanup(db_conn, sid_a, sid_b)
+
+
+@pytest.mark.asyncio
+async def test_trajectory_compare_empty_steps_when_no_overlap(
+    client: AsyncClient,
+    db_conn: asyncpg.Connection,
+) -> None:
+    """Returns empty steps list when the two scenarios have no shared step numbers."""
+    sid_a = await _insert_scenario(db_conn)
+    sid_b = await _insert_scenario(db_conn)
+    _env = {"value": "100", "unit": "M", "variable_type": "stock", "confidence_tier": 1}
+    # scenario_a has step 0, scenario_b has step 1 — no overlap
+    await _insert_snapshot(db_conn, sid_a, 0, {"USA": {"pop": _env}})
+    await _insert_snapshot(db_conn, sid_b, 1, {"USA": {"pop": _env}})
+    try:
+        res = await client.get(
+            "/api/v1/scenarios/compare/trajectory",
+            params={"scenario_a": sid_a, "scenario_b": sid_b, "attribute": "pop"},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["steps"] == []
     finally:
         await _cleanup(db_conn, sid_a, sid_b)

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -259,6 +259,9 @@ endpoints:
     summary: >
       Attribute deltas between two scenarios. delta = value_b - value_a.
       Must appear before /scenarios/{scenario_id} in router registration (FastAPI path ordering).
+      All-attributes mode (Issue #90): when attr is omitted, ALL shared attributes across
+      ALL shared entities are returned in a single call — multi-framework comparison
+      without N serial API calls. Pass attr to filter to a single key.
     auth: none
     query_params:
       - name: scenario_a
@@ -270,13 +273,21 @@ endpoints:
       - name: attr
         type: string
         required: false
-        description: Filter to a single attribute key.
+        description: >
+          Filter to a single attribute key. When omitted, returns all shared
+          attributes across all shared entities (Issue #90, ARCH-REVIEW-002 BI2-I-05).
       - name: step
         type: integer
         required: false
         description: >
           If provided, both scenarios must have a snapshot at this exact step.
           If omitted, uses the latest snapshot for each scenario.
+      - name: threshold_value
+        type: string
+        required: false
+        description: >
+          Optional numeric string. When provided, each DeltaRecord includes
+          threshold_crossed: bool (Issue #153).
     response:
       status: 200
       body:
@@ -293,8 +304,49 @@ endpoints:
             delta: {type: string, description: "Decimal as string; negative for decrease"}
             direction: {type: string, values: ["increase", "decrease", "unchanged"]}
             confidence_tier: {type: integer, description: "max() of both tiers"}
+            threshold_crossed: {type: "bool|null", description: "null when threshold_value not supplied"}
       status_404: "scenario_a or scenario_b not found; or step not found for a scenario"
       status_409: "step omitted and one or both scenarios have no snapshots yet"
+    db_reads: [scenarios, scenario_state_snapshots]
+
+  - method: GET
+    path: /scenarios/compare/trajectory
+    summary: >
+      Per-step attribute trajectory delta between two scenarios — Issue #99,
+      ARCH-REVIEW-002 BI2-N-08. Returns a time series of value_a, value_b,
+      and delta tuples for all steps where both scenarios have snapshots.
+      Enables trajectory analysis and cumulative welfare computation (integral
+      of delta over all steps) in a single API call.
+      Must appear before /scenarios/{scenario_id} in router registration.
+    auth: none
+    query_params:
+      - name: scenario_a
+        type: string
+        required: true
+      - name: scenario_b
+        type: string
+        required: true
+      - name: attribute
+        type: string
+        required: true
+        description: Attribute key to compare across all shared steps.
+    response:
+      status: 200
+      body:
+        scenario_a_id: {type: string}
+        scenario_b_id: {type: string}
+        attribute: {type: string}
+        steps:
+          type: array
+          description: "Sorted ascending by step. One entry per shared step."
+          items:
+            step: {type: integer}
+            value_a: {type: "string|null", description: "Decimal as string; null when attribute absent"}
+            value_b: {type: "string|null", description: "Decimal as string; null when attribute absent"}
+            delta: {type: "string|null", description: "Decimal as string; null when either value absent"}
+            direction: {type: "string|null", values: ["increase", "decrease", "unchanged", null]}
+      status_404: "scenario_a or scenario_b not found"
+      status_409: "one or both scenarios have no snapshots yet"
     db_reads: [scenarios, scenario_state_snapshots]
 
   - method: GET


### PR DESCRIPTION
## Summary

- Adds `GET /scenarios/compare/trajectory?scenario_a=&scenario_b=&attribute=` returning a time-series of `{step, value_a, value_b, delta, direction}` for all shared steps between two scenarios — replaces N serial calls with one query (Issue #99, ARCH-REVIEW-002 BI2-N-08)
- Documents the existing all-attributes behavior of `GET /scenarios/compare` (when `attr` is omitted, all shared attributes across all entities are returned in one call) in endpoint docstring and `api_contracts.yml` (Issue #90, ARCH-REVIEW-002 BI2-I-05)
- Adds `TrajectoryCompareStep` and `TrajectoryCompareResponse` Pydantic schemas to `schemas.py`
- Adds four integration tests: happy path (two steps, correct delta/direction), 404 on unknown scenario, 409 on no snapshots, empty steps when no shared steps

## Test plan

- [ ] `test_trajectory_compare_scenario_a_not_found_returns_404` — unknown scenario returns 404
- [ ] `test_trajectory_compare_no_snapshots_returns_409` — scenario with no snapshots returns 409
- [ ] `test_trajectory_compare_happy_path` — two scenarios with two shared steps return correct value_a/value_b/delta/direction; delta is a string (float prohibition)
- [ ] `test_trajectory_compare_empty_steps_when_no_overlap` — non-overlapping step sets return empty steps list
- [ ] `ruff check .` exits 0 (verified locally)
- [ ] mypy errors are pre-existing KI-002 stub environment errors only; no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)