### PR TITLE
feat(engine): CohortProfile, AttributeType, cohort JSONB serde — closes #28, #30

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -175,6 +175,8 @@ class QuantitySchema(BaseModel):
     observation_date: date | None = None
     source_registry_id: str | None = None
     measurement_framework: str | None = None
+    attribute_type: str | None = None
+    stock_flow_identity: bool = False
 
     @field_serializer("observation_date")
     def _serialize_date(self, v: date | None) -> str | None:
@@ -210,6 +212,8 @@ class QuantitySchema(BaseModel):
             observation_date=obs_date,
             source_registry_id=data.get("source_registry_id"),
             measurement_framework=data.get("measurement_framework"),
+            attribute_type=data.get("attribute_type"),
+            stock_flow_identity=bool(data.get("stock_flow_identity", False)),
         )
 
 

--- a/backend/app/simulation/engine/models.py
+++ b/backend/app/simulation/engine/models.py
@@ -1,5 +1,5 @@
 """
-Simulation core data model — ADR-001, Amendment 1; ADR-011 (non-linear propagation).
+Simulation core data model — ADR-001, Amendments 1 and 2; ADR-011.
 
 All entities, relationships, events, and measurement structures that the
 simulation engine operates on. This module has no database or framework
@@ -10,6 +10,12 @@ Amendment 1 (SCR-001): SimulationEntity.attributes changed from
 dict[str, float] to dict[str, Quantity]. Event.affected_attributes
 changed from dict[str, float] to dict[str, Quantity]. See ADR-001
 Amendment 1 for the full renewal record.
+
+Amendment 2 (Issue #28, Issue #30): CohortProfile type added for income-
+quintile-level disaggregation. SimulationEntity gains optional
+cohort_profiles field (None at Level 1, populated at Level 4+). AttributeType
+enum added to quantity.py for economic-semantic classification. See ADR-001
+Amendment 2 for the full record.
 
 ADR-011: PropagationMode enum added. PropagationRule extended with
 propagation_mode, threshold, and ceiling fields. LINEAR remains the
@@ -259,6 +265,41 @@ class DebtProfile:
 
 
 # ---------------------------------------------------------------------------
+# Cohort disaggregation — ADR-001 Amendment 2, Issue #28
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CohortProfile:
+    """Income-quintile or age-band level attribute container for one entity cohort.
+
+    CohortProfile is the Level 4 sub-entity structure — it holds Quantity
+    attributes measured at the cohort level rather than the national aggregate.
+    The parent SimulationEntity holds national aggregates in its attributes dict;
+    CohortProfile holds the disaggregated view for one cohort segment.
+
+    Key convention (ADR-001 Amendment 2):
+        Income quintiles: "Q1" (bottom 20%) through "Q5" (top 20%).
+        Age bands: "youth_15_24", "prime_25_54", "older_55_64", "senior_65plus".
+        Combined: compound keys are not used at Level 4 stub — use a single
+        dimension per profile key for legibility.
+
+    confidence_tier inheritance rule (ADR-001 Amendment 2):
+        Each Quantity in attributes carries its own confidence_tier, sourced
+        from the cohort-level data directly (not inherited from the parent
+        entity's aggregate tier). Eurostat EU-SILC cohort data is Tier 2;
+        synthetic cohort estimates are Tier 4.
+
+    Attributes:
+        attributes: Cohort-level simulation state variables as Quantity instances.
+            Same structure as SimulationEntity.attributes — attribute key maps to
+            a typed Quantity carrying value, unit, variable_type, and provenance.
+    """
+
+    attributes: dict[str, Quantity]
+
+
+# ---------------------------------------------------------------------------
 # Core entities
 # ---------------------------------------------------------------------------
 
@@ -294,6 +335,11 @@ class SimulationEntity:
         geometry: Spatial reference for the entity; populated in Milestone 2.
         debt_profile: Structured debt composition (Issue #36). Exposes six
             debt-structure dimensions via the get_attribute() namespace.
+        cohort_profiles: Income-quintile and age-band level attribute containers
+            (ADR-001 Amendment 2, Issue #28). None at Level 1 (national aggregate);
+            populated at Level 4+ when cohort-level data is available. Keys follow
+            the convention "Q1"–"Q5" for income quintiles, "youth_15_24" for age
+            bands. Stored in state_data JSONB under "_cohort_profiles" sub-key.
     """
     id: str
     entity_type: str
@@ -302,6 +348,7 @@ class SimulationEntity:
     parent_id: str | None = None
     geometry: Geometry | None = None
     debt_profile: DebtProfile | None = None
+    cohort_profiles: dict[str, CohortProfile] | None = None
 
     # Mapping from debt_profile.* attribute keys to DebtProfile field names.
     # Used by get_attribute() to expose debt structure as Quantity attributes

--- a/backend/app/simulation/engine/quantity.py
+++ b/backend/app/simulation/engine/quantity.py
@@ -1,5 +1,5 @@
 """
-Quantity type system — SCR-001, ADR-001 Amendment 1.
+Quantity type system — SCR-001, ADR-001 Amendment 1; AttributeType ADR-001 Amendment 2.
 
 Every physical and economic measurement in the simulation is a Quantity.
 Never raw float, never raw Decimal without a unit and provenance.
@@ -9,6 +9,17 @@ The VariableType enum determines propagation semantics:
   FLOW   — change over a period; additive accumulation
   RATIO  — dimensionless fraction derived from other quantities; additive
   DIMENSIONLESS — index/score with no natural unit; module-defined update rule
+
+AttributeType (Amendment 2, Issue #30) is a complementary economic-semantic tag:
+  STOCK           — natural capital stock, debt stock, FX reserves (accumulated level)
+  FLOW            — GDP, exports, deficit (change per period)
+  STRUCTURAL_INDEX — governance quality, political stability (index, no natural unit)
+  RATE            — rates per period (inflation rate, unemployment rate)
+
+AttributeType and VariableType are complementary: VariableType drives propagation
+behaviour; AttributeType annotates economic meaning for MDA classification and
+ecological stock-depletion accounting. AttributeType is optional — None when the
+economic class has not been determined.
 
 confidence_tier propagation uses the lower-of-two rule — a deliberately
 conservative policy approximation, not a statistical formula.
@@ -27,6 +38,36 @@ if TYPE_CHECKING:
     from decimal import Decimal
 
     from app.simulation.engine.models import MeasurementFramework
+
+
+class AttributeType(str, Enum):
+    """Economic-semantic classification of simulation attributes (ADR-001 Amendment 2, Issue #30).
+
+    Complements VariableType, which drives propagation behaviour. AttributeType
+    annotates the economic meaning for MDA classification, ecological stock-depletion
+    accounting, and stock-flow identity validation.
+
+    Use AttributeType.STOCK for accumulated levels (forest cover, debt stock, FX reserves).
+    Use AttributeType.FLOW for per-period changes (GDP, exports, fiscal deficit).
+    Use AttributeType.STRUCTURAL_INDEX for quality/governance indexes with no natural unit.
+    Use AttributeType.RATE for rates per period (unemployment rate, inflation rate).
+    """
+
+    STOCK = "stock"
+    """Accumulated level at a point in time. Natural capital stocks, debt outstanding,
+    FX reserves. Stocks can be depleted below irreversible MDA thresholds."""
+
+    FLOW = "flow"
+    """Change or production over a period. GDP, exports, government spending.
+    Flows drive stock updates via the stock-flow identity when stock_flow_identity=True."""
+
+    STRUCTURAL_INDEX = "structural_index"
+    """Quality index or composite score with no natural unit. Political stability,
+    governance effectiveness, V-Dem indicators. Cannot be summed across entities."""
+
+    RATE = "rate"
+    """Rate per unit time. Unemployment rate, inflation rate, GDP growth rate.
+    Expressed as a fraction (0.0–1.0) or annualised percentage."""
 
 
 class VariableType(Enum):
@@ -89,6 +130,11 @@ class Quantity:
             Data Quality Tier System. Defaults to 1 (highest confidence).
             Must be set explicitly at ingestion — do not rely on the default
             for ingested data (ingestion pipeline requirement, SCR-001).
+        attribute_type: Economic-semantic classification (ADR-001 Amendment 2,
+            Issue #30). None when not yet classified. See AttributeType for values.
+        stock_flow_identity: When True, the engine validates that the stock
+            value satisfies stock[t+1] = stock[t] + net_flow[t], surfaced as a
+            warning in Milestone 1. Only meaningful for STOCK attributes.
     """
 
     value: Decimal
@@ -98,6 +144,8 @@ class Quantity:
     observation_date: date | None = None
     source_id: str | None = None
     confidence_tier: int = 1
+    attribute_type: AttributeType | None = None
+    stock_flow_identity: bool = False
 
 
 @dataclass(kw_only=True)

--- a/backend/app/simulation/repositories/quantity_serde.py
+++ b/backend/app/simulation/repositories/quantity_serde.py
@@ -26,10 +26,10 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from app.schemas import QuantitySchema
-from app.simulation.engine.quantity import Quantity, VariableType
+from app.simulation.engine.quantity import AttributeType, Quantity, VariableType
 
 if TYPE_CHECKING:
-    from app.simulation.engine.models import MeasurementFramework
+    from app.simulation.engine.models import CohortProfile, MeasurementFramework
 
 # ---------------------------------------------------------------------------
 # IA-1 canonical text — SA-01
@@ -95,7 +95,7 @@ def quantity_to_jsonb_envelope(q: Quantity) -> dict[str, Any]:
     """
     from app.simulation.engine.models import MeasurementFramework  # noqa: PLC0415
 
-    return {
+    envelope: dict[str, Any] = {
         "_envelope_version": _ENVELOPE_VERSION,
         "value": str(q.value),
         "unit": q.unit,
@@ -111,6 +111,11 @@ def quantity_to_jsonb_envelope(q: Quantity) -> dict[str, Any]:
             else None
         ),
     }
+    if q.attribute_type is not None:
+        envelope["attribute_type"] = q.attribute_type.value
+    if q.stock_flow_identity:
+        envelope["stock_flow_identity"] = True
+    return envelope
 
 
 def quantity_from_schema(schema: QuantitySchema) -> Quantity:
@@ -133,6 +138,13 @@ def quantity_from_schema(schema: QuantitySchema) -> Quantity:
     except ValueError:
         vt = VariableType.DIMENSIONLESS
 
+    at: AttributeType | None = None
+    if schema.attribute_type is not None:
+        try:
+            at = AttributeType(schema.attribute_type)
+        except ValueError:
+            at = None
+
     return Quantity(
         value=Decimal(schema.value),
         unit=schema.unit,
@@ -141,6 +153,8 @@ def quantity_from_schema(schema: QuantitySchema) -> Quantity:
         observation_date=schema.observation_date,
         source_id=schema.source_registry_id,
         measurement_framework=mf,
+        attribute_type=at,
+        stock_flow_identity=schema.stock_flow_identity,
     )
 
 
@@ -150,3 +164,51 @@ def quantity_from_jsonb(data: dict[str, Any]) -> Quantity:
     Convenience wrapper: QuantitySchema.from_jsonb() → quantity_from_schema().
     """
     return quantity_from_schema(QuantitySchema.from_jsonb(data))
+
+
+# ---------------------------------------------------------------------------
+# CohortProfile serde — ADR-001 Amendment 2, Issue #28
+# ---------------------------------------------------------------------------
+
+
+def cohort_profile_to_jsonb(profile: CohortProfile) -> dict[str, Any]:
+    """Serialize a CohortProfile to a JSONB-safe dict.
+
+    Each attribute in the profile is serialized with quantity_to_jsonb_envelope.
+    The result is stored as the value of the "_cohort_profiles" sub-key within
+    an entity's state_data block.
+
+    Args:
+        profile: A CohortProfile instance.
+
+    Returns:
+        Dict mapping attribute_key → SA-09 Quantity envelope.
+    """
+    return {
+        attr_key: quantity_to_jsonb_envelope(qty)
+        for attr_key, qty in profile.attributes.items()
+    }
+
+
+def cohort_profile_from_jsonb(data: dict[str, Any]) -> CohortProfile:
+    """Deserialize a JSONB dict to a CohortProfile.
+
+    Inverse of cohort_profile_to_jsonb. Unknown or malformed envelope keys
+    are silently skipped (same defensive pattern as _reconstruct_state_from_snapshot).
+
+    Args:
+        data: Dict mapping attribute_key → SA-09 Quantity envelope.
+
+    Returns:
+        CohortProfile with deserialized attributes.
+    """
+    import contextlib  # noqa: PLC0415
+
+    from app.simulation.engine.models import CohortProfile  # noqa: PLC0415
+
+    attributes: dict[str, Quantity] = {}
+    for attr_key, envelope in data.items():
+        if isinstance(envelope, dict):
+            with contextlib.suppress(ValueError, KeyError):
+                attributes[attr_key] = quantity_from_jsonb(envelope)
+    return CohortProfile(attributes=attributes)

--- a/backend/app/simulation/repositories/snapshot_repository.py
+++ b/backend/app/simulation/repositories/snapshot_repository.py
@@ -33,6 +33,7 @@ import asyncpg  # noqa: TCH002 — used in method signatures at runtime
 from app.simulation.repositories.quantity_serde import (
     IA1_CANONICAL_PHRASE,
     STATE_DATA_ENVELOPE_VERSION,
+    cohort_profile_to_jsonb,
     quantity_to_jsonb_envelope,
     validate_ia1_disclosure,
 )
@@ -129,8 +130,14 @@ def _serialize_state(
         "_steps_projected": steps_projected,
     }
     for entity_id, entity in state.entities.items():
-        data[entity_id] = {
+        entity_data: dict[str, object] = {
             attr_key: quantity_to_jsonb_envelope(qty)
             for attr_key, qty in entity.attributes.items()
         }
+        if entity.cohort_profiles is not None:
+            entity_data["_cohort_profiles"] = {
+                cohort_key: cohort_profile_to_jsonb(profile)
+                for cohort_key, profile in entity.cohort_profiles.items()
+            }
+        data[entity_id] = entity_data
     return data

--- a/backend/app/simulation/repositories/state_repository.py
+++ b/backend/app/simulation/repositories/state_repository.py
@@ -126,6 +126,8 @@ def _build_entity(row: Any) -> SimulationEntity:  # noqa: ANN401 — asyncpg Rec
     attributes: dict[str, Quantity] = {}
     if isinstance(attrs_raw, dict):
         for key, val in attrs_raw.items():
+            if key.startswith("_"):
+                continue
             if isinstance(val, dict):
                 with contextlib.suppress(ValueError, KeyError):
                     attributes[key] = quantity_from_jsonb(val)

--- a/backend/app/simulation/web_scenario_runner.py
+++ b/backend/app/simulation/web_scenario_runner.py
@@ -54,7 +54,11 @@ from app.simulation.orchestration.inputs import (
     TradePolicyInput,
 )
 from app.simulation.orchestration.runner import ScenarioRunner
-from app.simulation.repositories.quantity_serde import quantity_from_jsonb, quantity_from_schema
+from app.simulation.repositories.quantity_serde import (
+    cohort_profile_from_jsonb,
+    quantity_from_jsonb,
+    quantity_from_schema,
+)
 from app.simulation.repositories.snapshot_repository import ScenarioSnapshotRepository
 from app.simulation.repositories.state_repository import (
     SimulationStateRepository,
@@ -854,8 +858,18 @@ async def _reconstruct_state_from_snapshot(
             meta_raw = json.loads(meta_raw)
 
         attributes = {}
+        cohort_profiles = None
         if isinstance(attr_data, dict):
+            raw_cohort = attr_data.get("_cohort_profiles")
+            if isinstance(raw_cohort, dict):
+                cohort_profiles = {
+                    cohort_key: cohort_profile_from_jsonb(profile_data)
+                    for cohort_key, profile_data in raw_cohort.items()
+                    if isinstance(profile_data, dict)
+                }
             for attr_key, envelope in attr_data.items():
+                if attr_key.startswith("_"):
+                    continue
                 if isinstance(envelope, dict):
                     try:
                         attributes[attr_key] = quantity_from_jsonb(envelope)
@@ -875,6 +889,7 @@ async def _reconstruct_state_from_snapshot(
             entity_type=meta_row["entity_type"],
             attributes=attributes,
             metadata=meta_raw,
+            cohort_profiles=cohort_profiles or None,
         )
 
     scenario_cfg = ScenarioConfig(

--- a/backend/tests/unit/test_nb3_entity_model.py
+++ b/backend/tests/unit/test_nb3_entity_model.py
@@ -1,0 +1,359 @@
+"""Unit tests for ADR-001 Amendment 2 — CohortProfile and AttributeType.
+
+Covers: AttributeType enum (Issue #30), CohortProfile dataclass (Issue #28),
+cohort_profiles field on SimulationEntity, JSONB round-trip via quantity_serde,
+Greece M12 seed fixture (EU-SILC 2010, Tier 2).
+"""
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.engine.models import CohortProfile, SimulationEntity
+from app.simulation.engine.quantity import AttributeType, Quantity, VariableType
+from app.simulation.repositories.quantity_serde import (
+    cohort_profile_from_jsonb,
+    cohort_profile_to_jsonb,
+    quantity_from_jsonb,
+    quantity_to_jsonb_envelope,
+)
+
+# ---------------------------------------------------------------------------
+# AttributeType enum
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeType:
+    def test_all_four_values_present(self) -> None:
+        values = {at.value for at in AttributeType}
+        assert values == {"stock", "flow", "structural_index", "rate"}
+
+    def test_str_enum_construction(self) -> None:
+        assert AttributeType("rate") is AttributeType.RATE
+        assert AttributeType("stock") is AttributeType.STOCK
+        assert AttributeType("flow") is AttributeType.FLOW
+        assert AttributeType("structural_index") is AttributeType.STRUCTURAL_INDEX
+
+    def test_unknown_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            AttributeType("unknown")
+
+
+# ---------------------------------------------------------------------------
+# Quantity.attribute_type and stock_flow_identity fields
+# ---------------------------------------------------------------------------
+
+
+class TestQuantityAmendment2Fields:
+    def test_attribute_type_defaults_none(self) -> None:
+        q = Quantity(value=Decimal("1"), unit="ratio", variable_type=VariableType.RATIO)
+        assert q.attribute_type is None
+
+    def test_stock_flow_identity_defaults_false(self) -> None:
+        q = Quantity(value=Decimal("1"), unit="ratio", variable_type=VariableType.RATIO)
+        assert q.stock_flow_identity is False
+
+    def test_attribute_type_set(self) -> None:
+        q = Quantity(
+            value=Decimal("0.18"),
+            unit="dimensionless",
+            variable_type=VariableType.RATIO,
+            attribute_type=AttributeType.RATE,
+        )
+        assert q.attribute_type is AttributeType.RATE
+
+    def test_stock_flow_identity_set(self) -> None:
+        q = Quantity(
+            value=Decimal("100"),
+            unit="USD_millions_current",
+            variable_type=VariableType.STOCK,
+            stock_flow_identity=True,
+        )
+        assert q.stock_flow_identity is True
+
+
+# ---------------------------------------------------------------------------
+# Quantity JSONB envelope — attribute_type and stock_flow_identity
+# ---------------------------------------------------------------------------
+
+
+class TestQuantityEnvelopeAmendment2:
+    def test_attribute_type_omitted_when_none(self) -> None:
+        q = Quantity(value=Decimal("1"), unit="ratio", variable_type=VariableType.RATIO)
+        envelope = quantity_to_jsonb_envelope(q)
+        assert "attribute_type" not in envelope
+
+    def test_stock_flow_identity_omitted_when_false(self) -> None:
+        q = Quantity(value=Decimal("1"), unit="ratio", variable_type=VariableType.RATIO)
+        envelope = quantity_to_jsonb_envelope(q)
+        assert "stock_flow_identity" not in envelope
+
+    def test_attribute_type_serialised_when_set(self) -> None:
+        q = Quantity(
+            value=Decimal("0.201"),
+            unit="dimensionless",
+            variable_type=VariableType.RATIO,
+            attribute_type=AttributeType.RATE,
+        )
+        envelope = quantity_to_jsonb_envelope(q)
+        assert envelope["attribute_type"] == "rate"
+
+    def test_stock_flow_identity_serialised_when_true(self) -> None:
+        q = Quantity(
+            value=Decimal("100"),
+            unit="USD_millions_current",
+            variable_type=VariableType.STOCK,
+            stock_flow_identity=True,
+        )
+        envelope = quantity_to_jsonb_envelope(q)
+        assert envelope["stock_flow_identity"] is True
+
+    def test_attribute_type_round_trips(self) -> None:
+        q = Quantity(
+            value=Decimal("0.065"),
+            unit="dimensionless",
+            variable_type=VariableType.RATIO,
+            confidence_tier=2,
+            attribute_type=AttributeType.RATE,
+        )
+        restored = quantity_from_jsonb(quantity_to_jsonb_envelope(q))
+        assert restored.attribute_type is AttributeType.RATE
+
+    def test_stock_flow_identity_round_trips(self) -> None:
+        q = Quantity(
+            value=Decimal("500"),
+            unit="USD_millions_current",
+            variable_type=VariableType.STOCK,
+            stock_flow_identity=True,
+        )
+        restored = quantity_from_jsonb(quantity_to_jsonb_envelope(q))
+        assert restored.stock_flow_identity is True
+
+    def test_unknown_attribute_type_in_jsonb_silently_none(self) -> None:
+        envelope = {
+            "_envelope_version": "1",
+            "value": "1.0",
+            "unit": "dimensionless",
+            "variable_type": "ratio",
+            "confidence_tier": 1,
+            "attribute_type": "FUTURE_UNKNOWN_TYPE",
+        }
+        q = quantity_from_jsonb(envelope)
+        assert q.attribute_type is None
+
+
+# ---------------------------------------------------------------------------
+# CohortProfile dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestCohortProfile:
+    def test_construct_with_attributes(self) -> None:
+        profile = CohortProfile(
+            attributes={
+                "poverty_headcount": Quantity(
+                    value=Decimal("0.201"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                )
+            }
+        )
+        assert "poverty_headcount" in profile.attributes
+        assert profile.attributes["poverty_headcount"].value == Decimal("0.201")
+
+    def test_empty_attributes_allowed(self) -> None:
+        profile = CohortProfile(attributes={})
+        assert profile.attributes == {}
+
+
+# ---------------------------------------------------------------------------
+# CohortProfile JSONB serde
+# ---------------------------------------------------------------------------
+
+
+class TestCohortProfileSerde:
+    def _q1_profile(self) -> CohortProfile:
+        return CohortProfile(
+            attributes={
+                "poverty_headcount": Quantity(
+                    value=Decimal("0.201"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                    source_id="EU_SILC_2010_GRC",
+                ),
+                "unemployment_rate": Quantity(
+                    value=Decimal("0.18"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                    source_id="EU_SILC_2010_GRC",
+                ),
+            }
+        )
+
+    def test_to_jsonb_produces_attribute_envelopes(self) -> None:
+        serialised = cohort_profile_to_jsonb(self._q1_profile())
+        assert "poverty_headcount" in serialised
+        assert "unemployment_rate" in serialised
+        assert serialised["poverty_headcount"]["value"] == "0.201"
+        assert serialised["unemployment_rate"]["value"] == "0.18"
+
+    def test_round_trip_preserves_value(self) -> None:
+        original = self._q1_profile()
+        serialised = cohort_profile_to_jsonb(original)
+        restored = cohort_profile_from_jsonb(serialised)
+        assert restored.attributes["poverty_headcount"].value == Decimal("0.201")
+        assert restored.attributes["unemployment_rate"].value == Decimal("0.18")
+
+    def test_round_trip_preserves_confidence_tier(self) -> None:
+        restored = cohort_profile_from_jsonb(cohort_profile_to_jsonb(self._q1_profile()))
+        assert restored.attributes["poverty_headcount"].confidence_tier == 2
+
+    def test_round_trip_preserves_attribute_type(self) -> None:
+        restored = cohort_profile_from_jsonb(cohort_profile_to_jsonb(self._q1_profile()))
+        assert restored.attributes["poverty_headcount"].attribute_type is AttributeType.RATE
+
+    def test_malformed_envelope_silently_skipped(self) -> None:
+        data = {
+            "poverty_headcount": {"value": "0.201", "unit": "dimensionless"},
+            "broken_key": "not_a_dict",
+        }
+        restored = cohort_profile_from_jsonb(data)
+        assert "broken_key" not in restored.attributes
+
+
+# ---------------------------------------------------------------------------
+# SimulationEntity.cohort_profiles field
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationEntityCohortProfiles:
+    def test_cohort_profiles_defaults_none(self) -> None:
+        entity = SimulationEntity(
+            id="GRC",
+            entity_type="country",
+            attributes={},
+            metadata={"name_en": "Greece"},
+        )
+        assert entity.cohort_profiles is None
+
+    def test_cohort_profiles_accepted(self) -> None:
+        q1 = CohortProfile(
+            attributes={
+                "poverty_headcount": Quantity(
+                    value=Decimal("0.201"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                )
+            }
+        )
+        entity = SimulationEntity(
+            id="GRC",
+            entity_type="country",
+            attributes={},
+            metadata={"name_en": "Greece"},
+            cohort_profiles={"Q1": q1},
+        )
+        assert entity.cohort_profiles is not None
+        assert "Q1" in entity.cohort_profiles
+
+
+# ---------------------------------------------------------------------------
+# Greece M12 seed fixture — EU-SILC 2010, Tier 2
+# ---------------------------------------------------------------------------
+
+
+class TestGreeceM12CohortSeed:
+    """Canonical seed fixture: EU-SILC 2010 Greece income-quintile distributional data."""
+
+    def _build_grc_entity(self) -> SimulationEntity:
+        q1 = CohortProfile(
+            attributes={
+                "poverty_headcount": Quantity(
+                    value=Decimal("0.201"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                    source_id="EU_SILC_2010_GRC",
+                ),
+                "unemployment_rate": Quantity(
+                    value=Decimal("0.18"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                    source_id="EU_SILC_2010_GRC",
+                ),
+            }
+        )
+        q5 = CohortProfile(
+            attributes={
+                "poverty_headcount": Quantity(
+                    value=Decimal("0.065"),
+                    unit="dimensionless",
+                    variable_type=VariableType.RATIO,
+                    attribute_type=AttributeType.RATE,
+                    confidence_tier=2,
+                    source_id="EU_SILC_2010_GRC",
+                ),
+            }
+        )
+        return SimulationEntity(
+            id="GRC",
+            entity_type="country",
+            attributes={},
+            metadata={"name_en": "Greece"},
+            cohort_profiles={"Q1": q1, "Q5": q5},
+        )
+
+    def test_q1_poverty_headcount_value(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q1_ph = entity.cohort_profiles["Q1"].attributes["poverty_headcount"]
+        assert q1_ph.value == pytest.approx(Decimal("0.201"))
+
+    def test_q1_poverty_headcount_confidence_tier(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        assert entity.cohort_profiles["Q1"].attributes["poverty_headcount"].confidence_tier == 2
+
+    def test_q5_poverty_headcount_value(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q5_ph = entity.cohort_profiles["Q5"].attributes["poverty_headcount"]
+        assert q5_ph.value == pytest.approx(Decimal("0.065"))
+
+    def test_q1_unemployment_rate_value(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q1_ur = entity.cohort_profiles["Q1"].attributes["unemployment_rate"]
+        assert q1_ur.value == pytest.approx(Decimal("0.18"))
+
+    def test_q1_poverty_headcount_is_rate(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q1_ph = entity.cohort_profiles["Q1"].attributes["poverty_headcount"]
+        assert q1_ph.attribute_type is AttributeType.RATE
+
+    def test_distributional_inequality_q1_greater_than_q5(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q1_ph = entity.cohort_profiles["Q1"].attributes["poverty_headcount"].value
+        q5_ph = entity.cohort_profiles["Q5"].attributes["poverty_headcount"].value
+        assert q1_ph > q5_ph
+
+    def test_cohort_profile_jsonb_round_trip(self) -> None:
+        entity = self._build_grc_entity()
+        assert entity.cohort_profiles is not None
+        q1_serialised = cohort_profile_to_jsonb(entity.cohort_profiles["Q1"])
+        q1_restored = cohort_profile_from_jsonb(q1_serialised)
+        assert q1_restored.attributes["poverty_headcount"].value == Decimal("0.201")
+        assert q1_restored.attributes["poverty_headcount"].confidence_tier == 2
+        assert q1_restored.attributes["poverty_headcount"].attribute_type is AttributeType.RATE

--- a/docs/adr/ADR-001-simulation-core-data-model.md
+++ b/docs/adr/ADR-001-simulation-core-data-model.md
@@ -9,7 +9,9 @@ Accepted
 **Valid Until:** Milestone 11.5 — Usability Validation and Experience Audit
 **License Status:** CURRENT
 
-**Last Reviewed:** 2026-06-04 — M11 exit review (SCAN-025). No renewal triggers fired during Milestone 11. PoliticalEconomyModule uses existing `MeasurementFramework.GOVERNANCE` and `HUMAN_DEVELOPMENT` enum values; `legitimacy_index` and `elite_capture_coefficient` are standard Quantity attributes on `SimulationEntity.attributes`. `_steps_projected` field added to state_data envelope (snapshot JSONB — application layer, not Quantity type). Matrix engine uses identical Quantity types and Event contracts — equivalence harness confirms 1e-10 agreement. `InputSource.CONDITIONALITY` and `CompoundStateCondition` extend the orchestration layer (ADR-002 territory), not the core data model. No `MeasurementFramework` taxonomy modifications, no `DATA_STANDARDS.md` unit standard changes affecting attribute store design. License renewed to Milestone 11.5.
+**Last Reviewed:** 2026-06-06 — M12 Wave B (Amendment 2). Renewal trigger fired: `SimulationEntity` gains `cohort_profiles` field; `Quantity` gains `attribute_type` and `stock_flow_identity` fields; new `AttributeType` enum and `CohortProfile` dataclass added. Amendment 2 applied — see Amendment 2 section below. License Status renewed to CURRENT. License renewed to Milestone 11.5.
+
+**Previously reviewed:** 2026-06-04 — M11 exit review (SCAN-025). No renewal triggers fired during Milestone 11. PoliticalEconomyModule uses existing `MeasurementFramework.GOVERNANCE` and `HUMAN_DEVELOPMENT` enum values; `legitimacy_index` and `elite_capture_coefficient` are standard Quantity attributes on `SimulationEntity.attributes`. `_steps_projected` field added to state_data envelope (snapshot JSONB — application layer, not Quantity type). Matrix engine uses identical Quantity types and Event contracts — equivalence harness confirms 1e-10 agreement. `InputSource.CONDITIONALITY` and `CompoundStateCondition` extend the orchestration layer (ADR-002 territory), not the core data model. No `MeasurementFramework` taxonomy modifications, no `DATA_STANDARDS.md` unit standard changes affecting attribute store design. License renewed to Milestone 11.5.
 
 **Previously reviewed:** 2026-06-02 — M10 exit review (SCAN-024). No renewal triggers fired
 during Milestone 10. GovernanceModule promotion (`"governance"` removed from
@@ -322,3 +324,98 @@ In addition to original triggers, this amendment adds:
 - `VariableType` enum values modified (STOCK/FLOW/RATIO/DIMENSIONLESS)
 - `propagate_confidence` rule changed to anything other than lower-of-two
 - `Quantity` field contract broken (required fields removed or type changed)
+
+---
+
+## Amendment 2 — Issue #28, Issue #30: CohortProfile and AttributeType
+
+**Date:** 2026-06-06
+**Closes:** Issue #28 (CohortProfile dataclass), Issue #30 (AttributeType enum)
+**Implemented in:** PR closing #28 + #30 (M12 Wave B, branch feat/nb3-entity-model)
+
+### What Changed
+
+**`AttributeType` enum** added to `app/simulation/engine/quantity.py`:
+
+```python
+class AttributeType(str, Enum):
+    STOCK = "stock"
+    FLOW = "flow"
+    STRUCTURAL_INDEX = "structural_index"
+    RATE = "rate"
+```
+
+Economic-semantic classification — complementary to `VariableType`. `VariableType`
+drives propagation behaviour (STOCK replaces, FLOW accumulates). `AttributeType`
+records what the quantity *means* economically (balance-sheet stock, income-statement
+flow, headcount rate, composite index). Both fields can coexist on the same Quantity.
+
+**Two new optional fields on `Quantity`:**
+- `attribute_type: AttributeType | None = None` — economic classification; None when not yet assigned
+- `stock_flow_identity: bool = False` — when True, engine warns if `stock[t+1] ≠ stock[t] + net_flow[t]`
+
+Both fields are **backwards-compatible** — all existing Quantity instances remain valid
+with `attribute_type=None, stock_flow_identity=False`.
+
+**`CohortProfile` dataclass** added to `app/simulation/engine/models.py`:
+
+```python
+@dataclass
+class CohortProfile:
+    attributes: dict[str, Quantity]
+```
+
+Income-quintile or age-band level attribute container for one entity cohort.
+Not a sub-entity — cohort profiles do not participate in the propagation graph.
+
+**`cohort_profiles: dict[str, CohortProfile] | None = None`** field added to
+`SimulationEntity`. Cohort key convention: `"Q1"`–`"Q5"` for income quintiles,
+`"youth_15_24"` etc. for age bands.
+
+**Cohort key convention** (canonical):
+- Income quintiles: `"Q1"` (lowest) through `"Q5"` (highest)
+- Age bands: `"youth_15_24"`, `"prime_25_54"`, `"older_55_64"`, `"senior_65plus"`
+- Cross-dimension: `"Q1_youth_15_24"` (underscore separator)
+
+**JSONB storage path:**
+- `attribute_type` and `stock_flow_identity` added to the SA-09 Quantity envelope.
+  `attribute_type` omitted when None; `stock_flow_identity` omitted when False
+  (wire-space optimisation preserving backwards compatibility with v1 snapshots).
+- `cohort_profiles` stored as `"_cohort_profiles"` sub-key within the entity's block
+  in `scenario_state_snapshots.state_data`. Underscore prefix marks it as metadata,
+  invisible to the compare endpoint's attribute key iteration.
+- Serialised via `cohort_profile_to_jsonb` / `cohort_profile_from_jsonb` in
+  `app/simulation/repositories/quantity_serde.py`.
+- NOT stored in `simulation_entities.attributes` (that column holds entity baseline
+  attributes, not distributional cohort data).
+
+**Snapshot reconstruction** (`web_scenario_runner.py` `_reconstruct_state_from_snapshot`):
+- `_cohort_profiles` popped from `attr_data` before quantity iteration
+- All underscore-prefixed keys skipped in quantity loop (defensive, future-proof)
+- `cohort_profile_from_jsonb` called per cohort; result passed as `cohort_profiles=`
+  to `SimulationEntity` constructor
+
+**Greece M12 seed fixture** (EU-SILC 2010, Tier 2, `source_registry_id="EU_SILC_2010_GRC"`):
+- `Q1.poverty_headcount = 0.201` (RATE, dimensionless)
+- `Q5.poverty_headcount = 0.065` (RATE, dimensionless)
+- `Q1.unemployment_rate = 0.18` (RATE, dimensionless)
+
+### Known Limitations at Amendment Time
+
+**CP-1:** `CohortProfile` is a distributional data container only. Cohort profiles
+do not participate in the propagation graph — modules cannot emit Events that target
+a cohort profile, only cohort entities (the existing `GRC:CHT:...` entity injection
+pattern from ADR-005). Full distributional-level propagation (Q1 attributes respond
+differently to fiscal shocks than Q5) is deferred to a future amendment.
+
+**CP-2:** `stock_flow_identity` flag records intent but enforcement (the actual
+engine warning) is not yet wired into the propagation engine. Flag is stored and
+round-trips through JSONB; engine enforcement is an M13 obligation.
+
+### Renewal Triggers Added
+
+In addition to triggers from Amendments 1 and original ADR, this amendment adds:
+- `AttributeType` enum values modified or removed
+- `CohortProfile.attributes` field contract broken
+- Cohort key convention changed without migration path
+- `_cohort_profiles` JSONB storage key renamed without migration

--- a/docs/schema/simulation_state.yml
+++ b/docs/schema/simulation_state.yml
@@ -12,8 +12,10 @@
 #   backend/app/simulation/repositories/quantity_serde.py — serialisation contracts
 
 ---
-schema_version: "1.0"
-captured: "2026-04-26"
+schema_version: "1.1"
+captured: "2026-06-06"
+amendments:
+  - "Amendment 2 (Issue #28, Issue #30): AttributeType enum, CohortProfile dataclass, cohort_profiles field on SimulationEntity, attribute_type and stock_flow_identity fields on Quantity"
 
 # ---------------------------------------------------------------------------
 # VariableType
@@ -52,6 +54,43 @@ VariableType:
         The classification describes storage behaviour, not significance.
         A capability index is DIMENSIONLESS and a primary output with equal
         display weight to financial indicators.
+
+# ---------------------------------------------------------------------------
+# AttributeType
+# ---------------------------------------------------------------------------
+AttributeType:
+  type: enum
+  module: app.simulation.engine.quantity
+  description: >
+    Economic-semantic classification of a Quantity (ADR-001 Amendment 2, Issue #30).
+    Complementary to VariableType — VariableType drives propagation behaviour;
+    AttributeType records economic meaning. Both can coexist on the same Quantity.
+    Optional: defaults to None when classification is not relevant or not yet assigned.
+  values:
+    STOCK:
+      value: "stock"
+      description: >
+        Level at a point in time (economic balance sheet sense).
+        Examples: debt outstanding, foreign exchange reserves, forest cover.
+        Distinct from VariableType.STOCK — an economic STOCK may use
+        VariableType.STOCK, RATIO, or DIMENSIONLESS depending on unit.
+    FLOW:
+      value: "flow"
+      description: >
+        Change over a period (economic income statement sense).
+        Examples: GDP, exports, government revenue, remittances.
+    STRUCTURAL_INDEX:
+      value: "structural_index"
+      description: >
+        A composite or index capturing institutional or structural capacity.
+        Examples: press_freedom_index, rule_of_law_percentile, HDI component.
+        Not derived from a simple ratio of two commensurable quantities.
+    RATE:
+      value: "rate"
+      description: >
+        A ratio or proportional measure. Examples: unemployment_rate,
+        poverty_headcount, inflation_rate, interest_rate.
+        Dimensionally a fraction (often per-annum or headcount proportion).
 
 # ---------------------------------------------------------------------------
 # MeasurementFramework
@@ -133,6 +172,21 @@ Quantity:
         Data quality tier per DATA_STANDARDS.md. 1=highest, 5=lowest.
         Tier propagation: max() of all contributing tiers (lower-of-two rule).
         DO NOT use the default 1 for ingested data — set explicitly at ingestion.
+    attribute_type:
+      type: "AttributeType | None"
+      default: null
+      description: >
+        Economic-semantic classification (ADR-001 Amendment 2, Issue #30).
+        Optional — None when not yet classified. Serialised to JSONB as
+        "attribute_type" key (string value) when not None; omitted when None.
+    stock_flow_identity:
+      type: bool
+      default: false
+      description: >
+        When True, the engine warns if stock[t+1] ≠ stock[t] + net_flow[t].
+        Set on stock-flow identity pairs where integrity checking is meaningful.
+        Serialised to JSONB as "stock_flow_identity": true only when True;
+        omitted from envelope when False (wire-space optimisation).
   methods:
     propagate_confidence:
       signature: "propagate_confidence(*quantities: Quantity) -> int"
@@ -168,6 +222,43 @@ MonetaryValue:
       type: str
       default: ""
       values: ["official", "parallel", "ppp", "fixed"]
+
+# ---------------------------------------------------------------------------
+# CohortProfile
+# ---------------------------------------------------------------------------
+CohortProfile:
+  type: dataclass
+  module: app.simulation.engine.models
+  description: >
+    Income-quintile or age-band level attribute container for one entity cohort
+    (ADR-001 Amendment 2, Issue #28). Stored on SimulationEntity.cohort_profiles
+    under a cohort key string. Each CohortProfile holds the same attribute
+    structure as SimulationEntity.attributes — Quantity instances keyed by
+    attribute name. Not a sub-entity: cohort profiles do not participate in
+    the propagation graph; they are read-only distributional data.
+  fields:
+    attributes:
+      type: "dict[str, Quantity]"
+      description: >
+        Cohort-level simulation state variables as Quantity instances.
+        Same structure as SimulationEntity.attributes — attribute_key maps to
+        a typed Quantity. At M12 seeding, relevant keys include:
+        poverty_headcount (RATE), unemployment_rate (RATE).
+  cohort_key_convention: >
+    Income quintiles: "Q1" (lowest) through "Q5" (highest).
+    Age bands: "youth_15_24", "prime_25_54", "older_55_64", "senior_65plus".
+    Keys are case-sensitive. Multiple dimensions can be combined with underscore:
+    "Q1_youth_15_24" (income-quintile × age-band intersection).
+  jsonb_storage: >
+    Serialised to the "_cohort_profiles" sub-key of the entity's block in
+    scenario_state_snapshots.state_data (snapshot path) via
+    cohort_profile_to_jsonb() / cohort_profile_from_jsonb() in quantity_serde.py.
+    Underscore prefix marks it as metadata, invisible to the compare endpoint's
+    entity attribute iteration. NOT stored in simulation_entities.attributes.
+  seed_reference: >
+    Greece (GRC) M12 seed: Q1 poverty_headcount=0.201, Q5 poverty_headcount=0.065,
+    Q1 unemployment_rate=0.18 (EU-SILC 2010, Tier 2).
+    Seed fixture: backend/tests/unit/test_nb3_entity_model.py
 
 # ---------------------------------------------------------------------------
 # SimulationEntity
@@ -214,6 +305,15 @@ SimulationEntity:
       type: "Geometry | None"
       default: null
       description: Spatial reference. Populated from DB in Milestone 2+.
+    cohort_profiles:
+      type: "dict[str, CohortProfile] | None"
+      default: null
+      description: >
+        Income-quintile or age-band level distributional data (ADR-001 Amendment 2,
+        Issue #28). None when no cohort data is available for this entity.
+        Cohort key convention: "Q1"–"Q5" for income quintiles, "youth_15_24" etc.
+        for age bands. Serialised under "_cohort_profiles" in snapshot state_data;
+        NOT loaded from simulation_entities.attributes (that column has no cohort data).
   key_methods:
     get_attribute:
       signature: "(key: str) -> Quantity | None"
@@ -641,12 +741,28 @@ quantity_serde:
       source_registry_id: "str or null"
       measurement_framework: "enum.value string or null  — e.g. 'human_development'"
       _envelope_version: "'1'  — always set in simulation layer output"
+      attribute_type: "AttributeType.value string — omitted when None (Amendment 2)"
+      stock_flow_identity: "true — omitted from envelope when False (Amendment 2)"
   quantity_from_jsonb:
     input_handling:
       value: "Decimal(str(raw_value))  — handles int, float, str, Decimal inputs"
       variable_type: "VariableType(raw_string)"
       measurement_framework: "MeasurementFramework(raw_string) if present, else None"
       confidence_tier: "int(raw) — required field"
+      attribute_type: "AttributeType(raw_string) if present, else None — unknown strings → None"
+      stock_flow_identity: "bool(data.get('stock_flow_identity', False))"
+  cohort_serde:
+    cohort_profile_to_jsonb:
+      description: >
+        Serialises a CohortProfile to dict[attr_key → SA-09 envelope].
+        Stored as the value under a cohort_key within "_cohort_profiles".
+    cohort_profile_from_jsonb:
+      description: >
+        Inverse of cohort_profile_to_jsonb. Malformed envelope keys silently
+        skipped (contextlib.suppress). Returns CohortProfile with deserialized
+        Quantity attributes.
+    storage_path: >
+      entity_block["_cohort_profiles"][cohort_key][attr_key] → SA-09 Quantity envelope
   ia1_disclosure:
     constant_name: IA1_CANONICAL_PHRASE
     description: >


### PR DESCRIPTION
## Summary

- **AttributeType enum** (Issue #30): economic-semantic classification `STOCK | FLOW | STRUCTURAL_INDEX | RATE` — complementary to `VariableType` which drives propagation; stored in Quantity.attribute_type (optional, None when not classified)
- **CohortProfile dataclass** (Issue #28): `attributes: dict[str, Quantity]` container for income-quintile/age-band distributional data; added as `cohort_profiles: dict[str, CohortProfile] | None` on `SimulationEntity`
- **Full JSONB round-trip**: `cohort_profile_to_jsonb` / `cohort_profile_from_jsonb` in `quantity_serde.py`; stored under `_cohort_profiles` sub-key in entity's state_data block; underscore prefix keeps it invisible to compare endpoint iteration
- **Snapshot reconstruction** in `web_scenario_runner._reconstruct_state_from_snapshot`: pops `_cohort_profiles`, skips all underscore-prefixed keys in quantity loop
- **ADR-001 Amendment 2** section added; `simulation_state.yml` updated to schema v1.1
- **Greece M12 seed fixture** (EU-SILC 2010, Tier 2): Q1 poverty_headcount=0.201, Q5 poverty_headcount=0.065, Q1 unemployment_rate=0.18

## Test plan

- [x] 30 new unit tests in `test_nb3_entity_model.py` — all passing
- [x] `AttributeType` enum construction, unknown-value handling
- [x] `Quantity.attribute_type` and `stock_flow_identity` field defaults, setting, JSONB round-trip
- [x] Wire-space optimisation: attribute_type omitted from envelope when None; stock_flow_identity omitted when False
- [x] `CohortProfile` construct, empty attributes allowed
- [x] `cohort_profile_to_jsonb` / `cohort_profile_from_jsonb` round-trip preserving value, confidence_tier, attribute_type
- [x] Malformed envelope key silently skipped
- [x] `SimulationEntity.cohort_profiles` defaults None, accepts dict
- [x] Greece M12 seed assertions (value ≈ 0.201, tier=2, RATE, distributional inequality Q1>Q5)
- [x] `ruff check .` — 0 violations
- [x] `python -m mypy app/` — Success: no issues found in 54 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)