### PR TITLE
feat(engine): investment climate state variables for demo fixtures (closes #34)

### DIFF
--- a/backend/tests/fixtures/argentina_2001_2002_scenario.py
+++ b/backend/tests/fixtures/argentina_2001_2002_scenario.py
@@ -91,13 +91,79 @@ def build_argentina_scenario() -> ScenarioCreateRequest:
         measurement_framework="human_development",
     )
 
+    # Investment climate state variables — Issue #34, NB-4 (ADR-001 Amendment 2).
+    # Argentina 2000 baseline (scenario initial state reflects end-2000 conditions).
+
+    # JP Morgan EMBI+ spread — Argentina December 2000.
+    # Argentina's EMBI spread reached ~700-750bps in late 2000 after S&P's
+    # negative outlook revision (October 2000). The Blindaje ($39.7bn) in
+    # December 2000 temporarily compressed spreads, but pre-Blindaje close
+    # was ~750bps. Confidence tier 2: market data, JP Morgan index series.
+    initial_sovereign_risk_premium = QuantitySchema(
+        value="0.075",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="rate",
+        confidence_tier=2,
+        observation_date=date(2001, 1, 1),
+        source_registry_id="JPMORGAN_EMBI_ARG_2000",
+        measurement_framework="financial",
+    )
+
+    # UNCTAD World Investment Report 2001 — FDI inward stock / GDP for Argentina.
+    # Argentina's inward FDI stock was approximately $67bn against GDP of ~$267bn
+    # (25.1% ratio) at end-2000. Spain, USA, and France were largest investors.
+    # Confidence tier 2: official multilateral statistics, annual vintage.
+    initial_fdi_stock_pct_gdp = QuantitySchema(
+        value="0.251",
+        unit="ratio",
+        variable_type="stock",
+        attribute_type="stock",
+        confidence_tier=2,
+        observation_date=date(2001, 1, 1),
+        source_registry_id="UNCTAD_FDI_STATS_ARG_2000",
+        measurement_framework="financial",
+    )
+
+    # INDEC Balance of Payments 2000 — net portfolio investment / GDP.
+    # Argentina had significant portfolio outflows in 2000 as investor
+    # confidence deteriorated: approximately -$12bn (~-4.5% of GDP).
+    # Confidence tier 2: official national statistics.
+    initial_portfolio_flow_velocity = QuantitySchema(
+        value="-0.045",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="flow",
+        confidence_tier=2,
+        observation_date=date(2001, 1, 1),
+        source_registry_id="INDEC_BOP_ARG_2000",
+        measurement_framework="financial",
+    )
+
+    # S&P sovereign credit rating — Argentina January 2001: BB.
+    # Mapped to 0–100 index (AAA=100, D=0) using standard 21-notch linear scale:
+    # BB = 38. Argentina had been downgraded steadily through 2000 and was rated
+    # BB by S&P at the start of 2001, reflecting sub-investment-grade status.
+    # Confidence tier 1: direct observation from rating agency announcement.
+    initial_credit_rating_score = QuantitySchema(
+        value="38.0",
+        unit="index_0_100",
+        variable_type="stock",
+        attribute_type="structural_index",
+        confidence_tier=1,
+        observation_date=date(2001, 1, 1),
+        source_registry_id="SP_SOVEREIGN_RATINGS_ARG_2001",
+        measurement_framework="financial",
+    )
+
     return ScenarioCreateRequest(
         name="Argentina 2001-2002 Currency and Debt Crisis Backtesting Fixture",
         description=(
             "Backtesting fixture for Issue #192. "
             "Reproduces the Argentina 2001–2002 sovereign default and convertibility "
             "collapse to validate DIRECTION_ONLY GDP contraction thresholds. "
-            "Initial state: IMF WEO April 2001 + INDEC EPH October 2000."
+            "Initial state: IMF WEO April 2001 + INDEC EPH October 2000 "
+            "+ investment climate variables NB-4 (Issue #34)."
         ),
         configuration=ScenarioConfigSchema(
             entities=["ARG"],
@@ -107,6 +173,10 @@ def build_argentina_scenario() -> ScenarioCreateRequest:
                 "ARG": {
                     "gdp_growth": initial_gdp_growth,
                     "unemployment_rate": initial_unemployment_rate,
+                    "sovereign_risk_premium": initial_sovereign_risk_premium,
+                    "fdi_stock_pct_gdp": initial_fdi_stock_pct_gdp,
+                    "portfolio_flow_velocity": initial_portfolio_flow_velocity,
+                    "credit_rating_score": initial_credit_rating_score,
                 },
             },
         ),

