### PR TITLE
fix(demo): GCC emergency spending for visible Mode 3 divergence (closes #817)

### DIFF
--- a/backend/scripts/demo_hormuz_jordan.py
+++ b/backend/scripts/demo_hormuz_jordan.py
@@ -34,10 +34,23 @@ ExternalSectorModule demonstration (ADR-012):
   HCL transmission factor 0.3 → bottom-quintile consumption capacity reduced by
   30% of gross shock effect in human_development framework.
 
-Mode 3 steering scenario:
-  Begin at step 3 — what if Jordan secures emergency GCC reserve support?
-  Mode 3 branch: increase fiscal multiplier to 1.3 (demand stimulus via Gulf aid)
-  Branch trajectory shows the reserve pathway with vs. without the intervention.
+Mode 3 steering scenario (Issue #817):
+  The baseline already includes step 3 GCC emergency support (+6% GDP) alongside
+  the IMF program. The Mode 3 question is: "What if that GCC support was 30% more
+  effective — i.e., what if the fiscal multiplier on the Gulf aid was 1.30x rather
+  than the base depressed-regime 1.0x?"
+
+  UI instructions:
+    1. Load the scenario and advance to step 3 (or step 8, then rewind in the UI).
+    2. Click "Mode 3" in the header to open the Active Control panel.
+    3. Set "Fiscal Multiplier" slider to 1.30.
+    4. Set "Branch From Step" slider to 3.
+    5. Click "Apply Change" — the branch runs from step 3 with the GCC aid event
+       amplified by 1.30x. The step-4 austerity cut is NOT in the branch (it was
+       scheduled at step 4 > branch_from_step=3, so it was not copied).
+    6. Zone 1A shows the branch financial composite curve lifting above the baseline —
+       the reserve trajectory diverges upward as the amplified GCC aid reduces
+       the deficit and extends the reserve runway.
 
 Platform principle demonstration:
   The engine, instruments, and UX are invariant between Greece, Argentina, and Jordan.
@@ -75,7 +88,7 @@ _STEP_YEARS = {
 _STEP_LABELS = {
     1: "Hormuz disruption / fuel shock",
     2: "Food supply chain disruption",
-    3: "Dual shock peak / IMF program",
+    3: "Dual shock peak / IMF + GCC",
     4: "IMF conditionality austerity",
     5: "Reserve drawdown critical",
     6: "Hormuz resolution begins",
@@ -113,9 +126,10 @@ def _print_header() -> None:
         "\n  Step 2 (2025): Food supply chain disruption joins."
         "\n    Egypt faces the highest food import exposure (35% — world's largest wheat importer)."
         "\n    Food shock effect: EGY 0.053 / JOR 0.042 per step."
-        "\n  Step 3 (2026): Dual shock peak."
-        "\n    Jordan: IMF program engagement triggered by reserve drawdown."
+        "\n  Step 3 (2026): Dual shock peak — IMF program + GCC emergency support."
+        "\n    Jordan: IMF program engaged; GCC emergency disbursement (+6% GDP) also arrives."
         "\n    Egypt: Emergency declaration — bread subsidy pressure beyond fiscal capacity."
+        "\n    [Mode 3 demo anchor: branch from step 3 at 1.30x to show amplified GCC effect]"
         "\n  Step 4 (2027): IMF conditionality — Jordan austerity during peak shock."
         "\n  Step 5 (2028): Reserve drawdown critical — both economies under stress."
         "\n  Step 6 (2029): Hormuz resolution begins — shocks end."

--- a/backend/tests/fixtures/jordan_hormuz_scenario.py
+++ b/backend/tests/fixtures/jordan_hormuz_scenario.py
@@ -395,6 +395,7 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
       - elite_capture_coefficient seeds (JOR: 0.45; EGY: 0.62 — Tier 4 synthetic)
       - political_context for JOR (constitutional monarchy context)
       - step_metadata with SIGNIFICANT/CRITICAL labels for steps 1–6
+      - GCC emergency budget support at step 3 (+6% GDP — Mode 3 demo anchor)
 
     Composite score status (M12):
       Financial       — live (percentile rank; JOR + EGY ≥2 entities, Issue #193)
@@ -405,14 +406,24 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
     Step arc:
       Step 1 (2024): Hormuz disruption — fuel shock starts (SIGNIFICANT)
       Step 2 (2025): Food supply chain disruption joins (SIGNIFICANT)
-      Step 3 (2026): Dual shock peak — JOR IMF program / EGY emergency (CRITICAL)
+      Step 3 (2026): Dual shock peak — JOR IMF program + GCC emergency support /
+                     EGY emergency declaration (CRITICAL)
       Step 4 (2027): IMF conditionality — austerity during shock (SIGNIFICANT)
       Step 5 (2028): Reserve drawdown critical — both countries stressed (CRITICAL)
       Step 6 (2029): Hormuz resolution begins — shocks end (SIGNIFICANT)
       Step 7 (2030): Post-shock recovery (ROUTINE — no label)
       Step 8 (2031): Stabilization assessment (ROUTINE — no label)
 
-    References: ADR-012; Issue #793; build_jordan_hormuz_scenario() (base).
+    Mode 3 demo (Issue #817):
+      Branch from step 3 at fiscal_multiplier=1.30.
+      Baseline: Jordan secures initial GCC emergency disbursement (+6% GDP) alongside
+      the IMF program. Mode 3 question: "What if Jordan had negotiated 30% more effective
+      fiscal support?" The branch trajectory shows the reserve arc under 1.30x GCC aid
+      and without the step-4 IMF conditionality austerity cut (not copied to branch since
+      it is at step 4 > branch_from_step=3). This produces a visible trajectory divergence:
+      the financial composite curve lifts away from the baseline in the Zone 1A chart.
+
+    References: ADR-012; Issue #793; Issue #817; build_jordan_hormuz_scenario() (base).
     """
     base = build_jordan_hormuz_scenario()
 
@@ -540,7 +551,7 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
     step_metadata = {
         "1": {"significance": "SIGNIFICANT", "label": "Hormuz disruption / fuel shock"},
         "2": {"significance": "SIGNIFICANT", "label": "Food supply chain disruption"},
-        "3": {"significance": "CRITICAL", "label": "Dual shock peak / IMF program"},
+        "3": {"significance": "CRITICAL", "label": "Dual shock peak / IMF + GCC"},
         "4": {"significance": "SIGNIFICANT", "label": "IMF conditionality austerity"},
         "5": {"significance": "CRITICAL", "label": "Reserve drawdown critical"},
         "6": {"significance": "SIGNIFICANT", "label": "Hormuz resolution begins"},
@@ -578,6 +589,27 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
         }
     )
 
+    # GCC emergency budget support — Mode 3 demo anchor (Issue #817).
+    # Saudi Arabia and Gulf states historically provide multi-billion emergency packages
+    # to Jordan in sovereign debt stress episodes. $3bn ≈ 6% of Jordan's 2024 GDP ($50bn).
+    # Fires at step 3 alongside IMF program acceptance — the dual support represents the
+    # policy response available to a well-connected MENA sovereign under external pressure.
+    # Confidence tier 4: constructed scenario assumption (no real-data source for this event).
+    # Mode 3 use: branch from step 3 at 1.30x fiscal multiplier amplifies the GCC aid.
+    # The step-4 austerity cut is NOT in the branch (step 4 > branch_from_step=3),
+    # so the branch shows both more GCC support AND no IMF conditionality — the
+    # "negotiated-better-deal" counterfactual. See Issue #817 for the investigation.
+    gcc_emergency_input = ScheduledInputSchema(
+        step=3,
+        input_type="FiscalPolicyInput",
+        input_data={
+            "instrument": "spending_change",
+            "target_entity": "JOR",
+            "value": "0.06",
+            "duration_years": 1,
+        },
+    )
+
     return base.model_copy(update={
         "name": "Jordan/Egypt 2024 Hormuz Demo 4 — Multi-Framework ExternalSector",
         "description": (
@@ -588,8 +620,11 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
             "Composite scores live for all four axes (JOR + EGY ≥2 entities, Issue #193). "
             "Egypt (EGY) governance already below MDA-GOV-DEMOCRACY-FLOOR (0.07 < 0.70) "
             "— alert fires from step 1; emergency_declaration at step 3 deepens it. "
-            "Jordan (JOR) reserve pressure drives IMF engagement at step 3. "
-            "Mode 3 steering demonstration: GCC emergency aid branch at step 3. "
+            "Jordan (JOR) reserve pressure drives IMF engagement at step 3; GCC emergency "
+            "budget support (+6% GDP) also fires at step 3 (bilateral sovereign support). "
+            "Mode 3 demo (Issue #817): branch from step 3 at 1.30x fiscal multiplier — "
+            "'what if Jordan secured 30% more GCC support and avoided IMF austerity?' "
+            "Produces visible trajectory divergence from step 4 onward. "
             "Initial state: IMF WEO April 2024 + DOS LFS Q1 2024 (JOR) "
             "+ CAPMAS LFS Q1 2024 (EGY) + WDI 2022 + CBJ 2023 + CBE/IMF 2024 "
             "+ WB 2023 energy trade + WFP 2024 food basket "
@@ -598,4 +633,5 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
             "+ V-Dem v14 2023 (democratic_quality: JOR=0.21, EGY=0.07)."
         ),
         "configuration": demo_config,
+        "scheduled_inputs": list(base.scheduled_inputs) + [gcc_emergency_input],
     })

--- a/backend/tests/unit/test_jordan_hormuz_fixtures.py
+++ b/backend/tests/unit/test_jordan_hormuz_fixtures.py
@@ -704,3 +704,56 @@ def test_demo_inherits_base_scheduled_inputs() -> None:
     assert base_inputs.issubset(demo_inputs), (
         f"Demo scenario is missing base inputs: {base_inputs - demo_inputs}"
     )
+
+
+def test_demo_has_gcc_emergency_spending_at_step3_for_jor() -> None:
+    """Demo adds GCC emergency support at step 3 for JOR — Mode 3 demo anchor (Issue #817).
+
+    The GCC spending event (+6% GDP) is the positive fiscal input that the Mode 3
+    fiscal multiplier amplifies. Without this, branching from step 3 at 1.30x
+    would only amplify the existing austerity cut (negative spending), producing
+    the wrong direction and invisible divergence.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    gcc_inputs = [
+        si for si in demo.scheduled_inputs
+        if si.step == 3
+        and si.input_type == "FiscalPolicyInput"
+        and si.input_data.get("instrument") == "spending_change"
+        and si.input_data.get("target_entity") == "JOR"
+    ]
+    assert len(gcc_inputs) == 1
+    gcc = gcc_inputs[0]
+    assert Decimal(gcc.input_data["value"]) > Decimal("0"), (
+        "GCC emergency spending must be positive (stimulus, not austerity)"
+    )
+    assert Decimal(gcc.input_data["value"]) == Decimal("0.06"), (
+        "GCC emergency support must be 6% of GDP (Tier 4 scenario assumption — $3bn / $50bn)"
+    )
+
+
+def test_demo_gcc_input_not_in_base() -> None:
+    """GCC emergency input is demo-only — base fixture has no step-3 fiscal inputs."""
+    base = build_jordan_hormuz_scenario()
+    base_fiscal_step3 = [
+        si for si in base.scheduled_inputs
+        if si.step == 3 and si.input_type == "FiscalPolicyInput"
+    ]
+    assert len(base_fiscal_step3) == 0, (
+        "Base fixture must not have step-3 FiscalPolicyInput — GCC aid is demo-only"
+    )
+
+
+def test_demo_has_four_scheduled_inputs_total() -> None:
+    """Demo has base 3 inputs + 1 GCC input = 4 total scheduled inputs."""
+    demo = build_jordan_hormuz_demo_scenario()
+    assert len(demo.scheduled_inputs) == 4, (
+        f"Demo must have 4 scheduled inputs (3 base + 1 GCC); got {len(demo.scheduled_inputs)}"
+    )
+
+
+def test_demo_step3_label_references_gcc() -> None:
+    """Step 3 label must reference GCC support (updated from 'IMF program' only)."""
+    demo = build_jordan_hormuz_demo_scenario()
+    label = demo.configuration.step_metadata["3"]["label"]
+    assert "GCC" in label, f"Step 3 label must reference GCC: {label!r}"

--- a/docs/demo/m12/screenshot-brief.md
+++ b/docs/demo/m12/screenshot-brief.md
@@ -120,7 +120,7 @@ divergence readable — JOR and EGY financial composites moving in opposite dire
 despite facing the same global shock.
 
 **Zone 1 requirements:**
-- 1A (Trajectory View): Step 3 labeled "Dual shock peak / IMF program." Two entity
+- 1A (Trajectory View): Step 3 labeled "Dual shock peak / IMF + GCC." Two entity
   trajectory bundles visibly diverging. Jordan financial/reserve curve approaching the
   CRITICAL floor visible in the display. Egypt human_development curve at its steepest
   descent. The divergence between the two entity postures is the dominant compositional
@@ -169,7 +169,7 @@ to avoid the reserve CRITICAL floor?"
   Two trajectories for Jordan: baseline (original) and Mode 3 branch (GCC aid scenario).
   The branch trajectory should show the reserve-linked financial curve diverging
   upward from the baseline — the intervention is visible as a trajectory split.
-  Step annotation "Dual shock peak / IMF program" remains legible.
+  Step annotation "Dual shock peak / IMF + GCC" remains legible.
 - Control Plane Zone: Fiscal multiplier slider at 1.3. "Apply Change" button visible.
   The Mode 3 toggle in its active state. Recompute badge cleared (not "Recomputing...").
 - 1B (MDA Alert Panel): If the branch trajectory clears the reserve CRITICAL threshold,


### PR DESCRIPTION
## Summary

- Adds GCC emergency budget support (+6% GDP) to the Demo 4 Jordan fixture at step 3, alongside the existing IMF program
- This gives the Mode 3 fiscal multiplier a positive spending event to amplify — the prior demo had no positive fiscal input at step 3, so branching at 1.30x was amplifying the wrong-direction austerity cut
- Step 3 label updated: `"Dual shock peak / IMF program"` → `"Dual shock peak / IMF + GCC"` (27 chars, under 32-char limit)
- Demo script Mode 3 section rewritten to accurately describe the scenario mechanics and provide step-by-step UI instructions
- Screenshot brief Frame C and Frame D label references updated to match new step 3 label

## Root cause (Issue #817)

The original Mode 3 branch from step 3 at 1.40x produced no visible trajectory divergence because:
1. The fiscal multiplier only applies when a `FiscalPolicyInput` event fires at that step
2. Step 3 had no scheduled fiscal input — the austerity cut was at step 4
3. The branch copied inputs `WHERE step <= branch_from_step=3`, so the step-4 austerity cut was NOT in the branch
4. With no fiscal event at step 3, the multiplier had nothing to amplify → identical trajectories

Fix (Option B from #817): add the positive GCC emergency disbursement at step 3, which the 1.30x multiplier amplifies, producing an upward-diverging reserve trajectory in Mode 3.

## New tests (4 added)

- `test_demo_has_gcc_emergency_spending_at_step3_for_jor` — GCC input exists, is positive, equals 0.06
- `test_demo_gcc_input_not_in_base` — GCC aid is demo-only (base fixture has no step-3 fiscal inputs)
- `test_demo_has_four_scheduled_inputs_total` — base 3 + GCC 1 = 4 total
- `test_demo_step3_label_references_gcc` — step 3 label contains "GCC"

## Mode 3 demo instructions (for IR prep)

1. Load scenario, advance to step 8 (or step 3)
2. Click "Mode 3" in the header
3. Set Fiscal Multiplier slider to **1.30**
4. Set Branch From Step to **3**
5. Click "Apply Change"
6. Zone 1A shows the branch financial composite lifting above baseline

The step-4 austerity cut is **not** in the branch (step 4 > branch_from_step=3, not copied). The branch shows Jordan's reserve arc with amplified GCC support and without IMF conditionality — the counterfactual the finance minister is actually asking about.

## Test plan

- [ ] `cd backend && pytest tests/unit/test_jordan_hormuz_fixtures.py -v` — all 42 tests pass
- [ ] `cd backend && ruff check .` — clean
- [ ] Load demo scenario via `python scripts/demo_hormuz_jordan.py --keep`, open in UI, branch from step 3 at 1.30x — Zone 1A shows upward divergence in financial composite

🤖 Generated with [Claude Code](https://claude.com/claude-code)