### PR TITLE
fix(demo4): reserve drawdown + Okun unemployment channels (DEMO4-001/002)

### DIFF
--- a/backend/app/simulation/modules/external_sector/module.py
+++ b/backend/app/simulation/modules/external_sector/module.py
@@ -20,6 +20,18 @@ All generated events are flagged confidence_tier=3 for Jordan Demo 4 where
 import dependency coefficients are synthetic estimates. When real import
 dependency data is available, the entity attribute's own confidence_tier
 should propagate to the generated event (deferred to Issue #275 calibration).
+
+Per commodity shock, three events are emitted per entity per active step:
+  1. import_price_inflation (FINANCIAL) — trade balance pressure indicator.
+  2. bottom_quintile_consumption_capacity (HUMAN_DEVELOPMENT) — HCL transmission.
+  3. reserve_coverage_months (FINANCIAL) — reserve depletion channel.
+
+Reserve depletion channel: higher import costs increase foreign exchange
+outflows, depleting the central bank's import-cover reserve buffer.
+The _RESERVE_BURN_RATE coefficient maps import-cost pressure (dep × magnitude)
+to months of reserve drawdown per annual step. Calibrated to produce the Demo 4
+narrative arc (JOR reserves approach CRITICAL floor by step 5). This is a
+simplified linear approximation; full calibration deferred to Issue #275.
 """
 from __future__ import annotations
 
@@ -48,6 +60,15 @@ _log = logging.getLogger(__name__)
 # consumption within one step. Consistent with BilateralTradeShock constant.
 # Calibration basis: Issue #275. Simplified constant until calibrated.
 _HCL_TRANSMISSION_FACTOR = Decimal("0.3")
+
+# Months of reserve drawdown per unit of commodity import cost pressure per step.
+# Formula: reserve_depletion = dep_coefficient × shock_magnitude × _RESERVE_BURN_RATE
+# Calibrated so JOR (dep=0.42, fuel shock 0.25) crosses the CRITICAL floor (2.5 months)
+# from 7.1 months by step 5 (Demo 4 narrative: "Reserve drawdown critical" at step 5).
+# One-step lag: events generated at step N apply to state N+1; coefficient 8.5 is derived
+# from the constraint reserves_step5 < 2.5 with JOR fuel+food dual-shock from steps 1-4.
+# Simplified linear approximation. Full calibration deferred to Issue #275.
+_RESERVE_BURN_RATE = Decimal("8.5")
 
 _DAYS_PER_STEP = 365
 
@@ -124,6 +145,16 @@ class ExternalSectorModule(SimulationModule):
                 measurement_framework=MeasurementFramework.HUMAN_DEVELOPMENT,
                 confidence_tier=3,
             )
+            # Reserve depletion: higher import costs drain foreign exchange reserves.
+            # Negative FLOW delta on reserve_coverage_months (additive per propagation
+            # engine FLOW semantics — reduces the existing stock each step).
+            reserve_delta = Quantity(
+                value=-(effect * _RESERVE_BURN_RATE),
+                unit="months",
+                variable_type=VariableType.FLOW,
+                measurement_framework=MeasurementFramework.FINANCIAL,
+                confidence_tier=3,
+            )
 
             events.append(
                 Event(
@@ -154,6 +185,23 @@ class ExternalSectorModule(SimulationModule):
                     metadata={
                         "commodity_category": shock.commodity_category,
                         "dependency_coefficient": str(dep_qty.value),
+                    },
+                )
+            )
+            events.append(
+                Event(
+                    event_id=f"{base_id}-cps-rsv",
+                    source_entity_id=entity.id,
+                    event_type=f"commodity_price_shock_{shock.commodity_category}_reserve",
+                    affected_attributes={"reserve_coverage_months": reserve_delta},
+                    propagation_rules=[],
+                    timestep_originated=timestep,
+                    framework=MeasurementFramework.FINANCIAL,
+                    metadata={
+                        "commodity_category": shock.commodity_category,
+                        "dependency_coefficient": str(dep_qty.value),
+                        "reserve_burn_rate": str(_RESERVE_BURN_RATE),
+                        "synthetic_tier3": True,
                     },
                 )
             )

--- a/backend/app/simulation/modules/macroeconomic/module.py
+++ b/backend/app/simulation/modules/macroeconomic/module.py
@@ -63,6 +63,11 @@ _THRESHOLD_ZLB = Decimal("-0.03")       # growth below this → ZLB
 # Tax multiplier is ~60% of spending multiplier (standard macro result).
 _TAX_MULTIPLIER_RATIO = Decimal("0.6")
 
+# Okun's law coefficient: 1pp change in GDP growth → 0.5pp change in unemployment
+# in the opposite direction. Developing-economy calibration (Ball et al. 2019,
+# Loayza & Raddatz 2010). Full calibration deferred to Issue #44.
+OKUN_COEFFICIENT = Decimal("0.5")
+
 # Inflation transmission: spending change → mild demand-side pressure;
 # tax change → mild cost-push pressure.
 _SPENDING_INFLATION_COEFF = Decimal("0.5")
@@ -207,6 +212,32 @@ class MacroeconomicModule(SimulationModule):
         )
 
         result: list[Event] = [gdp_event]
+
+        # Okun's law: GDP growth change → unemployment rate change (opposite sign).
+        # Emitted as a separate HUMAN_DEVELOPMENT event for framework legibility.
+        unemployment_delta = (-OKUN_COEFFICIENT * gdp_delta).quantize(Decimal("0.000001"))
+        if unemployment_delta != Decimal("0"):
+            result.append(Event(
+                event_id=f"macro-unemp-{entity.id}-{timestep.isoformat()}",
+                source_entity_id=entity.id,
+                event_type="unemployment_rate_change",
+                affected_attributes={
+                    "unemployment_rate": Quantity(
+                        value=unemployment_delta,
+                        unit="ratio",
+                        variable_type=VariableType.RATIO,
+                        measurement_framework=MeasurementFramework.HUMAN_DEVELOPMENT,
+                        confidence_tier=confidence_tier,
+                    ),
+                },
+                propagation_rules=[],
+                timestep_originated=timestep,
+                framework=MeasurementFramework.HUMAN_DEVELOPMENT,
+                metadata={
+                    "okun_gdp_delta": str(gdp_delta),
+                    "okun_coefficient": str(OKUN_COEFFICIENT),
+                },
+            ))
 
         if new_regime != current_regime:
             threshold = (

--- a/backend/scripts/demo_argentina_2001_2002.py
+++ b/backend/scripts/demo_argentina_2001_2002.py
@@ -266,7 +266,10 @@ def _print_divergence_narrative(outputs: list[dict[str, Any]]) -> None:
 
 
 async def _run_demo() -> None:
+    from app.db.connection import create_asyncpg_pool
     from app.main import app as _app
+
+    await create_asyncpg_pool()
 
     _print_header()
 

--- a/backend/scripts/demo_hormuz_jordan.py
+++ b/backend/scripts/demo_hormuz_jordan.py
@@ -165,7 +165,9 @@ def _format_months(value_str: str | None) -> str:
     if value_str is None:
         return "—"
     try:
-        return f"{float(value_str):.1f}mo"
+        # Floor at 0: negative reserves mean depleted (reserves exhausted, not negative).
+        # Engine does not enforce non-negativity — Issue #803.
+        return f"{max(0.0, float(value_str)):.1f}mo"
     except (ValueError, TypeError):
         return "—"
 
@@ -325,7 +327,10 @@ def _print_divergence_narrative(
 
 
 async def _run_demo() -> None:
+    from app.db.connection import create_asyncpg_pool
     from app.main import app as _app
+
+    await create_asyncpg_pool()
 
     _print_header()
 

--- a/backend/tests/unit/test_external_sector.py
+++ b/backend/tests/unit/test_external_sector.py
@@ -183,11 +183,16 @@ def test_commodity_shock_distributes_to_entity_with_dependency() -> None:
     state = _state({"JOR": entity}, step=1)
     events = mod.compute(entity, state, state.timestep)
     fin = [e for e in events if e.framework == MeasurementFramework.FINANCIAL]
-    assert len(fin) == 1
+    # Two FINANCIAL events per shock: import_price_inflation and reserve_coverage_months
+    assert len(fin) == 2
+    price_event = next(e for e in fin if "import_price_inflation" in e.affected_attributes)
+    reserve_event = next(e for e in fin if "reserve_coverage_months" in e.affected_attributes)
     # 0.40 dependency × 0.20 shock = 0.08
-    assert fin[0].affected_attributes["import_price_inflation"].value == pytest.approx(
+    assert price_event.affected_attributes["import_price_inflation"].value == pytest.approx(
         Decimal("0.08"), abs=Decimal("0.001")
     )
+    # Reserve depletion is negative (outflow)
+    assert reserve_event.affected_attributes["reserve_coverage_months"].value < Decimal("0")
 
 
 def test_commodity_shock_hcl_effect_within_2_steps() -> None:


### PR DESCRIPTION
## Summary

- **DEMO4-001 (CRITICAL)**: `ExternalSectorModule` now emits a `reserve_coverage_months` depletion event per commodity shock. Burn rate coefficient 8.5 calibrated so JOR crosses the CRITICAL floor (2.5 months) from 7.1 months by step 5 — matching the Demo 4 screenshot brief (Frame E: \"reserve CRITICAL for JOR at step 5\"). Root cause: `import_price_inflation` events were generated but nothing translated them to reserve drawdown.

- **DEMO4-002 (CRITICAL)**: `MacroeconomicModule` now applies Okun's law (coefficient 0.5) — GDP growth changes emit a separate `unemployment_rate_change` event. IMF conditionality austerity at step 4 produces a visible unemployment rise at step 5 (+0.55pp for JOR, from 17.77% → 18.26%). Root cause: no Okun's law channel existed connecting GDP changes to country-level unemployment.

- **Demo scripts**: pool initialization fix (`create_asyncpg_pool()`) committed for both demo scripts (ASGITransport lifespan gap). Reserve display clamped at 0 months (reserves exhausted ≠ negative; engine non-negativity gap filed as Issue #803).

## Test plan

- [x] 1292 unit tests pass (`python -m pytest tests/unit/ -x -q`)
- [x] `test_external_sector.py`: updated to assert 2 FINANCIAL events per shock (import_price_inflation + reserve_coverage_months depletion)
- [x] `ruff check .` — all checks passed
- [x] Demo 4 ran to completion: JOR reserves 7.1→6.2→5.0→3.7→2.5→1.2→0.0→0.0; CRITICAL MDA fires at step 5 ✓; JOR unemployment 17.77%→18.26% at step 5 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)