### PR TITLE
feat(demo): --keep flag to skip cleanup and print UI URL

### DIFF
--- a/backend/scripts/demo_hormuz_jordan.py
+++ b/backend/scripts/demo_hormuz_jordan.py
@@ -47,10 +47,14 @@ Usage:
   cd backend
   DATABASE_URL=postgresql://... python scripts/demo_hormuz_jordan.py
 
+  Pass --keep to skip cleanup and view the scenario in the UI:
+  DATABASE_URL=postgresql://... python scripts/demo_hormuz_jordan.py --keep
+
   Without DATABASE_URL the script skips gracefully with an explanation.
 """
 from __future__ import annotations
 
+import argparse
 import asyncio
 import os
 import sys
@@ -326,7 +330,7 @@ def _print_divergence_narrative(
     print()
 
 
-async def _run_demo() -> None:
+async def _run_demo(*, keep: bool = False) -> None:
     from app.db.connection import create_asyncpg_pool
     from app.main import app as _app
 
@@ -407,16 +411,40 @@ async def _run_demo() -> None:
                 print(f"  {ia1}")
                 print()
 
-        print("Cleaning up demo scenario...")
-        await client.delete(f"/api/v1/scenarios/{scenario_id}")
-        print("Done.")
+        if keep:
+            ui_url = f"http://localhost:5173/?scenario={scenario_id}"
+            print("=" * 80)
+            print("SCENARIO KEPT — skipping cleanup (--keep flag active)")
+            print(f"  Scenario ID : {scenario_id}")
+            print(f"  Open in UI  : {ui_url}")
+            print("=" * 80)
+            print()
+            print("Open the URL above in your browser. The frontend must be running")
+            print("(docker compose up, or npm run dev in frontend/).")
+            print()
+            print("To delete this scenario when you are done:")
+            print(f"  curl -X DELETE http://localhost:8000/api/v1/scenarios/{scenario_id}")
+            print()
+        else:
+            print("Cleaning up demo scenario...")
+            await client.delete(f"/api/v1/scenarios/{scenario_id}")
+            print("Done.")
 
 
 def main() -> None:
     """Run the Jordan/Egypt Demo 4 Strait of Hormuz disruption walkthrough."""
     if not _require_db():
         return
-    asyncio.run(_run_demo())
+    parser = argparse.ArgumentParser(
+        description="WorldSim Demo 4 — Jordan/Egypt Strait of Hormuz disruption."
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Skip cleanup after the demo run and print a URL to view the scenario in the UI.",
+    )
+    args = parser.parse_args()
+    asyncio.run(_run_demo(keep=args.keep))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `--keep` flag to `backend/scripts/demo_hormuz_jordan.py`
- When `--keep` is passed: skips the `DELETE /api/v1/scenarios/{id}` cleanup call and prints the scenario ID plus a direct `http://localhost:5173/?scenario=<id>` URL for the EL to open in the browser
- Default behaviour unchanged — cleanup runs as before when no flag is passed
- Non-breaking: no changes to the simulation logic, fixture, or output format

## Usage

```bash
DATABASE_URL=postgresql+asyncpg://worldsim:worldsim@localhost:5432/worldsim \
    python -m scripts.demo_hormuz_jordan --keep
```

After the console output, the script prints:

```
================================================================================
SCENARIO KEPT — skipping cleanup (--keep flag active)
  Scenario ID : <uuid>
  Open in UI  : http://localhost:5173/?scenario=<uuid>
================================================================================
```

## Test plan

- [ ] Run without `--keep` — cleanup still runs, "Done." printed as before
- [ ] Run with `--keep` — scenario persists in DB, URL printed, scenario visible in UI at the printed URL
- [ ] `--help` shows the flag description

🤖 Generated with [Claude Code](https://claude.com/claude-code)