--- a/backend/tests/fixtures/greece_2010_scenario.py
+++ b/backend/tests/fixtures/greece_2010_scenario.py
@@ -140,6 +140,70 @@ def build_greece_scenario() -> ScenarioCreateRequest:
         measurement_framework="financial",
     )
 
+    # Investment climate state variables — Issue #34, NB-4 (ADR-001 Amendment 2).
+    # All four carry attribute_type tags per the AttributeType enum.
+
+    # ECB Statistical Data Warehouse — 10Y GRC-DEU spread, January 2010 mean.
+    # Spread widened from ~130bps in mid-2009 to ~300bps by January 2010 as
+    # market scrutiny of Greek fiscal accounts intensified ahead of the May
+    # bailout request. Confidence tier 2: official central bank data series.
+    initial_sovereign_risk_premium = QuantitySchema(
+        value="0.030",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="rate",
+        confidence_tier=2,
+        observation_date=date(2010, 1, 31),
+        source_registry_id="ECB_SDW_GRC_SPREAD_2010",
+        measurement_framework="financial",
+    )
+
+    # UNCTAD World Investment Report 2010 — FDI inward stock / GDP for Greece.
+    # Greece's inward FDI stock was approximately €23bn against GDP of ~€230bn
+    # (10.5% ratio). Tourism infrastructure and shipping were primary recipients.
+    # Confidence tier 2: official multilateral statistics, annual vintage.
+    initial_fdi_stock_pct_gdp = QuantitySchema(
+        value="0.105",
+        unit="ratio",
+        variable_type="stock",
+        attribute_type="stock",
+        confidence_tier=2,
+        observation_date=date(2010, 1, 1),
+        source_registry_id="UNCTAD_FDI_STATS_GRC_2010",
+        measurement_framework="financial",
+    )
+
+    # IMF Balance of Payments Statistics 2010 — net portfolio investment / GDP.
+    # Greece experienced accelerating portfolio outflows as sovereign spreads
+    # widened: net portfolio investment was approximately -€18bn in 2009 (pre-
+    # programme year), equivalent to ~-8% of GDP. Confidence tier 2.
+    initial_portfolio_flow_velocity = QuantitySchema(
+        value="-0.080",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="flow",
+        confidence_tier=2,
+        observation_date=date(2010, 1, 1),
+        source_registry_id="IMF_BOP_GRC_2010",
+        measurement_framework="financial",
+    )
+
+    # S&P sovereign credit rating — Greece January 2010: BBB+.
+    # Mapped to 0–100 index (AAA=100, D=0) using standard 21-notch linear scale:
+    # BBB+ = 55. Greece was downgraded to BB+ (junk) in April 2010 on programme
+    # entry. The January 2010 BBB+ baseline precedes the first IMF step.
+    # Confidence tier 1: direct observation from rating agency announcement.
+    initial_credit_rating_score = QuantitySchema(
+        value="55.0",
+        unit="index_0_100",
+        variable_type="stock",
+        attribute_type="structural_index",
+        confidence_tier=1,
+        observation_date=date(2010, 1, 1),
+        source_registry_id="SP_SOVEREIGN_RATINGS_GRC_2010",
+        measurement_framework="financial",
+    )
+
     return ScenarioCreateRequest(
         name="Greece 2010-2015 IMF Program Backtesting Fixture",
         description=(
@@ -174,6 +238,10 @@ def build_greece_scenario() -> ScenarioCreateRequest:
                     "net_enrollment_secondary": initial_net_enrollment_secondary,
                     "reserve_coverage_months": initial_reserve_coverage_months,
                     "trend_growth": initial_trend_growth,
+                    "sovereign_risk_premium": initial_sovereign_risk_premium,
+                    "fdi_stock_pct_gdp": initial_fdi_stock_pct_gdp,
+                    "portfolio_flow_velocity": initial_portfolio_flow_velocity,
+                    "credit_rating_score": initial_credit_rating_score,
                 },
             },
         ),

