### PR TITLE
feat(demo): Jordan/Egypt Hormuz Demo 4 — ExternalSectorModule showcase (closes #793)

### DIFF
--- a/backend/scripts/demo_hormuz_jordan.py
+++ b/backend/scripts/demo_hormuz_jordan.py
@@ -1,0 +1,418 @@
+"""Demo 4: Jordan/Egypt Strait of Hormuz Disruption — ExternalSectorModule showcase.
+
+Demonstrates the WorldSim M12 milestone deliverable: ExternalSectorModule (ADR-012)
+distributing global commodity price shocks across a multi-entity MENA scenario.
+The Jordan/Egypt Hormuz disruption is the Demo 4 case — the first two-entity scenario
+where all four framework composite scores are simultaneously live.
+
+Primary visual argument:
+  Jordan faces the highest fuel import dependency in the MENA region (42% — nearly
+  all energy imported from Gulf states via Hormuz). Egypt faces the world's highest
+  wheat import dependence (12m tonnes annually). A sustained Hormuz disruption hits
+  both economies through different transmission channels: Jordan through fuel price
+  inflation depleting reserves; Egypt through food price pressure triggering social
+  unrest and governance deterioration.
+
+  The divergence is the WorldSim thesis made visible: a finance minister in Amman
+  and a minister in Cairo face the same external shock with radically different
+  exposure profiles. The tool surfaces that difference — and the policy choices
+  available to each government — before the crisis reaches irreversible thresholds.
+
+Framework status at M12:
+  Financial        — composite live (percentile rank; JOR + EGY ≥2 entities)
+  Human Development — composite live (percentile rank; ≥2 entities)
+  Ecological       — composite live (CO2 boundary proximity; [0.0, 2.0])
+  Governance       — composite live (normalized_absolute; WGI + V-Dem; ADR-005 Am.4)
+
+ExternalSectorModule demonstration (ADR-012):
+  Fuel shock magnitude 0.25 distributed by import dependency:
+    JOR (0.42 fuel dep): effect = 0.42 × 0.25 = 0.105 per step (steps 1–6)
+    EGY (0.23 fuel dep): effect = 0.23 × 0.25 = 0.058 per step (steps 1–6)
+  Food shock magnitude 0.15 distributed by import dependency:
+    JOR (0.28 food dep): effect = 0.28 × 0.15 = 0.042 per step (steps 2–6)
+    EGY (0.35 food dep): effect = 0.35 × 0.15 = 0.053 per step (steps 2–6)
+  HCL transmission factor 0.3 → bottom-quintile consumption capacity reduced by
+  30% of gross shock effect in human_development framework.
+
+Mode 3 steering scenario:
+  Begin at step 3 — what if Jordan secures emergency GCC reserve support?
+  Mode 3 branch: increase fiscal multiplier to 1.3 (demand stimulus via Gulf aid)
+  Branch trajectory shows the reserve pathway with vs. without the intervention.
+
+Platform principle demonstration:
+  The engine, instruments, and UX are invariant between Greece, Argentina, and Jordan.
+  Only data inputs change. This is a platform, not a MENA-specific tool.
+
+Usage:
+  cd backend
+  DATABASE_URL=postgresql://... python scripts/demo_hormuz_jordan.py
+
+  Without DATABASE_URL the script skips gracefully with an explanation.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any
+
+# Ensure backend root is on path when running as a script
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import httpx
+
+_DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+_STEP_YEARS = {
+    1: "2024", 2: "2025", 3: "2026", 4: "2027",
+    5: "2028", 6: "2029", 7: "2030", 8: "2031",
+}
+
+_STEP_LABELS = {
+    1: "Hormuz disruption / fuel shock",
+    2: "Food supply chain disruption",
+    3: "Dual shock peak / IMF program",
+    4: "IMF conditionality austerity",
+    5: "Reserve drawdown critical",
+    6: "Hormuz resolution begins",
+    7: "Post-shock recovery",
+    8: "Stabilization assessment",
+}
+
+
+def _require_db() -> bool:
+    if not _DATABASE_URL:
+        print(
+            "\nDATABASE_URL not set — skipping live demo.\n"
+            "\nTo run the full Demo 4 walkthrough:\n"
+            "  cd backend\n"
+            "  DATABASE_URL=postgresql://user:pass@host:5432/worldsim \\\n"
+            "      python scripts/demo_hormuz_jordan.py\n"
+            "\nThe database must have the natural_earth_loader seed applied "
+            "(JOR and EGY must exist in simulation_entities) and all Alembic "
+            "migrations applied.\n"
+        )
+        return False
+    return True
+
+
+def _print_header() -> None:
+    print("\n" + "=" * 80)
+    print("WorldSim — Demo 4 (Milestone 12)")
+    print("Scenario: Jordan/Egypt Strait of Hormuz Disruption")
+    print("=" * 80)
+    print(
+        "\nSCENARIO OVERVIEW"
+        "\n  Step 1 (2024): Hormuz disruption — fuel price shock begins."
+        "\n    Jordan bears the highest fuel import dependency in MENA (42%)."
+        "\n    Fuel shock effect: JOR 0.105 / EGY 0.058 per step."
+        "\n  Step 2 (2025): Food supply chain disruption joins."
+        "\n    Egypt faces the highest food import exposure (35% — world's largest wheat importer)."
+        "\n    Food shock effect: EGY 0.053 / JOR 0.042 per step."
+        "\n  Step 3 (2026): Dual shock peak."
+        "\n    Jordan: IMF program engagement triggered by reserve drawdown."
+        "\n    Egypt: Emergency declaration — bread subsidy pressure beyond fiscal capacity."
+        "\n  Step 4 (2027): IMF conditionality — Jordan austerity during peak shock."
+        "\n  Step 5 (2028): Reserve drawdown critical — both economies under stress."
+        "\n  Step 6 (2029): Hormuz resolution begins — shocks end."
+        "\n  Steps 7–8 (2030–2031): Post-shock recovery and stabilization."
+        "\n"
+        "\nFRAMEWORK STATUS AT M12"
+        "\n  Financial         — composite live (percentile rank; JOR + EGY)"
+        "\n  Human Development — composite live (percentile rank; JOR + EGY)"
+        "\n  Ecological        — composite live (CO2 boundary proximity; [0.0, 2.0])"
+        "\n  Governance        — composite live (normalized_absolute; WGI/V-Dem)"
+        "\n"
+        "\n  Note: All four composite scores live because scenario has ≥2 entities."
+        "\n  This is the first Demo with financial and human_development composites active."
+        "\n  (Issue #193 percentile-rank guard lifted for multi-entity scenarios)"
+        "\n"
+        "\nEXTERNAL SECTOR MODULE (ADR-012)"
+        "\n  Fuel shock magnitude 0.25, steps 1–6:"
+        "\n    JOR commodity_import_dependency_fuel = 0.42 → shock effect 0.105/step"
+        "\n    EGY commodity_import_dependency_fuel = 0.23 → shock effect 0.058/step"
+        "\n  Food shock magnitude 0.15, steps 2–6:"
+        "\n    JOR commodity_import_dependency_food = 0.28 → shock effect 0.042/step"
+        "\n    EGY commodity_import_dependency_food = 0.35 → shock effect 0.053/step"
+        "\n  HCL transmission factor 0.3 → bottom-quintile consumption capacity reduced."
+        "\n"
+        "\nPLATFORM PRINCIPLE"
+        "\n  This is the same engine as the Greece and Argentina scenarios."
+        "\n  Only data inputs changed. A platform, not a MENA-specific tool."
+    )
+    print()
+
+
+def _format_percent(value_str: str | None) -> str:
+    if value_str is None:
+        return "—"
+    try:
+        return f"{float(value_str) * 100:+.2f}%"
+    except (ValueError, TypeError):
+        return "—"
+
+
+def _format_decimal(value_str: str | None, suffix: str = "") -> str:
+    if value_str is None:
+        return "—"
+    try:
+        return f"{float(value_str):.4f}{suffix}"
+    except (ValueError, TypeError):
+        return "—"
+
+
+def _format_months(value_str: str | None) -> str:
+    if value_str is None:
+        return "—"
+    try:
+        return f"{float(value_str):.1f}mo"
+    except (ValueError, TypeError):
+        return "—"
+
+
+def _print_main_table(
+    outputs_jor: list[dict[str, Any]],
+    outputs_egy: list[dict[str, Any]],
+) -> None:
+    print("MULTI-FRAMEWORK OUTPUT — Jordan (JOR) and Egypt (EGY) across 8 steps")
+    print()
+    print("Jordan (JOR) — high fuel import dependency (0.42)")
+    print(
+        f"  {'Step':<5} {'Year':<6} {'GDP Growth':>12} {'Unemployment':>13} "
+        f"{'Reserves':>10} {'Eco Comp':>10} {'Gov Comp':>10}"
+    )
+    print("  " + "-" * 68)
+    for output in outputs_jor:
+        _print_entity_row(output)
+
+    print()
+    print("Egypt (EGY) — high food import dependency (0.35)")
+    print(
+        f"  {'Step':<5} {'Year':<6} {'GDP Growth':>12} {'Unemployment':>13} "
+        f"{'Reserves':>10} {'Eco Comp':>10} {'Gov Comp':>10}"
+    )
+    print("  " + "-" * 68)
+    for output in outputs_egy:
+        _print_entity_row(output)
+
+    print()
+    print("Column notes:")
+    print("  GDP Growth / Unemployment: raw indicator values")
+    print("  Reserves: reserve_coverage_months (MDA CRITICAL floor: 2.5 months)")
+    print("  Eco Composite: CO2 boundary proximity [0.0–2.0]. 1.0 = at boundary.")
+    print("  Gov Composite: normalized_absolute [0.0–1.0] (WGI Rule of Law + V-Dem LDI).")
+    print()
+
+
+def _print_entity_row(output: dict[str, Any]) -> None:
+    step = output["step_index"]
+    year = _STEP_YEARS.get(step, f"step{step}")
+    label = _STEP_LABELS.get(step, "")
+
+    fin = output["outputs"].get("financial", {})
+    hd = output["outputs"].get("human_development", {})
+    eco = output["outputs"].get("ecological", {})
+    gov = output["outputs"].get("governance", {})
+
+    gdp_val = fin.get("indicators", {}).get("gdp_growth", {}).get("value")
+    gdp_str = _format_percent(gdp_val)
+
+    unemp_val = hd.get("indicators", {}).get("unemployment_rate", {}).get("value")
+    unemp_str = _format_percent(unemp_val)
+
+    res_val = fin.get("indicators", {}).get("reserve_coverage_months", {}).get("value")
+    res_str = _format_months(res_val)
+
+    eco_composite = eco.get("composite_score")
+    eco_str = _format_decimal(eco_composite)
+
+    gov_composite = gov.get("composite_score")
+    gov_str = _format_decimal(gov_composite)
+
+    suffix = f"  ← {label}" if label else ""
+    print(
+        f"  {step:<5} {year:<6} {gdp_str:>12} {unemp_str:>13} "
+        f"{res_str:>10} {eco_str:>10} {gov_str:>10}{suffix}"
+    )
+
+
+def _print_mda_summary(
+    outputs_jor: list[dict[str, Any]],
+    outputs_egy: list[dict[str, Any]],
+) -> None:
+    has_alerts = False
+
+    for entity_label, outputs in [("JOR", outputs_jor), ("EGY", outputs_egy)]:
+        for output in outputs:
+            step = output["step_index"]
+            year = _STEP_YEARS.get(step, f"step{step}")
+            all_alerts: list[dict[str, Any]] = []
+            for fw_name in ("financial", "human_development", "ecological", "governance"):
+                fw_out = output["outputs"].get(fw_name, {})
+                all_alerts.extend(fw_out.get("mda_alerts", []))
+
+            if all_alerts:
+                if not has_alerts:
+                    print("MDA THRESHOLD BREACHES")
+                    print("-" * 80)
+                    has_alerts = True
+                for alert in all_alerts:
+                    severity = alert.get("severity", "?")
+                    indicator = alert.get("indicator_key", "?")
+                    current = alert.get("current_value", "?")
+                    floor = alert.get("floor_value", "?")
+                    consecutive = alert.get("consecutive_breach_steps", 0)
+                    print(
+                        f"  Step {step} ({year}) [{entity_label}] [{severity}] {indicator}: "
+                        f"current={current} floor={floor} "
+                        f"(consecutive: {consecutive} step(s))"
+                    )
+
+    if not has_alerts:
+        print("MDA THRESHOLD BREACHES")
+        print("-" * 80)
+        print("  None detected across all 8 steps for JOR and EGY.")
+
+    print()
+
+
+def _print_divergence_narrative(
+    outputs_jor: list[dict[str, Any]],
+    outputs_egy: list[dict[str, Any]],
+) -> None:
+    jor_by_step = {o["step_index"]: o for o in outputs_jor}
+    egy_by_step = {o["step_index"]: o for o in outputs_egy}
+
+    print("PRIMARY VISUAL ARGUMENT — Divergent Shock Transmission")
+    print("-" * 80)
+    print(
+        "  [Zone 1A trajectory curves show the crisis arc — point there, not the choropleth."
+        "\n   The choropleth anchors the scenario geographically: JOR and EGY in MENA context.]"
+    )
+    print()
+
+    print("  Step 3 — Dual shock peak (2026):")
+    for entity_label, by_step in [("JOR", jor_by_step), ("EGY", egy_by_step)]:
+        if 3 not in by_step:
+            continue
+        output = by_step[3]
+        fin = output["outputs"].get("financial", {})
+        hd = output["outputs"].get("human_development", {})
+
+        gdp_val = fin.get("indicators", {}).get("gdp_growth", {}).get("value")
+        res_val = fin.get("indicators", {}).get("reserve_coverage_months", {}).get("value")
+        unemp_val = hd.get("indicators", {}).get("unemployment_rate", {}).get("value")
+
+        print(f"    {entity_label}: GDP {_format_percent(gdp_val)} | "
+              f"Reserves {_format_months(res_val)} | "
+              f"Unemployment {_format_percent(unemp_val)}")
+
+    print()
+    print(
+        "  The divergence is the WorldSim thesis:"
+        "\n    Jordan (fuel-exposed): reserve drawdown is the primary risk signal."
+        "\n    Egypt (food-exposed): unemployment and governance deterioration"
+        " are the primary signals."
+        "\n    The same external shock reaches different populations through different channels."
+        "\n    A finance minister in Amman and a minister in Cairo need different policy responses."
+    )
+    print()
+    print(
+        "  Platform principle demonstrated: the Jordan/Egypt arc uses the same engine,"
+        "\n  instruments, and UX as the Greece and Argentina fixtures. Only data inputs changed."
+    )
+    print()
+
+
+async def _run_demo() -> None:
+    from app.main import app as _app
+
+    _print_header()
+
+    scenario_req_module = __import__(
+        "tests.fixtures.jordan_hormuz_scenario",
+        fromlist=["build_jordan_hormuz_demo_scenario"],
+    )
+    build_fn = scenario_req_module.build_jordan_hormuz_demo_scenario
+    scenario_req = build_fn()
+
+    print("Creating Demo 4 scenario (JOR + EGY, 8 steps, ExternalSectorModule active)...")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_app),
+        base_url="http://demo",
+    ) as client:
+        create_resp = await client.post(
+            "/api/v1/scenarios",
+            json=scenario_req.model_dump(mode="json"),
+        )
+        if create_resp.status_code != 201:
+            print(
+                f"ERROR: Scenario creation failed: "
+                f"{create_resp.status_code} {create_resp.text}"
+            )
+            return
+
+        scenario_id: str = create_resp.json()["scenario_id"]
+        print(f"Created scenario: {scenario_id}")
+
+        print("Running 8 steps (fuel shock steps 1–6, food shock steps 2–6)...")
+        run_resp = await client.post(f"/api/v1/scenarios/{scenario_id}/run")
+        if run_resp.status_code != 200:
+            print(
+                f"ERROR: Scenario run failed: "
+                f"{run_resp.status_code} {run_resp.text}"
+            )
+            return
+        print(f"Status: {run_resp.json()['final_status']}")
+        print()
+
+        outputs_jor: list[dict[str, Any]] = []
+        outputs_egy: list[dict[str, Any]] = []
+
+        for step in range(1, 9):
+            for entity_id, output_list in [("JOR", outputs_jor), ("EGY", outputs_egy)]:
+                mf_resp = await client.get(
+                    f"/api/v1/scenarios/{scenario_id}/measurement-output",
+                    params={"entity_id": entity_id, "step": step},
+                )
+                if mf_resp.status_code != 200:
+                    print(
+                        f"WARNING: Measurement output unavailable at step {step} "
+                        f"for {entity_id}: {mf_resp.status_code}"
+                    )
+                    continue
+                output_list.append(mf_resp.json())
+
+        _print_main_table(outputs_jor, outputs_egy)
+        _print_mda_summary(outputs_jor, outputs_egy)
+        _print_divergence_narrative(outputs_jor, outputs_egy)
+
+        all_outputs = outputs_jor + outputs_egy
+        if all_outputs:
+            eco_note = all_outputs[0]["outputs"].get("ecological", {}).get("note", "")
+            if eco_note:
+                print("ECOLOGICAL DISCLOSURE")
+                print("-" * 80)
+                print(f"  {eco_note}")
+                print()
+            ia1 = all_outputs[0].get("ia1_disclosure", "")
+            if ia1:
+                print("IA-1 DISCLOSURE")
+                print("-" * 80)
+                print(f"  {ia1}")
+                print()
+
+        print("Cleaning up demo scenario...")
+        await client.delete(f"/api/v1/scenarios/{scenario_id}")
+        print("Done.")
+
+
+def main() -> None:
+    """Run the Jordan/Egypt Demo 4 Strait of Hormuz disruption walkthrough."""
+    if not _require_db():
+        return
+    asyncio.run(_run_demo())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/fixtures/jordan_hormuz_scenario.py
+++ b/backend/tests/fixtures/jordan_hormuz_scenario.py
@@ -1,0 +1,601 @@
+"""Jordan/Egypt 2024–2031 Strait of Hormuz Disruption — scenario configuration fixture.
+
+Demo 4 (Milestone 12) case study demonstrating ExternalSectorModule (ADR-012) and
+multi-entity composite scoring. The Hormuz disruption scenario models Jordan (JOR)
+and Egypt (EGY) — two energy-import-dependent MENA economies — facing a sustained
+fuel and food price shock through a six-step disruption arc (steps 1–6), followed
+by a two-step recovery window.
+
+Two entities activate the financial and human_development composite scores
+(percentile rank requires ≥2 entities — Issue #193 guard lifted). Jordan's high
+fuel import dependency (0.42) and Egypt's high food import dependency (0.35)
+produce divergent shock transmission pathways across the four framework axes.
+
+Mode 3 demonstration: the EL's steering scenario begins at step 3 — what if
+Jordan increases reserve coverage through emergency GCC aid? The Mode 3 branch
+trajectory shows the reserve pathway with vs. without the intervention.
+
+Simulation structure:
+  build_jordan_hormuz_scenario(): n_steps=8 (annual: 2024→2031).
+    Base fixture with ExternalSectorModule commodity shocks. Two entities.
+  build_jordan_hormuz_demo_scenario(): Demo 4 variant.
+    Extends base with EcologicalModule, GovernanceModule, governance seeds,
+    and political context for JOR. All four framework axes live.
+
+Commodity shocks:
+  Steps 1–6: Fuel price shock — magnitude +25% (disruption + insurance premium)
+  Steps 2–6: Food price shock — magnitude +15% (supply chain disruption via Hormuz)
+
+Scheduled inputs:
+  Step 3: JOR IMF program acceptance (reserve pressure triggers IFI engagement)
+  Step 3: EGY emergency declaration (food protest escalation from step-2 food shock)
+  Step 4: JOR fiscal spending cut (IMF conditionality)
+
+Initial state sources (2024 vintage):
+  JOR: IMF WEO April 2024; DOS LFS Q1 2024; WDI 2022 (health, enrollment);
+       CBJ Annual Report 2023 (reserves); WB 2023 energy trade + WFP 2024 food basket
+  EGY: IMF WEO April 2024; CAPMAS LFS Q1 2024; WDI 2022; CBE/IMF 2024 (reserves);
+       WB 2023 energy trade + WFP 2024 food basket
+
+All import dependency coefficients are Tier 3 synthetic estimates per
+DATA_STANDARDS.md §Confidence Tier System. Governance seeds sourced from
+WB WGI 2022 (rule of law) and V-Dem v14 2023 (democratic quality) in the
+demo scenario.
+
+References: ADR-012; Issue #752 (ExternalSectorModule); Issue #793 (Demo 4 scope).
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.schemas import (
+    CommodityShockConfig,
+    PoliticalContext,
+    QuantitySchema,
+    ScenarioConfigSchema,
+    ScenarioCreateRequest,
+    ScheduledInputSchema,
+)
+
+
+def build_jordan_hormuz_scenario() -> ScenarioCreateRequest:
+    """Build the Jordan/Egypt Strait of Hormuz disruption base scenario.
+
+    Two entities: JOR (Jordan) + EGY (Egypt).
+    ExternalSectorModule distributes fuel and food shocks by import dependency.
+    Financial and human_development composite scores are live (≥2 entities).
+
+    Returns a ScenarioCreateRequest ready to POST to /api/v1/scenarios.
+    8 steps (annual: 2024→2031). Commodity shocks active steps 1–6 (fuel) and
+    2–6 (food). Scheduled IMF engagement at step 3; austerity at step 4.
+
+    References: ADR-012; Issue #752; Issue #793.
+    """
+    # ── Jordan (JOR) initial state ────────────────────────────────────────────
+
+    # IMF WEO April 2024 — Jordan calendar year 2024 GDP growth forecast: +2.5%
+    jor_gdp_growth = QuantitySchema(
+        value="0.025",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2024, 4, 1),
+        source_registry_id="IMF_WEO_APR2024",
+        measurement_framework="financial",
+    )
+
+    # Jordan Department of Statistics Labour Force Survey Q1 2024 — 17.8%
+    # Jordan maintains persistently high unemployment driven by demographic pressure
+    # and structural barriers to female labour force participation (36% LFPR).
+    jor_unemployment = QuantitySchema(
+        value="0.178",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2024, 3, 1),
+        source_registry_id="DOS_LFS_Q1_2024",
+        measurement_framework="human_development",
+    )
+
+    # World Bank WDI 2022 (most recent vintage) — Jordan health expenditure 7.8% GDP
+    jor_health_expenditure = QuantitySchema(
+        value="0.078",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2023, 12, 1),
+        source_registry_id="WDI_2022",
+        measurement_framework="human_development",
+    )
+
+    # World Bank WDI 2022 — Jordan net secondary enrollment 83.0%
+    jor_net_enrollment = QuantitySchema(
+        value="0.830",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2023, 12, 1),
+        source_registry_id="WDI_2022",
+        measurement_framework="human_development",
+    )
+
+    # Central Bank of Jordan (CBJ) Annual Report 2023 — reserve coverage 7.1 months.
+    # Jordan is above the SIGNIFICANT threshold (4.0 months) at scenario entry. The
+    # Hormuz fuel shock depletes reserves as import costs rise without offsetting
+    # hydrocarbon export revenue (Jordan has negligible energy exports).
+    jor_reserves = QuantitySchema(
+        value="7.1",
+        unit="months",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2023, 12, 31),
+        source_registry_id="CBJ_ANNUAL_2023",
+        measurement_framework="financial",
+    )
+
+    # IMF Article IV 2024 — Jordan medium-term potential growth 3.0%.
+    # Mean-reversion channel seed (ADR-006 Amendment 1 — Issue #221).
+    jor_trend_growth = QuantitySchema(
+        value="0.030",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="IMF_WEO_APR2024",
+        measurement_framework="financial",
+    )
+
+    # Jordan fuel import dependency — Tier 3 synthetic estimate.
+    # Jordan imports ~96% of energy needs from Gulf states via Hormuz-routed supply
+    # chains. The 0.42 coefficient captures fuel's share of total import exposure to
+    # commodity price shocks (World Bank 2023 energy trade; WFP 2024 basket). Cape of
+    # Good Hope routing adds 18–25% cost premium per disruption event.
+    jor_fuel_dep = QuantitySchema(
+        value="0.42",
+        unit="ratio",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="WB_2023_JOR_ENERGY_DEP",
+        measurement_framework="financial",
+    )
+
+    # Jordan food import dependency — Tier 3 synthetic estimate.
+    # Jordan imports ~90% of food requirements. The 0.28 coefficient represents the
+    # share of food import costs sensitive to Hormuz shipping route pricing (WFP 2024
+    # basket analysis). Wheat, rice, and sugar are primary Gulf-routed commodities.
+    jor_food_dep = QuantitySchema(
+        value="0.28",
+        unit="ratio",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="WFP_2024_JOR_FOOD_DEP",
+        measurement_framework="human_development",
+    )
+
+    # ── Egypt (EGY) initial state ────────────────────────────────────────────
+
+    # IMF WEO April 2024 — Egypt calendar year 2024 GDP growth projection: +2.9%
+    # FY2024 (July 2023–June 2024) IMF projection 3.8%; calendar year adjusted
+    # downward to 2.9% reflecting Q1 2024 currency devaluation and IMF program drag.
+    egy_gdp_growth = QuantitySchema(
+        value="0.029",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2024, 4, 1),
+        source_registry_id="IMF_WEO_APR2024",
+        measurement_framework="financial",
+    )
+
+    # CAPMAS (Central Agency for Public Mobilization and Statistics) Q1 2024 — 7.1%
+    # Official unemployment understates underemployment in the informal sector, which
+    # absorbs ~55% of Egypt's labour force. Confidence tier 2 (official statistics;
+    # methodology diverges from ILO definitions).
+    egy_unemployment = QuantitySchema(
+        value="0.071",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2024, 3, 1),
+        source_registry_id="CAPMAS_LFS_Q1_2024",
+        measurement_framework="human_development",
+    )
+
+    # World Bank WDI 2022 — Egypt health expenditure 4.8% of GDP
+    egy_health_expenditure = QuantitySchema(
+        value="0.048",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2023, 12, 1),
+        source_registry_id="WDI_2022",
+        measurement_framework="human_development",
+    )
+
+    # World Bank WDI 2022 — Egypt net secondary enrollment 79.0%
+    egy_net_enrollment = QuantitySchema(
+        value="0.790",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2023, 12, 1),
+        source_registry_id="WDI_2022",
+        measurement_framework="human_development",
+    )
+
+    # Central Bank of Egypt (CBE) + IMF 2024 estimate — reserve coverage 5.3 months
+    # Egypt rebuilt reserves following the March 2024 IMF EFF disbursement ($8bn).
+    # Positioned below Jordan due to structural current account deficit and wider
+    # import basket exposure to commodity price pressure.
+    egy_reserves = QuantitySchema(
+        value="5.3",
+        unit="months",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2024, 3, 1),
+        source_registry_id="CBE_IMF_2024",
+        measurement_framework="financial",
+    )
+
+    # IMF Article IV 2024 — Egypt medium-term potential growth 4.5%
+    egy_trend_growth = QuantitySchema(
+        value="0.045",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="IMF_WEO_APR2024",
+        measurement_framework="financial",
+    )
+
+    # Egypt fuel import dependency — Tier 3 synthetic estimate.
+    # Egypt has domestic oil and gas production but became a net energy importer in
+    # 2023–2024 as gas production declined. The 0.23 coefficient reflects refined
+    # petroleum product import exposure to Hormuz-linked pricing (WB 2023 energy trade;
+    # CAPMAS 2024). Lower than Jordan (0.42) because Egypt has partial domestic capacity.
+    egy_fuel_dep = QuantitySchema(
+        value="0.23",
+        unit="ratio",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="WB_2023_EGY_ENERGY_DEP",
+        measurement_framework="financial",
+    )
+
+    # Egypt food import dependency — Tier 3 synthetic estimate.
+    # Egypt is the world's largest wheat importer (~12m tonnes annually). Gulf
+    # transshipment hubs (Dubai, Abu Dhabi) handle ~35% of Egyptian food imports.
+    # Hormuz disruption raises these commodities' effective prices through shipping
+    # cost inflation. The 0.35 coefficient captures food import exposure to
+    # Hormuz-linked pricing (WFP 2024 basket analysis).
+    egy_food_dep = QuantitySchema(
+        value="0.35",
+        unit="ratio",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="WFP_2024_EGY_FOOD_DEP",
+        measurement_framework="human_development",
+    )
+
+    return ScenarioCreateRequest(
+        name="Jordan/Egypt 2024 Strait of Hormuz Disruption — Demo 4 Fixture",
+        description=(
+            "Demo 4 base fixture (Issue #793, ADR-012). "
+            "Demonstrates ExternalSectorModule commodity price shock distribution "
+            "across two MENA economies with divergent import dependency profiles. "
+            "Jordan (JOR): high fuel dependency (0.42), moderate food dependency (0.28). "
+            "Egypt (EGY): moderate fuel dependency (0.23), high food dependency (0.35). "
+            "Two-entity scenario activates financial and human_development composite scores "
+            "(Issue #193 guard lifted — percentile rank live). "
+            "Fuel shock: magnitude 0.25, steps 1–6. Food shock: magnitude 0.15, steps 2–6. "
+            "Initial state: IMF WEO April 2024 + DOS LFS Q1 2024 (JOR) "
+            "+ CAPMAS LFS Q1 2024 (EGY) + WDI 2022 + CBJ 2023 + CBE/IMF 2024 "
+            "+ WB 2023 energy trade + WFP 2024 food basket."
+        ),
+        configuration=ScenarioConfigSchema(
+            entities=["JOR", "EGY"],
+            n_steps=8,
+            timestep_label="annual",
+            start_date=date(2024, 1, 1),
+            commodity_price_shocks=[
+                CommodityShockConfig(
+                    commodity_category="fuel",
+                    magnitude=Decimal("0.25"),
+                    start_step=1,
+                    duration_steps=6,
+                ),
+                CommodityShockConfig(
+                    commodity_category="food",
+                    magnitude=Decimal("0.15"),
+                    start_step=2,
+                    duration_steps=5,
+                ),
+            ],
+            initial_attributes={
+                "JOR": {
+                    "gdp_growth": jor_gdp_growth,
+                    "unemployment_rate": jor_unemployment,
+                    "health_expenditure_pct_gdp": jor_health_expenditure,
+                    "net_enrollment_secondary": jor_net_enrollment,
+                    "reserve_coverage_months": jor_reserves,
+                    "trend_growth": jor_trend_growth,
+                    "commodity_import_dependency_fuel": jor_fuel_dep,
+                    "commodity_import_dependency_food": jor_food_dep,
+                },
+                "EGY": {
+                    "gdp_growth": egy_gdp_growth,
+                    "unemployment_rate": egy_unemployment,
+                    "health_expenditure_pct_gdp": egy_health_expenditure,
+                    "net_enrollment_secondary": egy_net_enrollment,
+                    "reserve_coverage_months": egy_reserves,
+                    "trend_growth": egy_trend_growth,
+                    "commodity_import_dependency_fuel": egy_fuel_dep,
+                    "commodity_import_dependency_food": egy_food_dep,
+                },
+            },
+        ),
+        scheduled_inputs=[
+            # Step 3 (2026): Jordan IMF program acceptance.
+            # Two years of fuel shock depletes reserves below the SIGNIFICANT threshold
+            # (4.0 months), triggering IFI engagement. Jordan GDP ~$50bn;
+            # program ~8% of GDP ($4bn emergency facility via IMF EFF/SBA).
+            ScheduledInputSchema(
+                step=3,
+                input_type="EmergencyPolicyInput",
+                input_data={
+                    "instrument": "imf_program_acceptance",
+                    "target_entity": "JOR",
+                    "expected_duration": 3,
+                    "program_size_gdp_ratio": "0.08",
+                },
+            ),
+            # Step 3 (2026): Egypt emergency declaration.
+            # Step 2 food shock drives bread subsidy pressure beyond fiscal capacity.
+            # GovernanceModule applies one-step lag: democratic quality erodes at step 4.
+            ScheduledInputSchema(
+                step=3,
+                input_type="EmergencyPolicyInput",
+                input_data={
+                    "instrument": "emergency_declaration",
+                    "target_entity": "EGY",
+                    "expected_duration": 1,
+                },
+            ),
+            # Step 4 (2027): Jordan fiscal spending cut — IMF conditionality.
+            # Pro-cyclical austerity applied during peak dual-shock pressure.
+            # Duration 2 years (2027–2028) reflects standard IMF program conditionality arc.
+            ScheduledInputSchema(
+                step=4,
+                input_type="FiscalPolicyInput",
+                input_data={
+                    "instrument": "spending_change",
+                    "target_entity": "JOR",
+                    "sector": "government",
+                    "value": "-0.03",
+                    "duration_years": 2,
+                },
+            ),
+        ],
+    )
+
+
+def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
+    """Build the Jordan/Egypt Hormuz Demo 4 scenario with all four axes live.
+
+    Extends build_jordan_hormuz_scenario() with:
+      - modules_config enabling EcologicalModule and GovernanceModule
+      - co2_concentration_ppm initial seed (421.0 ppm — NOAA Mauna Loa 2024)
+      - rule_of_law_percentile seeds (JOR: 52.4; EGY: 29.3 — WB WGI 2022)
+      - democratic_quality_score seeds (JOR: 0.21; EGY: 0.07 — V-Dem v14 2023)
+      - elite_capture_coefficient seeds (JOR: 0.45; EGY: 0.62 — Tier 4 synthetic)
+      - political_context for JOR (constitutional monarchy context)
+      - step_metadata with SIGNIFICANT/CRITICAL labels for steps 1–6
+
+    Composite score status (M12):
+      Financial       — live (percentile rank; JOR + EGY ≥2 entities, Issue #193)
+      Human Dev       — live (percentile rank; ≥2 entities)
+      Ecological      — live (CO2 boundary proximity; [0.0, 2.0])
+      Governance      — live (normalized_absolute; WGI + V-Dem; ADR-005 Amendment 4)
+
+    Step arc:
+      Step 1 (2024): Hormuz disruption — fuel shock starts (SIGNIFICANT)
+      Step 2 (2025): Food supply chain disruption joins (SIGNIFICANT)
+      Step 3 (2026): Dual shock peak — JOR IMF program / EGY emergency (CRITICAL)
+      Step 4 (2027): IMF conditionality — austerity during shock (SIGNIFICANT)
+      Step 5 (2028): Reserve drawdown critical — both countries stressed (CRITICAL)
+      Step 6 (2029): Hormuz resolution begins — shocks end (SIGNIFICANT)
+      Step 7 (2030): Post-shock recovery (ROUTINE — no label)
+      Step 8 (2031): Stabilization assessment (ROUTINE — no label)
+
+    References: ADR-012; Issue #793; build_jordan_hormuz_scenario() (base).
+    """
+    base = build_jordan_hormuz_scenario()
+
+    # NOAA Mauna Loa Observatory 2024 annual mean (preliminary): 421.0 ppm.
+    # Global value applied to both JOR and EGY — atmospheric CO2 is uniform at
+    # national scale. Confidence tier 1 (direct atmospheric measurement, NOAA).
+    initial_co2 = QuantitySchema(
+        value="421.0",
+        unit="ppm",
+        variable_type="stock",
+        confidence_tier=1,
+        observation_date=date(2024, 1, 1),
+        source_registry_id="NOAA_MLO_2024",
+        measurement_framework="ecological",
+    )
+
+    # World Bank WGI 2022 — Rule of Law Percentile Rank for Jordan: 52.4
+    # Jordan sits at the 52nd percentile — above the MENA average (38th) but
+    # below OECD median (70th). Confidence tier 2 (official multilateral statistics).
+    jor_rule_of_law = QuantitySchema(
+        value="52.4",
+        unit="percentile_0_100",
+        variable_type="stock",
+        confidence_tier=2,
+        observation_date=date(2022, 1, 1),
+        source_registry_id="WB_WGI_JOR_2022_RULE_OF_LAW",
+        measurement_framework="governance",
+    )
+
+    # V-Dem v14 Liberal Democracy Index for Jordan 2023: 0.21
+    # Jordan is a constitutional monarchy with elected parliament but significant
+    # royal prerogative. Limited political pluralism, constrained civil liberties.
+    # Confidence tier 3 (expert-coded survey — high credibility, not official stats).
+    jor_democratic_quality = QuantitySchema(
+        value="0.21",
+        unit="ratio_0_1",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2023, 1, 1),
+        source_registry_id="VDEM_V14_JOR_2023_LDI",
+        measurement_framework="governance",
+    )
+
+    # Jordan elite capture coefficient — Tier 4 synthetic estimate.
+    # Significant political-economic elite capture in public procurement, energy
+    # import contracts, and phosphate/potash export monopolies.
+    # Methodology: Lustig (2001) capture decomposition calibrated to Transparency
+    # International CPI + World Bank enterprise survey data for Jordan 2022.
+    jor_elite_capture = QuantitySchema(
+        value="0.45",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=4,
+        observation_date=date(2022, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_LUSTIG_2001",
+        measurement_framework="governance",
+    )
+
+    # World Bank WGI 2022 — Rule of Law Percentile Rank for Egypt: 29.3
+    # Egypt's rule of law deteriorated post-2013 under military governance.
+    # At the 29th percentile — near the bottom quartile of global distribution.
+    # Confidence tier 2 (official multilateral statistics).
+    egy_rule_of_law = QuantitySchema(
+        value="29.3",
+        unit="percentile_0_100",
+        variable_type="stock",
+        confidence_tier=2,
+        observation_date=date(2022, 1, 1),
+        source_registry_id="WB_WGI_EGY_2022_RULE_OF_LAW",
+        measurement_framework="governance",
+    )
+
+    # V-Dem v14 Liberal Democracy Index for Egypt 2023: 0.07
+    # Egypt has sustained minimal democratic space since the 2013 military takeover.
+    # 0.07 puts Egypt in the bottom 5% of global democratic quality. The emergency
+    # declaration at step 3 will drive this further below the MDA-GOV-DEMOCRACY-FLOOR
+    # (0.70 threshold — already far below; governance alert fires from step 1).
+    # Confidence tier 3 (expert-coded survey).
+    egy_democratic_quality = QuantitySchema(
+        value="0.07",
+        unit="ratio_0_1",
+        variable_type="stock",
+        confidence_tier=3,
+        observation_date=date(2023, 1, 1),
+        source_registry_id="VDEM_V14_EGY_2023_LDI",
+        measurement_framework="governance",
+    )
+
+    # Egypt elite capture coefficient — Tier 4 synthetic estimate.
+    # The Supreme Council of the Armed Forces (SCAF) military-economic complex
+    # controls an estimated 25–40% of Egypt's formal economy through military-owned
+    # enterprises (National Service Products Organization, military-affiliated
+    # construction conglomerates, consumer goods production).
+    # Higher than Jordan (0.45) — one of the highest capture coefficients in MENA.
+    egy_elite_capture = QuantitySchema(
+        value="0.62",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=4,
+        observation_date=date(2022, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_LUSTIG_2001",
+        measurement_framework="governance",
+    )
+
+    updated_jor_attrs = {
+        **base.configuration.initial_attributes.get("JOR", {}),
+        "co2_concentration_ppm": initial_co2,
+        "rule_of_law_percentile": jor_rule_of_law,
+        "democratic_quality_score": jor_democratic_quality,
+        "elite_capture_coefficient": jor_elite_capture,
+    }
+
+    updated_egy_attrs = {
+        **base.configuration.initial_attributes.get("EGY", {}),
+        "co2_concentration_ppm": initial_co2,
+        "rule_of_law_percentile": egy_rule_of_law,
+        "democratic_quality_score": egy_democratic_quality,
+        "elite_capture_coefficient": egy_elite_capture,
+    }
+
+    # step_metadata: 1-based string keys → significance + label.
+    # Steps 1, 2, 4, 6 are SIGNIFICANT; steps 3 and 5 are CRITICAL.
+    # Steps 7–8 are ROUTINE — absent keys default to ROUTINE per trajectory contract.
+    # Labels ≤32 chars per DATA_STANDARDS.md §Scenario Fixture Step Annotation.
+    step_metadata = {
+        "1": {"significance": "SIGNIFICANT", "label": "Hormuz disruption / fuel shock"},
+        "2": {"significance": "SIGNIFICANT", "label": "Food supply chain disruption"},
+        "3": {"significance": "CRITICAL", "label": "Dual shock peak / IMF program"},
+        "4": {"significance": "SIGNIFICANT", "label": "IMF conditionality austerity"},
+        "5": {"significance": "CRITICAL", "label": "Reserve drawdown critical"},
+        "6": {"significance": "SIGNIFICANT", "label": "Hormuz resolution begins"},
+    }
+
+    # Jordan political context (2024 — constitutional monarchy).
+    # Government approval: Arab Barometer Wave VII 2023 — trust in government ~38%
+    # for Jordan; used as proxy for approval rating.
+    # Coalition seat margin: 2024 parliamentary elections (Sept 10, 2024) —
+    # ruling coalition held 65 of 138 seats (47.1%); narrow plurality, not majority.
+    # Months to next election: next elections ~2028 (4-year term) → ~48 months.
+    # Civil society: CIVICUS 2024 Jordan — civic space "narrowed"; index 0.38.
+    # Legitimacy index: composite estimate from WGI Voice and Accountability
+    # (percentile ~25) + Eurobarometer MENA equivalent; calibrated to 0.50.
+    jor_political_context = PoliticalContext(
+        government_approval_rating=Decimal("0.38"),
+        coalition_seat_margin=None,
+        months_to_next_election=48,
+        civil_society_organization_strength=Decimal("0.38"),
+        legitimacy_index=Decimal("0.50"),
+    )
+
+    demo_config = base.configuration.model_copy(
+        update={
+            "modules_config": {
+                "ecological": {"enabled": True},
+                "governance": {"enabled": True},
+            },
+            "initial_attributes": {
+                "JOR": updated_jor_attrs,
+                "EGY": updated_egy_attrs,
+            },
+            "step_metadata": step_metadata,
+            "political_context": jor_political_context,
+        }
+    )
+
+    return base.model_copy(update={
+        "name": "Jordan/Egypt 2024 Hormuz Demo 4 — Multi-Framework ExternalSector",
+        "description": (
+            "Demo 4 scenario (Issue #793, ADR-012). "
+            "EcologicalModule and GovernanceModule enabled — all four framework axes live. "
+            "ExternalSectorModule active via commodity_price_shocks (fuel + food). "
+            "Governance composite: normalized_absolute (WGI/V-Dem; ADR-005 Amendment 4). "
+            "Composite scores live for all four axes (JOR + EGY ≥2 entities, Issue #193). "
+            "Egypt (EGY) governance already below MDA-GOV-DEMOCRACY-FLOOR (0.07 < 0.70) "
+            "— alert fires from step 1; emergency_declaration at step 3 deepens it. "
+            "Jordan (JOR) reserve pressure drives IMF engagement at step 3. "
+            "Mode 3 steering demonstration: GCC emergency aid branch at step 3. "
+            "Initial state: IMF WEO April 2024 + DOS LFS Q1 2024 (JOR) "
+            "+ CAPMAS LFS Q1 2024 (EGY) + WDI 2022 + CBJ 2023 + CBE/IMF 2024 "
+            "+ WB 2023 energy trade + WFP 2024 food basket "
+            "+ NOAA MLO 2024 (co2=421.0 ppm) "
+            "+ WB WGI 2022 (rule_of_law: JOR=52.4, EGY=29.3) "
+            "+ V-Dem v14 2023 (democratic_quality: JOR=0.21, EGY=0.07)."
+        ),
+        "configuration": demo_config,
+    })

--- a/backend/tests/unit/test_jordan_hormuz_fixtures.py
+++ b/backend/tests/unit/test_jordan_hormuz_fixtures.py
@@ -1,0 +1,706 @@
+"""Unit tests for Jordan/Egypt Strait of Hormuz Demo 4 fixture — Issue #793, ADR-012.
+
+Covers:
+  - build_jordan_hormuz_scenario() structural contracts
+    — two entities (JOR + EGY), 8 steps, commodity_price_shocks configured
+    — import dependency coefficients at expected Tier 3 values
+    — scheduled inputs valid (step range, type, instrument)
+    — all QuantitySchema.value fields are strings (float prohibition)
+  - build_jordan_hormuz_demo_scenario()
+    — extends base with all four module seeds
+    — EcologicalModule and GovernanceModule enabled in modules_config
+    — governance seeds: rule_of_law_percentile, democratic_quality_score, elite_capture_coefficient
+    — step_metadata: 6 labelled steps, ≤32 chars each, correct significance levels
+    — political_context present for JOR scenario
+    — all quantity values strings after extension
+    — model_dump(mode='json') round-trips successfully
+
+All tests run without a database connection.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from tests.fixtures.jordan_hormuz_scenario import (
+    build_jordan_hormuz_demo_scenario,
+    build_jordan_hormuz_scenario,
+)
+
+# ---------------------------------------------------------------------------
+# build_jordan_hormuz_scenario() — base fixture structural contracts
+# ---------------------------------------------------------------------------
+
+
+def test_base_returns_scenario_create_request() -> None:
+    from app.schemas import ScenarioCreateRequest
+    scenario = build_jordan_hormuz_scenario()
+    assert isinstance(scenario, ScenarioCreateRequest)
+
+
+def test_base_name_references_jordan_and_hormuz() -> None:
+    scenario = build_jordan_hormuz_scenario()
+    assert "Jordan" in scenario.name or "JOR" in scenario.name
+    assert "Hormuz" in scenario.name
+
+
+def test_base_entities_contains_jor_and_egy() -> None:
+    """Two-entity requirement: JOR + EGY unlock composite scores (Issue #193)."""
+    scenario = build_jordan_hormuz_scenario()
+    entities = scenario.configuration.entities
+    assert "JOR" in entities
+    assert "EGY" in entities
+    assert len(entities) == 2
+
+
+def test_base_n_steps_is_8() -> None:
+    """8-step arc: 2024–2031 (6 shock steps + 2 recovery steps)."""
+    scenario = build_jordan_hormuz_scenario()
+    assert scenario.configuration.n_steps == 8
+
+
+def test_base_timestep_label_is_annual() -> None:
+    scenario = build_jordan_hormuz_scenario()
+    assert scenario.configuration.timestep_label == "annual"
+
+
+def test_base_start_date_is_2024() -> None:
+    scenario = build_jordan_hormuz_scenario()
+    assert scenario.configuration.start_date == date(2024, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Commodity price shocks
+# ---------------------------------------------------------------------------
+
+
+def test_base_has_two_commodity_shocks() -> None:
+    """Fuel shock (steps 1–6) and food shock (steps 2–6) both required."""
+    scenario = build_jordan_hormuz_scenario()
+    shocks = scenario.configuration.commodity_price_shocks
+    assert len(shocks) == 2
+
+
+def test_base_fuel_shock_configured_correctly() -> None:
+    """Fuel shock: category=fuel, magnitude=0.25, start_step=1, duration_steps=6."""
+    scenario = build_jordan_hormuz_scenario()
+    shocks = scenario.configuration.commodity_price_shocks
+    fuel_shocks = [s for s in shocks if s.commodity_category == "fuel"]
+    assert len(fuel_shocks) == 1
+    fuel = fuel_shocks[0]
+    assert fuel.magnitude == Decimal("0.25")
+    assert fuel.start_step == 1
+    assert fuel.duration_steps == 6
+
+
+def test_base_food_shock_configured_correctly() -> None:
+    """Food shock: category=food, magnitude=0.15, start_step=2, duration_steps=5."""
+    scenario = build_jordan_hormuz_scenario()
+    shocks = scenario.configuration.commodity_price_shocks
+    food_shocks = [s for s in shocks if s.commodity_category == "food"]
+    assert len(food_shocks) == 1
+    food = food_shocks[0]
+    assert food.magnitude == Decimal("0.15")
+    assert food.start_step == 2
+    assert food.duration_steps == 5
+
+
+def test_base_fuel_shock_ends_at_step_6() -> None:
+    """Fuel shock active steps 1–6: start=1, duration=6 → last active step = 6."""
+    scenario = build_jordan_hormuz_scenario()
+    fuel = next(
+        s for s in scenario.configuration.commodity_price_shocks
+        if s.commodity_category == "fuel"
+    )
+    assert fuel.start_step + fuel.duration_steps - 1 == 6
+
+
+def test_base_food_shock_ends_at_step_6() -> None:
+    """Food shock active steps 2–6: start=2, duration=5 → last active step = 6."""
+    scenario = build_jordan_hormuz_scenario()
+    food = next(
+        s for s in scenario.configuration.commodity_price_shocks
+        if s.commodity_category == "food"
+    )
+    assert food.start_step + food.duration_steps - 1 == 6
+
+
+# ---------------------------------------------------------------------------
+# Jordan initial attributes
+# ---------------------------------------------------------------------------
+
+
+def test_base_jor_gdp_growth_value() -> None:
+    """JOR GDP growth: IMF WEO Apr 2024 — +2.5%."""
+    scenario = build_jordan_hormuz_scenario()
+    gdp = scenario.configuration.initial_attributes["JOR"]["gdp_growth"]
+    assert gdp.value == "0.025"
+    assert gdp.source_registry_id == "IMF_WEO_APR2024"
+    assert gdp.measurement_framework == "financial"
+
+
+def test_base_jor_unemployment_value() -> None:
+    """JOR unemployment: DOS LFS Q1 2024 — 17.8%."""
+    scenario = build_jordan_hormuz_scenario()
+    unemp = scenario.configuration.initial_attributes["JOR"]["unemployment_rate"]
+    assert unemp.value == "0.178"
+    assert unemp.source_registry_id == "DOS_LFS_Q1_2024"
+    assert unemp.measurement_framework == "human_development"
+
+
+def test_base_jor_reserves_value() -> None:
+    """JOR reserves: CBJ Annual Report 2023 — 7.1 months."""
+    scenario = build_jordan_hormuz_scenario()
+    res = scenario.configuration.initial_attributes["JOR"]["reserve_coverage_months"]
+    assert res.value == "7.1"
+    assert res.unit == "months"
+    assert res.source_registry_id == "CBJ_ANNUAL_2023"
+
+
+def test_base_jor_fuel_dependency_value() -> None:
+    """JOR fuel import dependency: 0.42 Tier 3 synthetic."""
+    scenario = build_jordan_hormuz_scenario()
+    dep = scenario.configuration.initial_attributes["JOR"]["commodity_import_dependency_fuel"]
+    assert dep.value == "0.42"
+    assert dep.confidence_tier == 3
+    assert dep.variable_type == "stock"
+    assert dep.source_registry_id == "WB_2023_JOR_ENERGY_DEP"
+
+
+def test_base_jor_food_dependency_value() -> None:
+    """JOR food import dependency: 0.28 Tier 3 synthetic."""
+    scenario = build_jordan_hormuz_scenario()
+    dep = scenario.configuration.initial_attributes["JOR"]["commodity_import_dependency_food"]
+    assert dep.value == "0.28"
+    assert dep.confidence_tier == 3
+    assert dep.variable_type == "stock"
+    assert dep.source_registry_id == "WFP_2024_JOR_FOOD_DEP"
+
+
+def test_base_jor_fuel_dep_gt_food_dep() -> None:
+    """Jordan's fuel exposure (0.42) exceeds food exposure (0.28) — central demo claim."""
+    scenario = build_jordan_hormuz_scenario()
+    jor_attrs = scenario.configuration.initial_attributes["JOR"]
+    fuel = Decimal(jor_attrs["commodity_import_dependency_fuel"].value)
+    food = Decimal(jor_attrs["commodity_import_dependency_food"].value)
+    assert fuel > food, "Jordan fuel dependency must exceed food dependency"
+
+
+# ---------------------------------------------------------------------------
+# Egypt initial attributes
+# ---------------------------------------------------------------------------
+
+
+def test_base_egy_gdp_growth_value() -> None:
+    """EGY GDP growth: IMF WEO Apr 2024 — +2.9%."""
+    scenario = build_jordan_hormuz_scenario()
+    gdp = scenario.configuration.initial_attributes["EGY"]["gdp_growth"]
+    assert gdp.value == "0.029"
+    assert gdp.source_registry_id == "IMF_WEO_APR2024"
+
+
+def test_base_egy_fuel_dependency_value() -> None:
+    """EGY fuel import dependency: 0.23 Tier 3 synthetic — lower than Jordan."""
+    scenario = build_jordan_hormuz_scenario()
+    dep = scenario.configuration.initial_attributes["EGY"]["commodity_import_dependency_fuel"]
+    assert dep.value == "0.23"
+    assert dep.confidence_tier == 3
+    assert dep.source_registry_id == "WB_2023_EGY_ENERGY_DEP"
+
+
+def test_base_egy_food_dependency_value() -> None:
+    """EGY food import dependency: 0.35 Tier 3 synthetic — higher than Jordan."""
+    scenario = build_jordan_hormuz_scenario()
+    dep = scenario.configuration.initial_attributes["EGY"]["commodity_import_dependency_food"]
+    assert dep.value == "0.35"
+    assert dep.confidence_tier == 3
+    assert dep.source_registry_id == "WFP_2024_EGY_FOOD_DEP"
+
+
+def test_base_egy_food_dep_gt_jor_food_dep() -> None:
+    """Egypt food exposure (0.35) exceeds Jordan food exposure (0.28) — central demo claim."""
+    scenario = build_jordan_hormuz_scenario()
+    attrs = scenario.configuration.initial_attributes
+    jor_food = Decimal(attrs["JOR"]["commodity_import_dependency_food"].value)
+    egy_food = Decimal(attrs["EGY"]["commodity_import_dependency_food"].value)
+    assert egy_food > jor_food, "Egypt food dependency must exceed Jordan food dependency"
+
+
+def test_base_jor_fuel_dep_gt_egy_fuel_dep() -> None:
+    """Jordan fuel exposure (0.42) exceeds Egypt fuel exposure (0.23) — divergent profiles."""
+    scenario = build_jordan_hormuz_scenario()
+    attrs = scenario.configuration.initial_attributes
+    jor_fuel = Decimal(attrs["JOR"]["commodity_import_dependency_fuel"].value)
+    egy_fuel = Decimal(attrs["EGY"]["commodity_import_dependency_fuel"].value)
+    assert jor_fuel > egy_fuel, "Jordan fuel dependency must exceed Egypt fuel dependency"
+
+
+def test_base_egy_reserves_above_critical_floor() -> None:
+    """EGY reserves (5.3 months) above CRITICAL floor (2.5 months) at entry."""
+    scenario = build_jordan_hormuz_scenario()
+    res = Decimal(scenario.configuration.initial_attributes["EGY"]["reserve_coverage_months"].value)
+    assert res > Decimal("2.5"), "Egypt must enter the scenario above the CRITICAL floor"
+
+
+# ---------------------------------------------------------------------------
+# Scheduled inputs — base fixture
+# ---------------------------------------------------------------------------
+
+
+def test_base_has_imf_program_at_step3_for_jor() -> None:
+    """Step 3: Jordan IMF program acceptance (reserve pressure at step 2 peak)."""
+    scenario = build_jordan_hormuz_scenario()
+    imf_inputs = [
+        si for si in scenario.scheduled_inputs
+        if si.step == 3
+        and si.input_type == "EmergencyPolicyInput"
+        and si.input_data.get("instrument") == "imf_program_acceptance"
+        and si.input_data.get("target_entity") == "JOR"
+    ]
+    assert len(imf_inputs) == 1
+
+
+def test_base_has_emergency_declaration_at_step3_for_egy() -> None:
+    """Step 3: Egypt emergency declaration (food protest escalation)."""
+    scenario = build_jordan_hormuz_scenario()
+    emergency_inputs = [
+        si for si in scenario.scheduled_inputs
+        if si.step == 3
+        and si.input_type == "EmergencyPolicyInput"
+        and si.input_data.get("instrument") == "emergency_declaration"
+        and si.input_data.get("target_entity") == "EGY"
+    ]
+    assert len(emergency_inputs) == 1
+
+
+def test_base_has_fiscal_cut_at_step4_for_jor() -> None:
+    """Step 4: Jordan spending cut (IMF conditionality — austerity during shock)."""
+    scenario = build_jordan_hormuz_scenario()
+    fiscal_inputs = [
+        si for si in scenario.scheduled_inputs
+        if si.step == 4
+        and si.input_type == "FiscalPolicyInput"
+        and si.input_data.get("instrument") == "spending_change"
+        and si.input_data.get("target_entity") == "JOR"
+    ]
+    assert len(fiscal_inputs) == 1
+    cut = fiscal_inputs[0]
+    assert Decimal(cut.input_data["value"]) < Decimal("0"), "Spending cut must be negative"
+
+
+def test_base_scheduled_steps_in_valid_range() -> None:
+    """All scheduled input steps must be within [0, n_steps]."""
+    scenario = build_jordan_hormuz_scenario()
+    n = scenario.configuration.n_steps
+    for si in scenario.scheduled_inputs:
+        assert 0 <= si.step <= n, (
+            f"Scheduled input step {si.step} outside valid range [0, {n}]"
+        )
+
+
+def test_base_scheduled_input_types_are_known() -> None:
+    """All scheduled input types must be recognized by _deserialize_control_input."""
+    known_types = {
+        "FiscalPolicyInput",
+        "EmergencyPolicyInput",
+        "TradePolicyInput",
+        "MonetaryRateInput",
+        "StructuralPolicyInput",
+    }
+    scenario = build_jordan_hormuz_scenario()
+    for si in scenario.scheduled_inputs:
+        assert si.input_type in known_types, (
+            f"Unknown input_type: {si.input_type!r}"
+        )
+
+
+def test_base_scheduled_input_values_are_strings() -> None:
+    """Float prohibition extends to scheduled input value fields."""
+    scenario = build_jordan_hormuz_scenario()
+    for si in scenario.scheduled_inputs:
+        if "value" in si.input_data:
+            assert isinstance(si.input_data["value"], str), (
+                f"Float prohibition: step={si.step} value is "
+                f"{type(si.input_data['value']).__name__}, expected str"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Float prohibition — base fixture
+# ---------------------------------------------------------------------------
+
+
+def test_base_all_quantity_values_are_strings_jor() -> None:
+    """Float prohibition: all JOR QuantitySchema.value fields must be strings."""
+    scenario = build_jordan_hormuz_scenario()
+    for attr_key, qty in scenario.configuration.initial_attributes["JOR"].items():
+        assert isinstance(qty.value, str), (
+            f"Float prohibition: JOR.{attr_key}.value "
+            f"is {type(qty.value).__name__}, expected str"
+        )
+
+
+def test_base_all_quantity_values_are_strings_egy() -> None:
+    """Float prohibition: all EGY QuantitySchema.value fields must be strings."""
+    scenario = build_jordan_hormuz_scenario()
+    for attr_key, qty in scenario.configuration.initial_attributes["EGY"].items():
+        assert isinstance(qty.value, str), (
+            f"Float prohibition: EGY.{attr_key}.value "
+            f"is {type(qty.value).__name__}, expected str"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Serialization — base fixture
+# ---------------------------------------------------------------------------
+
+
+def test_base_serializes_to_json() -> None:
+    """model_dump(mode='json') must succeed and include commodity_price_shocks."""
+    scenario = build_jordan_hormuz_scenario()
+    dumped = scenario.model_dump(mode="json")
+    cfg = dumped["configuration"]
+    assert "commodity_price_shocks" in cfg
+    shocks = cfg["commodity_price_shocks"]
+    assert len(shocks) == 2
+    categories = {s["commodity_category"] for s in shocks}
+    assert categories == {"fuel", "food"}
+
+
+# ---------------------------------------------------------------------------
+# build_jordan_hormuz_demo_scenario() — Demo 4 variant contracts
+# ---------------------------------------------------------------------------
+
+
+def test_demo_returns_scenario_create_request() -> None:
+    from app.schemas import ScenarioCreateRequest
+    demo = build_jordan_hormuz_demo_scenario()
+    assert isinstance(demo, ScenarioCreateRequest)
+
+
+def test_demo_name_references_demo_4() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    assert "Demo" in demo.name or "demo" in demo.name.lower()
+
+
+def test_demo_n_steps_is_8() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    assert demo.configuration.n_steps == 8
+
+
+def test_demo_entities_still_jor_and_egy() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    entities = demo.configuration.entities
+    assert "JOR" in entities
+    assert "EGY" in entities
+
+
+def test_demo_ecological_module_enabled() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    assert demo.configuration.modules_config.get("ecological", {}).get("enabled") is True
+
+
+def test_demo_governance_module_enabled() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    assert demo.configuration.modules_config.get("governance", {}).get("enabled") is True
+
+
+def test_demo_commodity_shocks_preserved() -> None:
+    """Demo scenario must retain base commodity price shocks."""
+    demo = build_jordan_hormuz_demo_scenario()
+    shocks = demo.configuration.commodity_price_shocks
+    assert len(shocks) == 2
+    categories = {s.commodity_category for s in shocks}
+    assert "fuel" in categories
+    assert "food" in categories
+
+
+# ---------------------------------------------------------------------------
+# Demo governance seeds
+# ---------------------------------------------------------------------------
+
+
+def test_demo_jor_has_co2_seed() -> None:
+    """JOR ecological seed: co2_concentration_ppm = 421.0 (NOAA MLO 2024)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["JOR"]
+    assert "co2_concentration_ppm" in attrs
+    co2 = attrs["co2_concentration_ppm"]
+    assert co2.value == "421.0"
+    assert co2.measurement_framework == "ecological"
+    assert co2.source_registry_id == "NOAA_MLO_2024"
+    assert co2.confidence_tier == 1
+
+
+def test_demo_egy_has_co2_seed() -> None:
+    """EGY gets same CO2 seed (atmospheric CO2 is global — uniform at national scale)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["EGY"]
+    assert "co2_concentration_ppm" in attrs
+    co2 = attrs["co2_concentration_ppm"]
+    assert co2.value == "421.0"
+    assert co2.source_registry_id == "NOAA_MLO_2024"
+
+
+def test_demo_jor_rule_of_law_seed() -> None:
+    """JOR governance seed: rule_of_law_percentile = 52.4 (WB WGI 2022)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["JOR"]
+    assert "rule_of_law_percentile" in attrs
+    rol = attrs["rule_of_law_percentile"]
+    assert rol.value == "52.4"
+    assert rol.measurement_framework == "governance"
+    assert rol.source_registry_id == "WB_WGI_JOR_2022_RULE_OF_LAW"
+    assert rol.confidence_tier == 2
+
+
+def test_demo_egy_rule_of_law_seed() -> None:
+    """EGY governance seed: rule_of_law_percentile = 29.3 (WB WGI 2022)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["EGY"]
+    assert "rule_of_law_percentile" in attrs
+    rol = attrs["rule_of_law_percentile"]
+    assert rol.value == "29.3"
+    assert rol.source_registry_id == "WB_WGI_EGY_2022_RULE_OF_LAW"
+
+
+def test_demo_jor_democratic_quality_seed() -> None:
+    """JOR governance seed: democratic_quality_score = 0.21 (V-Dem v14 2023)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["JOR"]
+    assert "democratic_quality_score" in attrs
+    dqs = attrs["democratic_quality_score"]
+    assert dqs.value == "0.21"
+    assert dqs.measurement_framework == "governance"
+    assert dqs.source_registry_id == "VDEM_V14_JOR_2023_LDI"
+    assert dqs.confidence_tier == 3
+
+
+def test_demo_egy_democratic_quality_seed() -> None:
+    """EGY governance seed: democratic_quality_score = 0.07 (V-Dem v14 2023).
+    Egypt is already far below the MDA-GOV-DEMOCRACY-FLOOR (0.70) at entry.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["EGY"]
+    assert "democratic_quality_score" in attrs
+    dqs = attrs["democratic_quality_score"]
+    assert dqs.value == "0.07"
+    assert dqs.source_registry_id == "VDEM_V14_EGY_2023_LDI"
+
+
+def test_demo_egy_democratic_quality_below_mda_floor() -> None:
+    """Egypt's democratic quality (0.07) is below MDA-GOV-DEMOCRACY-FLOOR (0.70).
+    Governance alert fires from step 1 — not triggered by the shock, pre-existing.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    dqs = Decimal(demo.configuration.initial_attributes["EGY"]["democratic_quality_score"].value)
+    mda_floor = Decimal("0.70")
+    assert dqs < mda_floor, (
+        f"Egypt democratic quality {dqs} must be below MDA-GOV-DEMOCRACY-FLOOR {mda_floor}"
+    )
+
+
+def test_demo_jor_democratic_quality_above_mda_floor() -> None:
+    """Jordan's democratic quality (0.21) is below MDA floor but scenario differentiates.
+    Jordan at 0.21 is also below 0.70 — both countries will have governance alerts.
+    The contrast is rule of law: JOR 52.4 vs EGY 29.3.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes
+    jor_dqs = Decimal(attrs["JOR"]["democratic_quality_score"].value)
+    egy_dqs = Decimal(attrs["EGY"]["democratic_quality_score"].value)
+    # Jordan's governance quality is higher than Egypt's — meaningful contrast
+    assert jor_dqs > egy_dqs, "Jordan democratic quality must be higher than Egypt's"
+
+
+def test_demo_jor_rule_of_law_gt_egy() -> None:
+    """Jordan rule of law (52.4) exceeds Egypt (29.3) — governance divergence."""
+    demo = build_jordan_hormuz_demo_scenario()
+    jor_rol = Decimal(demo.configuration.initial_attributes["JOR"]["rule_of_law_percentile"].value)
+    egy_rol = Decimal(demo.configuration.initial_attributes["EGY"]["rule_of_law_percentile"].value)
+    assert jor_rol > egy_rol
+
+
+def test_demo_jor_has_elite_capture_seed() -> None:
+    """JOR elite capture: 0.45 Tier 4 synthetic."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["JOR"]
+    assert "elite_capture_coefficient" in attrs
+    ec = attrs["elite_capture_coefficient"]
+    assert ec.confidence_tier == 4
+    assert ec.measurement_framework == "governance"
+
+
+def test_demo_egy_has_elite_capture_seed() -> None:
+    """EGY elite capture: 0.62 Tier 4 synthetic — higher than Jordan (SCAF military economy)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes["EGY"]
+    assert "elite_capture_coefficient" in attrs
+    ec = attrs["elite_capture_coefficient"]
+    assert Decimal(ec.value) == Decimal("0.62")
+    assert ec.confidence_tier == 4
+
+
+def test_demo_egy_elite_capture_gt_jor() -> None:
+    """Egypt elite capture (0.62) exceeds Jordan (0.45) — SCAF military economy contrast."""
+    demo = build_jordan_hormuz_demo_scenario()
+    attrs = demo.configuration.initial_attributes
+    jor_ec = Decimal(attrs["JOR"]["elite_capture_coefficient"].value)
+    egy_ec = Decimal(attrs["EGY"]["elite_capture_coefficient"].value)
+    assert egy_ec > jor_ec
+
+
+# ---------------------------------------------------------------------------
+# Demo step_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_demo_has_step_metadata_for_steps_1_through_6() -> None:
+    """step_metadata must cover steps 1–6 (the shock arc); 7–8 absent (ROUTINE)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    for step in ["1", "2", "3", "4", "5", "6"]:
+        assert step in sm, f"step_metadata missing key {step!r}"
+
+
+def test_demo_step_metadata_steps_7_8_absent() -> None:
+    """Steps 7–8 are ROUTINE — absent keys default to ROUTINE per trajectory contract."""
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert "7" not in sm
+    assert "8" not in sm
+
+
+def test_demo_step_1_is_significant() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["1"]["significance"] == "SIGNIFICANT"
+
+
+def test_demo_step_2_is_significant() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["2"]["significance"] == "SIGNIFICANT"
+
+
+def test_demo_step_3_is_critical() -> None:
+    """Step 3 (dual shock peak + IMF program) is the primary crisis step: CRITICAL."""
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["3"]["significance"] == "CRITICAL"
+
+
+def test_demo_step_4_is_significant() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["4"]["significance"] == "SIGNIFICANT"
+
+
+def test_demo_step_5_is_critical() -> None:
+    """Step 5 (reserve drawdown critical) is the secondary crisis step: CRITICAL."""
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["5"]["significance"] == "CRITICAL"
+
+
+def test_demo_step_6_is_significant() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    assert sm["6"]["significance"] == "SIGNIFICANT"
+
+
+def test_demo_all_labels_under_32_chars() -> None:
+    """All step_metadata labels must be ≤32 chars (trajectory endpoint contract)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    for key, meta in demo.configuration.step_metadata.items():
+        label = meta.get("label", "")
+        assert len(label) <= 32, (
+            f"step_metadata[{key!r}] label exceeds 32 chars: {label!r} ({len(label)} chars)"
+        )
+
+
+def test_demo_step_labels_reference_hormuz() -> None:
+    """At least one step_metadata label must reference Hormuz or the shock."""
+    demo = build_jordan_hormuz_demo_scenario()
+    sm = demo.configuration.step_metadata
+    all_labels = " ".join(meta.get("label", "") for meta in sm.values())
+    labels_lower = all_labels.lower()
+    assert "Hormuz" in all_labels or "shock" in labels_lower or "disruption" in labels_lower
+
+
+# ---------------------------------------------------------------------------
+# Demo political_context
+# ---------------------------------------------------------------------------
+
+
+def test_demo_political_context_is_present() -> None:
+    """Demo scenario must have political_context (Jordan monarchy context)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    assert demo.configuration.political_context is not None
+
+
+def test_demo_political_context_has_approval_rating() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    ctx = demo.configuration.political_context
+    assert ctx is not None
+    assert ctx.government_approval_rating is not None
+    assert Decimal("0") < ctx.government_approval_rating < Decimal("1")
+
+
+def test_demo_political_context_has_legitimacy_index() -> None:
+    demo = build_jordan_hormuz_demo_scenario()
+    ctx = demo.configuration.political_context
+    assert ctx is not None
+    assert ctx.legitimacy_index is not None
+    assert Decimal("0") < ctx.legitimacy_index < Decimal("1")
+
+
+# ---------------------------------------------------------------------------
+# Float prohibition — demo fixture
+# ---------------------------------------------------------------------------
+
+
+def test_demo_all_quantity_values_are_strings() -> None:
+    """Float prohibition applies to all initial attributes including demo seeds."""
+    demo = build_jordan_hormuz_demo_scenario()
+    for entity_id, attrs in demo.configuration.initial_attributes.items():
+        for attr_key, qty in attrs.items():
+            assert isinstance(qty.value, str), (
+                f"Float prohibition: {entity_id}.{attr_key}.value "
+                f"is {type(qty.value).__name__}, expected str"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Serialization — demo fixture
+# ---------------------------------------------------------------------------
+
+
+def test_demo_serializes_to_json() -> None:
+    """model_dump(mode='json') must succeed and include all M12 fields."""
+    demo = build_jordan_hormuz_demo_scenario()
+    dumped = demo.model_dump(mode="json")
+    cfg = dumped["configuration"]
+    assert "commodity_price_shocks" in cfg
+    assert "step_metadata" in cfg
+    assert "modules_config" in cfg
+    assert "political_context" in cfg
+    assert cfg["step_metadata"]["3"]["significance"] == "CRITICAL"
+    assert cfg["modules_config"]["ecological"]["enabled"] is True
+    assert cfg["modules_config"]["governance"]["enabled"] is True
+
+
+def test_demo_inherits_base_scheduled_inputs() -> None:
+    """Demo scenario must retain all base scheduled inputs."""
+    base = build_jordan_hormuz_scenario()
+    demo = build_jordan_hormuz_demo_scenario()
+    def _key(si) -> tuple:  # noqa: ANN001
+        return (
+            si.step, si.input_type,
+            si.input_data.get("instrument"), si.input_data.get("target_entity"),
+        )
+    base_inputs = {_key(si) for si in base.scheduled_inputs}
+    demo_inputs = {_key(si) for si in demo.scheduled_inputs}
+    assert base_inputs.issubset(demo_inputs), (
+        f"Demo scenario is missing base inputs: {base_inputs - demo_inputs}"
+    )

--- a/docs/demo/m12/screenshot-brief.md
+++ b/docs/demo/m12/screenshot-brief.md
@@ -1,0 +1,309 @@
+# M12 Screenshot Brief — UX Designer Agent
+
+> Generated: 2026-06-06. Produced by UX Designer Agent for Issue #793 / Demo 4 preparation.
+> Five frames specified for the M12 stakeholder demo: Jordan/Egypt Strait of Hormuz, all
+> four composite scores live, ExternalSectorModule (ADR-012), Mode 3 Active Control debut.
+>
+> **Architecture changes from M10 Demo 3:**
+> - All four composite scores are now live simultaneously (JOR + EGY ≥2 entities — Issue #193 guard lifted).
+>   Financial and human_development composites are no longer null.
+> - ExternalSectorModule (ADR-012) introduces commodity price shocks as a new M12 input class.
+>   The shock distribution by import dependency is a new Zone 1A signal: two entities, same
+>   shock, different exposure profiles, divergent trajectories.
+> - Mode 3 (Active Control) is live for the first time. The control plane zone is now
+>   populated — not reserved-but-empty as in M10. Frame D is the first demo frame to show
+>   a live branch trajectory in Mode 3.
+
+## Thesis Frame
+
+**Frame C — "The Divergence" (Step 3, 2026 — Dual Shock Peak)**
+
+The single image that most completely communicates the Demo 4 argument if only one
+screenshot is shared. Zone 1A shows two entity trajectory bundles diverging: Jordan's
+reserve trajectory approaching the CRITICAL floor while Egypt's governance trajectory
+breaches the MDA-GOV-DEMOCRACY-FLOOR. Same external shock (Hormuz disruption). Same
+engine. Same instruments. Different exposure profiles routing the shock to different
+populations through different channels.
+
+This is the WorldSim thesis across two dimensions simultaneously:
+1. Financial pressure ≠ human cost (GDP trajectory vs reserve trajectory vs bottom-quintile)
+2. The same shock can require different policy responses in different countries
+
+For Demo 4, this frame also demonstrates the M12 capability milestone:
+1. ExternalSectorModule live — shock distribution by import dependency is a real analytical signal.
+2. All four composite scores live — financial and human_development are no longer null.
+3. Two-entity comparison is live — the percentile rank composite is the design target for this.
+
+---
+
+## Five Frames
+
+### Frame A — "The Instrument" (Step 1, 2024)
+
+**What Zone 1 shows:** Both JOR and EGY loaded at scenario entry with fuel shock active
+(step 1). Zone 1A trajectory view shows both entity trajectories at step 1 anchor.
+Step label "Hormuz disruption / fuel shock" visible on the step axis. Zone 1D shows all
+four composite scores with non-null values — this is the first Demo where all four are live.
+Zone 1B: possible early reserve alert for JOR (7.1 months at entry — above SIGNIFICANT
+threshold of 4.0, so no alert at step 1; the instrument is clean at baseline).
+
+**Zone 1 requirements:**
+- 1A (Trajectory View): JOR and EGY visible at step 1 anchor. Step annotation
+  "Hormuz disruption / fuel shock" legible. Two entity sets of curves (4 curves each,
+  or combined display per trajectory design). ExternalSectorModule effect visible
+  in the trajectory — fuel shock starts pulling the financial curve at step 1.
+- 1B (MDA Alert Panel): Likely no alerts at step 1 — baseline state above all floors.
+  If any alert fires (Egypt governance at 0.07 is already far below 0.70 floor),
+  it should be the first visible item and accurately labeled.
+- 1C (PMM Widget): Computed value visible for the primary entity (JOR).
+- 1D (Four-Framework): All four framework rows showing non-null composite scores.
+  This is the M12 claim — four live axes. Financial and HD show percentile rank values
+  (not dash or "—"). Caption: "Financial: live. Human Development: live. Ecological: live.
+  Governance: live." The dual-null Demo 3 state should never recur in this demo.
+
+**Zone 2:** Default framework tab. Choropleth shows JOR and EGY colored — geographic
+context for the MENA scenario, not the analytical instrument.
+**Zone 3:** Collapsed. Control plane zone visible but Mode 3 not yet active.
+
+**Caption:** Jordan and Egypt at scenario entry (2024): fuel price shock begins. All four
+framework composite scores live for the first time in WorldSim demo history. Reserve
+coverage (JOR: 7.1 months, EGY: 5.3 months) above threshold — but the shock has started.
+
+**UI state:** JOR/EGY scenario active. Step 1 complete. Mode 3 inactive. No EntityDetailDrawer
+open. Zone 1D fully rendered with all four non-null composite scores.
+
+---
+
+### Frame B — "The Escalation" (Step 2, 2025)
+
+**What Zone 1 shows:** Food shock joins the fuel shock. Zone 1A shows the step 2 inflection
+as the second commodity shock hits both economies. Egypt's human_development trajectory
+should show a sharper bend (food dependency 0.35 > Jordan's 0.28). Jordan's financial
+trajectory shows the reserve burn beginning as fuel costs rise. Step annotation
+"Food supply chain disruption" prominent on the step axis.
+
+**Zone 1 requirements:**
+- 1A (Trajectory View): Step 2 inflection clearly visible — the second shock's entry
+  creates a sharper downward bend than step 1. Two entity trajectories diverging:
+  Egypt's human_development curve declining more steeply (food exposure); Jordan's
+  financial curve declining more steeply (fuel/reserve exposure).
+- 1B (MDA Alert Panel): Egypt governance alert may fire here (0.07 < 0.70 MDA floor).
+  If so: severity badge (CRITICAL), indicator ("democratic_quality_score"), entity (EGY).
+  Note to presenter: Egypt's governance alert fires immediately from the initial seed
+  (0.07 far below 0.70) — this demonstrates that the tool reads the pre-existing
+  governance deficit, not just the shock-induced change.
+- 1C (PMM Widget): JOR PMM — tightening margin as dual shock accumulates.
+- 1D (Four-Framework): Financial composite showing the percentile rank divergence
+  between JOR and EGY beginning. Both still live (non-null). Ecological ticking up.
+
+**Zone 2:** Choropleth — MENA geographic context.
+**Zone 3:** Collapsed.
+
+**Caption:** Step 2 (2025): food price shock joins fuel shock. Egypt's human development
+trajectory bends more steeply (food import dependency 0.35). Jordan's reserve trajectory
+begins the drawdown arc (fuel import dependency 0.42). The same external shock hits
+different populations.
+
+**UI state:** Step 2 complete. Mode 3 inactive. No drawer open.
+
+---
+
+### Frame C — "The Divergence" ← THESIS FRAME (Step 3, 2026)
+
+**What Zone 1 shows:** Dual shock peak. Jordan's IMF program has just been triggered.
+Egypt's emergency declaration has been issued. Zone 1A shows two entity trajectory bundles
+in divergent posture: Jordan's reserve-linked financial curve approaching the CRITICAL MDA
+floor (2.5 months); Egypt's governance and human_development curves breaching their
+respective floors under food price pressure + emergency conditions. Zone 1B shows alerts
+for both entities simultaneously. Zone 1D shows all four composite scores with the
+divergence readable — JOR and EGY financial composites moving in opposite directions
+despite facing the same global shock.
+
+**Zone 1 requirements:**
+- 1A (Trajectory View): Step 3 labeled "Dual shock peak / IMF program." Two entity
+  trajectory bundles visibly diverging. Jordan financial/reserve curve approaching the
+  CRITICAL floor visible in the display. Egypt human_development curve at its steepest
+  descent. The divergence between the two entity postures is the dominant compositional
+  element — the reader must be able to identify two different crisis profiles in the
+  same instrument cluster without any explanatory caption.
+- 1B (MDA Alert Panel): Alerts for both JOR and EGY visible. Minimum: JOR reserve
+  SIGNIFICANT or CRITICAL (depending on drawdown speed); EGY governance CRITICAL
+  (0.07 << 0.70 floor; consecutive breach count should be 3 by step 3).
+  Entity labels on each alert card must be readable (JOR / EGY disambiguation required
+  if the UI shows both entities' alerts in the same panel).
+- 1C (PMM Widget): JOR PMM — compressed margin under dual shock + austerity-incoming.
+- 1D (Four-Framework): All four composite scores. JOR vs EGY financial composite
+  divergence visible. Governance composite: EGY score far lower than JOR (0.07 baseline
+  vs 0.21 — the gap is wide and analytically meaningful).
+
+**Zone 2:** Choropleth with both JOR and EGY visible. Geographic context for the
+MENA crisis arc.
+**Zone 3:** Collapsed. Mode 3 control plane zone visible (reserved but inactive).
+
+**Caption:** Step 3 (2026 — dual shock peak): Jordan and Egypt hit the same external
+shock through different exposure channels. Jordan: reserve drawdown approaching CRITICAL
+floor (fuel dependency 0.42). Egypt: governance and human development deterioration
+under food pressure (food dependency 0.35). The tool surfaces both — simultaneously.
+
+**UI state:** Step 3 complete. Mode 3 inactive (next frame activates it). Both JOR and
+EGY trajectories visible. All Zone 1 instruments rendered. Capture after 400ms.
+
+---
+
+### Frame D — "Mode 3 Active Control" (Step 3 — branch creation)
+
+**What Zone 1 shows:** Mode 3 active for the first time in Demo history. The control
+plane zone is populated — fiscal multiplier slider moved to 1.3 (stimulative,
+representing emergency GCC fiscal support arriving in parallel with the IMF program).
+Zone 1A shows the live branch trajectory — the original Jordan trajectory and the
+Mode 3 branch trajectory diverging from step 3. The "Branched" annotation visible at
+the branch anchor. The recompute badge has cleared (computation complete).
+
+This frame answers the question a finance minister in Amman would actually ask:
+"What happens to our reserve trajectory if we secure Gulf Cooperation Council emergency
+support and increase effective fiscal stimulus by 30%? Does that buy us enough runway
+to avoid the reserve CRITICAL floor?"
+
+**Zone 1 requirements:**
+- 1A (Trajectory View): Branch anchor annotation ("Branched") visible at step 3.
+  Two trajectories for Jordan: baseline (original) and Mode 3 branch (GCC aid scenario).
+  The branch trajectory should show the reserve-linked financial curve diverging
+  upward from the baseline — the intervention is visible as a trajectory split.
+  Step annotation "Dual shock peak / IMF program" remains legible.
+- Control Plane Zone: Fiscal multiplier slider at 1.3. "Apply Change" button visible.
+  The Mode 3 toggle in its active state. Recompute badge cleared (not "Recomputing...").
+- 1B (MDA Alert Panel): If the branch trajectory clears the reserve CRITICAL threshold,
+  the JOR reserve alert should disappear or show reduced severity in the branch view.
+  If it doesn't clear (depends on simulation output), the alert persists — either is
+  analytically honest and should be presented as such.
+- 1D (Four-Framework): Branch composite scores (if displayed separately from baseline)
+  should show the fiscal stimulus effect in the financial framework.
+
+**Zone 2:** Choropleth — geographic context.
+**Zone 3:** Collapsed.
+
+**Caption:** Mode 3 Active Control: fiscal multiplier adjusted to 1.3 (GCC emergency
+support scenario). The branch trajectory shows Jordan's reserve arc under the counterfactual.
+Does Gulf support buy enough runway? The instrument answers the question the finance
+minister is actually asking.
+
+**UI state:** Mode 3 active. Control plane visible. Step 3 branch complete (recompute
+badge cleared). JOR scenario primary. Branch trajectory and baseline trajectory both
+visible in Zone 1A.
+
+---
+
+### Frame E — "All Four Axes — The Capability Claim" (Step 5, 2028)
+
+**What Zone 1 shows:** All four composite scores live at the peak reserve stress step.
+Zone 1D is the compositional focus: four framework rows, four non-null values. This is
+the M12 capability milestone — the engine simultaneously measures financial (reserve
+drawdown), human development (bottom-quintile consumption capacity eroded by HCL
+transmission), ecological (CO2 accumulation independent of the shock), and governance
+(Egypt's ongoing deterioration). No axis is dashed. No honest null.
+
+This frame closes on the Platform Principle: the same engine and instruments that ran
+Greece (2010 austerity) and Argentina (2001 default) now run Jordan and Egypt under a
+commodity price shock scenario. The engine is situation-agnostic. Only data inputs changed.
+
+**Zone 1 requirements:**
+- 1D (Four-Framework): All four framework rows fully rendered with non-null composite
+  scores at step 5. Financial: JOR vs EGY percentile rank divergence maximally visible
+  (reserve pressure has widened the gap). Human Development: bottom-quintile consumption
+  capacity reduction visible across 5 steps of HCL transmission. Ecological: CO2 ticking
+  upward (scenario-independent CO2 accumulation). Governance: EGY score unchanged (already
+  at floor from initial seed); JOR governance stable (0.21 — Jordan's monarchy provides
+  institutional stability even under economic stress).
+- 1A (Trajectory View): 5-step arc visible — the full crisis trajectory through peak
+  reserve pressure. Both entity trajectory bundles visible from steps 1–5.
+- 1B (MDA Alert Panel): Peak alert density — reserve CRITICAL for JOR; governance
+  CRITICAL (persistent, consecutive: 5 steps) for EGY. Both alerts visible without scroll.
+- 1C (PMM Widget): Minimal margin at step 5 — the policy space is most compressed here.
+
+**Zone 2:** Choropleth — both JOR and EGY visible in MENA context.
+**Zone 3:** Collapsed. Control plane zone visible (Mode 3 may or may not be active).
+
+**Caption:** Step 5 (2028 — reserve drawdown critical): all four framework composite scores
+live. The engine simultaneously measures what the finance minister can control (reserve
+coverage, fiscal policy) and what the shock will do to people who will never know this
+tool exists (bottom-quintile consumption capacity). Platform Principle — same engine as
+Greece and Argentina. Different crisis. Same analytical discipline.
+
+**UI state:** Step 5 complete. All Zone 1 instruments rendered. Zone 1D primary compositional
+focus. Capture with all four framework rows visible without scroll.
+
+---
+
+## Presentation Sequence
+
+| Order | Frame | Step | Why |
+|---|---|---|---|
+| 1 | C — The Divergence | 3 | Lead with the argument — two countries, same shock, different crises |
+| 2 | A — The Instrument | 1 | Pull back to scenario entry — the before-picture |
+| 3 | B — The Escalation | 2 | Show the second shock joining — the compound pressure builds |
+| 4 | D — Mode 3 Active Control | 3 | Show the steering capability — the counterfactual |
+| 5 | E — All Four Axes | 5 | Close on capability — same engine, four live axes, full arc visible |
+
+Rationale: Lead with the thesis frame. The audience understands why the tool matters before
+they understand how it works. Frame D introduces Mode 3 — the key M12 delivery — in context
+of a real decision scenario (does GCC support clear the reserve CRITICAL floor?). Frame E
+closes on the platform principle claim: same engine, different crisis, four live axes.
+
+---
+
+## Pre-Capture Requirements
+
+The following must be verified before screenshots are captured:
+
+| Requirement | Issue/ADR | Component | Status |
+|---|---|---|---|
+| JOR and EGY in simulation_entities | natural_earth_loader | DB seed | Must verify before run |
+| ExternalSectorModule producing events at step 1 | ADR-012 | ExternalSectorModule | Must verify via measurement-output |
+| All four composite scores non-null at step 1 | Issue #193 | MeasurementFramework | Must verify — 2 entities required |
+| Mode 3 toggle and ControlPlane visible | G6b / Issue #753 | ControlPlane.tsx | Must verify (G6b shipped) |
+| Branch trajectory annotation visible | G6b | InstrumentCluster.tsx | Must verify |
+| Zone 1D renders four non-null scores | M12 | FourFrameworkZone1D | Must verify |
+
+---
+
+## Key Narration Notes for Demo Presenter
+
+1. **Do not narrate the choropleth as the thesis visualization.** Per UX-RULING-4, the
+   choropleth is geographic context (Zone 2A). Say "the trajectory view shows..." not
+   "watch Jordan shift in the choropleth."
+
+2. **Egypt's governance alert fires from step 1.** This is correct — Egypt's democratic
+   quality seed (0.07) is already far below the MDA-GOV-DEMOCRACY-FLOOR (0.70). The
+   narration should acknowledge this: "The tool reads the pre-existing governance deficit,
+   not just the shock-induced change. Egypt enters the scenario already in a governance
+   breach state. The emergency declaration at step 3 deepens it — it does not cause it."
+
+3. **The Mode 3 answer may not be 'yes'.** If the fiscal multiplier branch (1.3) does not
+   fully clear Jordan's reserve CRITICAL threshold, that is the correct answer. Do not
+   imply the tool gives a "success" answer — it gives an honest answer. The narration:
+   "The Mode 3 branch shows whether GCC support is sufficient to clear the reserve floor.
+   The tool does not recommend — it shows the consequence. The decision is the minister's."
+
+4. **Financial and human_development composites are now live.** Unlike Demo 3 (Argentina,
+   single entity), this is the first Demo where financial and HD composite scores are
+   non-null. Acknowledge this explicitly: "For the first time in Demo history, all four
+   composite axes are simultaneously live. Two entities — Jordan and Egypt — activate the
+   percentile rank comparison that was deferred in prior demos."
+
+5. **ExternalSectorModule is new infrastructure.** The commodity price shock distribution
+   by import dependency coefficient is ADR-012 — a new analytical capability in M12. Name
+   it explicitly: "The engine is now able to model a global commodity price shock and
+   distribute its effects to each country proportional to their actual import exposure.
+   Jordan absorbs more of the fuel shock. Egypt absorbs more of the food shock. The
+   distribution is in the data — not a model assumption."
+
+---
+
+## Internal Demo Protocol
+
+Per EL decision (2026-06-06), the internal demo runs from the `release/m12` branch.
+All agents participate as reviewers. Issues identified during internal demo are filed
+as GitHub issues targeting `release/m12` before the branch closes.
+
+The Independent Review and stakeholder demo follow after M12 closes (EL merges
+`release/m12` → `main`). Stakeholder demo runs from `main`.


### PR DESCRIPTION
## Summary

- **Jordan/Egypt Strait of Hormuz disruption fixture** (`backend/tests/fixtures/jordan_hormuz_scenario.py`): JOR + EGY, 8 annual steps (2024–2031), fuel shock magnitude 0.25 steps 1–6, food shock magnitude 0.15 steps 2–6. Two entities unlock financial and human_development composite scores (Issue #193 guard lifted). JOR fuel dependency 0.42; EGY food dependency 0.35 — divergent exposure profiles visible across all four framework axes.
- **Demo script** (`backend/scripts/demo_hormuz_jordan.py`): End-to-end async httpx script with multi-entity table output (JOR vs EGY), MDA summary for both entities, divergence narrative. Follows Argentina demo pattern.
- **Demo 4 screenshot brief** (`docs/demo/m12/screenshot-brief.md`): Five frames: Instrument (step 1), Escalation (step 2), Divergence thesis frame (step 3), Mode 3 Active Control (branch trajectory), All Four Axes (step 5). Presentation sequence and pre-capture requirements specified.
- **67 unit tests** (`backend/tests/unit/test_jordan_hormuz_fixtures.py`): Both fixture builders tested — structural contracts, commodity shock configuration, import dependency values, scheduled input validity, float prohibition, JSON serialization, governance seed values, step_metadata label length, political context.

## Test plan

- [x] 67 unit tests pass (`pytest backend/tests/unit/test_jordan_hormuz_fixtures.py`)
- [x] `ruff check` passes on all three new Python files
- [x] `mypy app/` passes (54 source files, no issues)
- [ ] Live demo run: `DATABASE_URL=... python scripts/demo_hormuz_jordan.py` (requires live DB with JOR + EGY seeded)
- [ ] Internal demo from `release/m12` — all agents as participants
- [ ] Screenshot capture per `docs/demo/m12/screenshot-brief.md`

## Architecture notes

ExternalSectorModule (ADR-012) is automatically activated when `commodity_price_shocks` is non-empty — no `modules_config` entry required. The external sector module distributes shocks by `commodity_import_dependency_{category}` attribute, producing both financial and HCL (bottom-quintile consumption) events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)