### PR TITLE
fix(frontend): scroll AlertDetailPanel into view on mount (#814)

### DIFF
--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -14,6 +14,7 @@
  *
  * Implements: ADR-008 Decision 5, FA brief §Layout and Viewport (UD-F1 compact row format)
  */
+import { useEffect, useRef } from "react";
 import { useScenarioStepStore, type Zone1BAlert } from "../store/scenarioStepStore";
 import { getIndicatorDisplayNameAny } from "../lib/indicatorDisplayNames";
 
@@ -154,6 +155,13 @@ interface AlertDetailPanelProps {
 function AlertDetailPanel({ alert, onClose }: AlertDetailPanelProps) {
   const { trajectory } = useScenarioStepStore();
   const color = SEVERITY_COLOR[alert.severity];
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Scroll into view on mount — Zone 1B is ~135px tall so the detail panel
+  // renders below the fold when 3 alerts already fill the visible area (#814).
+  useEffect(() => {
+    panelRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, []);
 
   // Human-readable name: frontend registry takes precedence over backend title-case
   const displayName = getIndicatorDisplayNameAny(alert.indicator_key);
@@ -194,6 +202,7 @@ function AlertDetailPanel({ alert, onClose }: AlertDetailPanelProps) {
 
   return (
     <div
+      ref={panelRef}
       data-testid="alert-detail-panel"
       data-alert-id={alert.mda_id}
       style={{


### PR DESCRIPTION
## Summary

- Zone 1B is ~135px tall (45% of the ~300px grid row established by TrajectoryView)
- With 3 TERMINAL alerts at step 8 of the Jordan/Egypt demo, the compact rows (~57px each) fill the visible area before the AlertDetailPanel renders
- The panel rendered correctly below the fold, requiring the user to scroll — appearing as a non-responsive click
- Fix: `scrollIntoView({ behavior: "smooth", block: "nearest" })` on AlertDetailPanel mount scrolls the panel into the Zone 1B scroll container's visible area without disturbing the page

## Root cause

The `AlertDetailPanel` is appended after `topAlerts` inside a scrollable div (`overflowY: "auto"`, `height: "100%"`) contained by a 135px Zone 1B container. In the multi-entity completed-scenario context, all 3 top-severity slots are occupied by TERMINAL alerts, leaving no visible room for the detail panel. 

The fix is in `AlertDetailPanel` alone — no changes to the rendering structure or parent components.

## Test plan

- [x] `npm run build` — passes (no TypeScript errors)
- [x] `vitest run MDAAlertPanelZone1B.test.ts` — 38/38 tests pass
- [ ] Manual: open `http://localhost:5173/?scenario=<completed-hormuz-scenario-id>`, click a TERMINAL alert row — detail panel should scroll into view automatically

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)