--- a/backend/tests/unit/test_backtesting_fixtures.py
+++ b/backend/tests/unit/test_backtesting_fixtures.py
@@ -339,11 +339,11 @@ def test_build_greece_scenario_initial_gdp_growth_is_string() -> None:
     assert isinstance(gdp.value, str)
 
 
-def test_build_greece_scenario_has_six_initial_attributes() -> None:
-    """Greece fixture has 6 initial attributes after mean-reversion seed added (Issue #221)."""
+def test_build_greece_scenario_has_ten_initial_attributes() -> None:
+    """Greece fixture has 10 initial attributes after NB-4 investment climate seed (Issue #34)."""
     scenario = build_greece_scenario()
     grc_attrs = scenario.configuration.initial_attributes["GRC"]
-    assert len(grc_attrs) == 6
+    assert len(grc_attrs) == 10
     expected_keys = {
         "gdp_growth",
         "unemployment_rate",
@@ -351,6 +351,10 @@ def test_build_greece_scenario_has_six_initial_attributes() -> None:
         "net_enrollment_secondary",
         "reserve_coverage_months",
         "trend_growth",
+        "sovereign_risk_premium",
+        "fdi_stock_pct_gdp",
+        "portfolio_flow_velocity",
+        "credit_rating_score",
     }
     assert set(grc_attrs.keys()) == expected_keys
 

--- a/backend/tests/unit/test_nb4_investment_climate.py
+++ b/backend/tests/unit/test_nb4_investment_climate.py
@@ -1,0 +1,228 @@
+"""Unit tests for NB-4 — investment climate state variables (Issue #34).
+
+Covers: sovereign_risk_premium, fdi_stock_pct_gdp, portfolio_flow_velocity,
+credit_rating_score in both the Greece 2010 and Argentina 2001 demo fixtures.
+Validates values, units, attribute_types, variable_types, and confidence tiers
+against the historical sources cited in each fixture.
+
+Greece 2010 sources:
+  ECB_SDW_GRC_SPREAD_2010     — ECB Statistical Data Warehouse 10Y spread
+  UNCTAD_FDI_STATS_GRC_2010   — UNCTAD World Investment Report 2010
+  IMF_BOP_GRC_2010            — IMF Balance of Payments Statistics 2010
+  SP_SOVEREIGN_RATINGS_GRC_2010 — S&P sovereign rating January 2010 (BBB+→55)
+
+Argentina 2001 sources:
+  JPMORGAN_EMBI_ARG_2000      — JP Morgan EMBI+ spread December 2000
+  UNCTAD_FDI_STATS_ARG_2000   — UNCTAD World Investment Report 2001
+  INDEC_BOP_ARG_2000          — INDEC Balance of Payments 2000
+  SP_SOVEREIGN_RATINGS_ARG_2001 — S&P sovereign rating January 2001 (BB→38)
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tests.fixtures.argentina_2001_2002_scenario import build_argentina_scenario
+from tests.fixtures.greece_2010_scenario import build_greece_scenario
+
+# ---------------------------------------------------------------------------
+# Greece 2010 — investment climate initial attributes
+# ---------------------------------------------------------------------------
+
+class TestGreeceInvestmentClimate:
+    """Investment climate state variables seeded for Greece 2010 (NB-4, Issue #34)."""
+
+    def _grc_attrs(self) -> dict:  # type: ignore[type-arg]
+        req = build_greece_scenario()
+        return req.configuration.initial_attributes["GRC"]  # type: ignore[index]
+
+    def test_sovereign_risk_premium_present(self) -> None:
+        assert "sovereign_risk_premium" in self._grc_attrs()
+
+    def test_sovereign_risk_premium_value(self) -> None:
+        attr = self._grc_attrs()["sovereign_risk_premium"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("0.030"))
+
+    def test_sovereign_risk_premium_unit(self) -> None:
+        assert self._grc_attrs()["sovereign_risk_premium"].unit == "ratio"
+
+    def test_sovereign_risk_premium_attribute_type(self) -> None:
+        assert self._grc_attrs()["sovereign_risk_premium"].attribute_type == "rate"
+
+    def test_sovereign_risk_premium_variable_type(self) -> None:
+        assert self._grc_attrs()["sovereign_risk_premium"].variable_type == "ratio"
+
+    def test_sovereign_risk_premium_confidence_tier(self) -> None:
+        assert self._grc_attrs()["sovereign_risk_premium"].confidence_tier == 2
+
+    def test_sovereign_risk_premium_source(self) -> None:
+        source = self._grc_attrs()["sovereign_risk_premium"].source_registry_id
+        assert source == "ECB_SDW_GRC_SPREAD_2010"
+
+    def test_sovereign_risk_premium_framework(self) -> None:
+        assert self._grc_attrs()["sovereign_risk_premium"].measurement_framework == "financial"
+
+    def test_fdi_stock_pct_gdp_present(self) -> None:
+        assert "fdi_stock_pct_gdp" in self._grc_attrs()
+
+    def test_fdi_stock_pct_gdp_value(self) -> None:
+        attr = self._grc_attrs()["fdi_stock_pct_gdp"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("0.105"))
+
+    def test_fdi_stock_pct_gdp_attribute_type(self) -> None:
+        assert self._grc_attrs()["fdi_stock_pct_gdp"].attribute_type == "stock"
+
+    def test_fdi_stock_pct_gdp_variable_type(self) -> None:
+        assert self._grc_attrs()["fdi_stock_pct_gdp"].variable_type == "stock"
+
+    def test_fdi_stock_pct_gdp_confidence_tier(self) -> None:
+        assert self._grc_attrs()["fdi_stock_pct_gdp"].confidence_tier == 2
+
+    def test_portfolio_flow_velocity_present(self) -> None:
+        assert "portfolio_flow_velocity" in self._grc_attrs()
+
+    def test_portfolio_flow_velocity_value(self) -> None:
+        attr = self._grc_attrs()["portfolio_flow_velocity"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("-0.080"))
+
+    def test_portfolio_flow_velocity_attribute_type(self) -> None:
+        assert self._grc_attrs()["portfolio_flow_velocity"].attribute_type == "flow"
+
+    def test_portfolio_flow_velocity_negative(self) -> None:
+        # Capital outflow: portfolio_flow_velocity must be negative for Greece 2010.
+        assert Decimal(self._grc_attrs()["portfolio_flow_velocity"].value) < 0
+
+    def test_credit_rating_score_present(self) -> None:
+        assert "credit_rating_score" in self._grc_attrs()
+
+    def test_credit_rating_score_value(self) -> None:
+        attr = self._grc_attrs()["credit_rating_score"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("55.0"))
+
+    def test_credit_rating_score_attribute_type(self) -> None:
+        assert self._grc_attrs()["credit_rating_score"].attribute_type == "structural_index"
+
+    def test_credit_rating_score_unit(self) -> None:
+        assert self._grc_attrs()["credit_rating_score"].unit == "index_0_100"
+
+    def test_credit_rating_score_confidence_tier(self) -> None:
+        # Confidence tier 1: direct observation from rating agency announcement.
+        assert self._grc_attrs()["credit_rating_score"].confidence_tier == 1
+
+
+# ---------------------------------------------------------------------------
+# Argentina 2001 — investment climate initial attributes
+# ---------------------------------------------------------------------------
+
+class TestArgentinaInvestmentClimate:
+    """Investment climate state variables seeded for Argentina 2001 (NB-4, Issue #34)."""
+
+    def _arg_attrs(self) -> dict:  # type: ignore[type-arg]
+        req = build_argentina_scenario()
+        return req.configuration.initial_attributes["ARG"]  # type: ignore[index]
+
+    def test_sovereign_risk_premium_present(self) -> None:
+        assert "sovereign_risk_premium" in self._arg_attrs()
+
+    def test_sovereign_risk_premium_value(self) -> None:
+        attr = self._arg_attrs()["sovereign_risk_premium"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("0.075"))
+
+    def test_sovereign_risk_premium_attribute_type(self) -> None:
+        assert self._arg_attrs()["sovereign_risk_premium"].attribute_type == "rate"
+
+    def test_sovereign_risk_premium_higher_than_greece(self) -> None:
+        # Argentina 2001 spread (~750bps) must exceed Greece 2010 spread (~300bps).
+        arg_spread = Decimal(self._arg_attrs()["sovereign_risk_premium"].value)
+        grc_attrs = build_greece_scenario().configuration.initial_attributes["GRC"]  # type: ignore[index]
+        grc_spread = Decimal(grc_attrs["sovereign_risk_premium"].value)
+        assert arg_spread > grc_spread
+
+    def test_fdi_stock_pct_gdp_present(self) -> None:
+        assert "fdi_stock_pct_gdp" in self._arg_attrs()
+
+    def test_fdi_stock_pct_gdp_value(self) -> None:
+        attr = self._arg_attrs()["fdi_stock_pct_gdp"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("0.251"))
+
+    def test_fdi_stock_pct_gdp_attribute_type(self) -> None:
+        assert self._arg_attrs()["fdi_stock_pct_gdp"].attribute_type == "stock"
+
+    def test_portfolio_flow_velocity_present(self) -> None:
+        assert "portfolio_flow_velocity" in self._arg_attrs()
+
+    def test_portfolio_flow_velocity_value(self) -> None:
+        attr = self._arg_attrs()["portfolio_flow_velocity"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("-0.045"))
+
+    def test_portfolio_flow_velocity_attribute_type(self) -> None:
+        assert self._arg_attrs()["portfolio_flow_velocity"].attribute_type == "flow"
+
+    def test_portfolio_flow_velocity_negative(self) -> None:
+        # Capital outflow: portfolio_flow_velocity must be negative for Argentina 2001.
+        assert Decimal(self._arg_attrs()["portfolio_flow_velocity"].value) < 0
+
+    def test_credit_rating_score_present(self) -> None:
+        assert "credit_rating_score" in self._arg_attrs()
+
+    def test_credit_rating_score_value(self) -> None:
+        attr = self._arg_attrs()["credit_rating_score"]
+        assert Decimal(attr.value) == pytest.approx(Decimal("38.0"))
+
+    def test_credit_rating_score_attribute_type(self) -> None:
+        assert self._arg_attrs()["credit_rating_score"].attribute_type == "structural_index"
+
+    def test_credit_rating_score_lower_than_greece(self) -> None:
+        # Argentina BB (38) must score lower than Greece BBB+ (55).
+        arg_score = Decimal(self._arg_attrs()["credit_rating_score"].value)
+        grc_attrs = build_greece_scenario().configuration.initial_attributes["GRC"]  # type: ignore[index]
+        grc_score = Decimal(grc_attrs["credit_rating_score"].value)
+        assert arg_score < grc_score
+
+
+# ---------------------------------------------------------------------------
+# Cross-fixture consistency
+# ---------------------------------------------------------------------------
+
+_INVESTMENT_CLIMATE_KEYS = (
+    "sovereign_risk_premium",
+    "fdi_stock_pct_gdp",
+    "portfolio_flow_velocity",
+    "credit_rating_score",
+)
+
+
+class TestInvestmentClimateConsistency:
+    """Cross-fixture consistency checks for investment climate variables (NB-4)."""
+
+    def test_all_four_variables_in_grc(self) -> None:
+        attrs = build_greece_scenario().configuration.initial_attributes["GRC"]  # type: ignore[index]
+        for key in _INVESTMENT_CLIMATE_KEYS:
+            assert key in attrs, f"Missing {key} in GRC initial_attributes"
+
+    def test_all_four_variables_in_arg(self) -> None:
+        attrs = build_argentina_scenario().configuration.initial_attributes["ARG"]  # type: ignore[index]
+        for key in _INVESTMENT_CLIMATE_KEYS:
+            assert key in attrs, f"Missing {key} in ARG initial_attributes"
+
+    def test_attribute_types_consistent_across_fixtures(self) -> None:
+        grc = build_greece_scenario().configuration.initial_attributes["GRC"]  # type: ignore[index]
+        arg = build_argentina_scenario().configuration.initial_attributes["ARG"]  # type: ignore[index]
+        for key in _INVESTMENT_CLIMATE_KEYS:
+            grc_type = grc[key].attribute_type
+            arg_type = arg[key].attribute_type
+            assert grc_type == arg_type, (
+                f"attribute_type mismatch for {key}: GRC={grc_type} ARG={arg_type}"
+            )
+
+    def test_measurement_framework_financial_all_vars(self) -> None:
+        for build_fn, entity in [
+            (build_greece_scenario, "GRC"),
+            (build_argentina_scenario, "ARG"),
+        ]:
+            attrs = build_fn().configuration.initial_attributes[entity]  # type: ignore[index]
+            for key in _INVESTMENT_CLIMATE_KEYS:
+                assert attrs[key].measurement_framework == "financial", (
+                    f"{entity}.{key}.measurement_framework should be 'financial'"
+                )


### PR DESCRIPTION
## Summary

Implements NB-4 (Issue #34) — four investment climate state variables with `AttributeType` tags, real historical seed data, and 41 unit tests covering both demo entities.

### Variables added

| Variable | AttributeType | VariableType | Framework |
|---|---|---|---|
| `sovereign_risk_premium` | `rate` | `ratio` | financial |
| `fdi_stock_pct_gdp` | `stock` | `stock` | financial |
| `portfolio_flow_velocity` | `flow` | `ratio` | financial |
| `credit_rating_score` | `structural_index` | `stock` | financial |

### Seed data

**Greece 2010 (GRC)** — M12 demo entity:
- `sovereign_risk_premium`: 300bps (ECB SDW, 10Y GRC-DEU spread January 2010 mean)
- `fdi_stock_pct_gdp`: 10.5% (UNCTAD WIR 2010, inward FDI stock / GDP)
- `portfolio_flow_velocity`: -8.0% (IMF BOP, net portfolio investment 2009 pre-programme)
- `credit_rating_score`: 55.0 / 100 (S&P BBB+ January 2010, linear 21-notch scale)

**Argentina 2001 (ARG)** — M12 demo entity:
- `sovereign_risk_premium`: 750bps (JP Morgan EMBI+ December 2000)
- `fdi_stock_pct_gdp`: 25.1% (UNCTAD WIR 2001, inward FDI stock / GDP)
- `portfolio_flow_velocity`: -4.5% (INDEC BOP 2000, net portfolio investment)
- `credit_rating_score`: 38.0 / 100 (S&P BB January 2001, linear 21-notch scale)

### Cross-fixture invariants verified by tests
- Argentina spread (750bps) > Greece spread (300bps)
- Argentina credit score (38) < Greece credit score (55)
- Both fixtures use capital outflow (negative portfolio_flow_velocity)
- `attribute_type` values are consistent across both entities for all four variables

## Test plan
- [x] 41 unit tests — all pass (`pytest tests/unit/test_nb4_investment_climate.py`)
- [x] `ruff check .` → clean
- [x] `python -m mypy app/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)