### PR TITLE
fix(ecological): clamp proximity to [0,2.0] and seed land_use_pressure_index in Demo 4 fixture (closes #821)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -1901,7 +1901,7 @@ def _boundary_proximity_strategy(
             continue
 
         if is_pre_normalized:
-            score = min(raw_val, Decimal("2.0"))
+            score = max(Decimal("0"), min(raw_val, Decimal("2.0")))
         else:
             boundary_val = boundary_constants[boundary_constant_id]
             if boundary_val == Decimal("0"):
@@ -1912,7 +1912,7 @@ def _boundary_proximity_strategy(
                     indicator_key,
                 )
                 continue
-            score = min(raw_val / boundary_val, Decimal("2.0"))
+            score = max(Decimal("0"), min(raw_val / boundary_val, Decimal("2.0")))
 
         proximity_scores.append(score)
 

--- a/backend/app/simulation/modules/ecological/module.py
+++ b/backend/app/simulation/modules/ecological/module.py
@@ -172,12 +172,12 @@ def _compute_proximity_indicators(
             continue
 
         if is_pre_normalized:
-            proximity = min(stock_val, Decimal("2.0"))
+            proximity = max(Decimal("0"), min(stock_val, Decimal("2.0")))
         else:
             boundary_val = _BOUNDARY_CONSTANT_VALUES.get(constant_id, Decimal("1"))
             if boundary_val == Decimal("0"):
                 continue
-            proximity = min(stock_val / boundary_val, Decimal("2.0"))
+            proximity = max(Decimal("0"), min(stock_val / boundary_val, Decimal("2.0")))
 
         result[output_key] = Quantity(
             value=proximity.quantize(Decimal("0.000001")),

--- a/backend/tests/fixtures/jordan_hormuz_scenario.py
+++ b/backend/tests/fixtures/jordan_hormuz_scenario.py
@@ -440,6 +440,45 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
         measurement_framework="ecological",
     )
 
+    # Jordan land use pressure index — Tier 4 synthetic estimate.
+    # FAO Global Forest Resources Assessment 2020 (country profile Jordan): ~40% of
+    # Jordan's agricultural land shows moderate-to-severe degradation; forest cover 1.5%
+    # and declining. World Atlas of Desertification (Cherlet et al. 2018) classifies the
+    # majority of Jordan's non-desert land as under "very high" human footprint pressure.
+    # Anchored against Richardson et al. (2023) Science Advances planetary boundary for
+    # land-system change (25% ice-free land as natural ecosystems).
+    # 0.18 = 18% of safe land-use boundary consumed — defensible lower end for MENA arid
+    # economy with significant soil degradation but minimal large-scale deforestation.
+    # Known calibration gap (Issue #824): this elasticity is calibrated to high-forest-cover
+    # countries; MENA arid transmission runs through soil conservation and irrigation, not
+    # forestry. Magnitude likely overstated for Jordan/Egypt.
+    jor_land_use_pressure = QuantitySchema(
+        value="0.18",
+        unit="ratio_0_1",
+        variable_type="ratio",
+        confidence_tier=4,
+        observation_date=date(2020, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_FAO_GFR_2020_FISCAL_LAND_USE",
+        measurement_framework="ecological",
+    )
+
+    # Egypt land use pressure index — Tier 4 synthetic estimate.
+    # FAO GFR 2020 country profile Egypt: Nile delta agricultural land under extreme
+    # intensity (3–4 crops/year in some areas), ~35% salinisation from poor drainage.
+    # World Atlas of Desertification (Cherlet et al. 2018): Egypt's non-delta zone is
+    # hyper-arid with negligible land-system pressure; the delta is the pressure centre.
+    # 0.24 = 24% of safe land-use boundary consumed — within the 0.20–0.28 defensible
+    # range for delta-concentrated intensive agriculture with peripheral desertification.
+    egy_land_use_pressure = QuantitySchema(
+        value="0.24",
+        unit="ratio_0_1",
+        variable_type="ratio",
+        confidence_tier=4,
+        observation_date=date(2020, 1, 1),
+        source_registry_id="ACADEMIC_LITERATURE_FAO_GFR_2020_FISCAL_LAND_USE",
+        measurement_framework="ecological",
+    )
+
     # World Bank WGI 2022 — Rule of Law Percentile Rank for Jordan: 52.4
     # Jordan sits at the 52nd percentile — above the MENA average (38th) but
     # below OECD median (70th). Confidence tier 2 (official multilateral statistics).
@@ -531,6 +570,7 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
     updated_jor_attrs = {
         **base.configuration.initial_attributes.get("JOR", {}),
         "co2_concentration_ppm": initial_co2,
+        "land_use_pressure_index": jor_land_use_pressure,
         "rule_of_law_percentile": jor_rule_of_law,
         "democratic_quality_score": jor_democratic_quality,
         "elite_capture_coefficient": jor_elite_capture,
@@ -539,6 +579,7 @@ def build_jordan_hormuz_demo_scenario() -> ScenarioCreateRequest:
     updated_egy_attrs = {
         **base.configuration.initial_attributes.get("EGY", {}),
         "co2_concentration_ppm": initial_co2,
+        "land_use_pressure_index": egy_land_use_pressure,
         "rule_of_law_percentile": egy_rule_of_law,
         "democratic_quality_score": egy_democratic_quality,
         "elite_capture_coefficient": egy_elite_capture,

--- a/backend/tests/unit/test_jordan_hormuz_fixtures.py
+++ b/backend/tests/unit/test_jordan_hormuz_fixtures.py
@@ -757,3 +757,68 @@ def test_demo_step3_label_references_gcc() -> None:
     demo = build_jordan_hormuz_demo_scenario()
     label = demo.configuration.step_metadata["3"]["label"]
     assert "GCC" in label, f"Step 3 label must reference GCC: {label!r}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #821 — ecological composite fix: land_use_pressure_index seed tests
+# ---------------------------------------------------------------------------
+
+def test_demo_jor_has_land_use_pressure_seed() -> None:
+    """JOR must have land_use_pressure_index seeded to eliminate composite denominator break.
+
+    Without a seed, the indicator first appears in entity.attributes only after the
+    first fiscal event's two-step lag. This causes the ecological composite to halve
+    mid-scenario (DEMO4-007). The seed anchors the composite from step 1.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    jor_attrs = demo.configuration.initial_attributes.get("JOR", {})
+    assert "land_use_pressure_index" in jor_attrs, (
+        "JOR must have land_use_pressure_index seeded — required to prevent "
+        "ecological composite denominator break at first fiscal event (Issue #821)"
+    )
+    val = Decimal(jor_attrs["land_use_pressure_index"].value)
+    assert val > Decimal("0"), "JOR land_use_pressure_index must be positive (Issue #821)"
+    assert val == Decimal("0.18"), (
+        "JOR land_use_pressure_index must be 0.18 (FAO GFR 2020 MENA Tier 4 synthetic)"
+    )
+
+
+def test_demo_egy_has_land_use_pressure_seed() -> None:
+    """EGY must have land_use_pressure_index seeded — same denominator-break prevention."""
+    demo = build_jordan_hormuz_demo_scenario()
+    egy_attrs = demo.configuration.initial_attributes.get("EGY", {})
+    assert "land_use_pressure_index" in egy_attrs, (
+        "EGY must have land_use_pressure_index seeded (Issue #821)"
+    )
+    val = Decimal(egy_attrs["land_use_pressure_index"].value)
+    assert val > Decimal("0"), "EGY land_use_pressure_index must be positive (Issue #821)"
+    assert val == Decimal("0.24"), (
+        "EGY land_use_pressure_index must be 0.24 (FAO GFR 2020 MENA Tier 4 synthetic)"
+    )
+
+
+def test_demo_land_use_pressure_is_ecological_framework() -> None:
+    """land_use_pressure_index must be tagged ecological for composite computation."""
+    demo = build_jordan_hormuz_demo_scenario()
+    for entity_id in ("JOR", "EGY"):
+        attrs = demo.configuration.initial_attributes.get(entity_id, {})
+        qty = attrs.get("land_use_pressure_index")
+        assert qty is not None
+        assert qty.measurement_framework == "ecological", (
+            f"{entity_id} land_use_pressure_index must have measurement_framework='ecological'"
+        )
+
+
+def test_demo_land_use_pressure_is_ratio_variable_type() -> None:
+    """land_use_pressure_index must be variable_type=ratio (accumulates via apply_attribute_delta).
+
+    RATIO type means apply_attribute_delta adds delta to existing value, not replaces.
+    """
+    demo = build_jordan_hormuz_demo_scenario()
+    for entity_id in ("JOR", "EGY"):
+        attrs = demo.configuration.initial_attributes.get(entity_id, {})
+        qty = attrs.get("land_use_pressure_index")
+        assert qty is not None
+        assert qty.variable_type == "ratio", (
+            f"{entity_id} land_use_pressure_index must be variable_type='ratio'"
+        )


### PR DESCRIPTION
## Summary

- **Fix A** — Clamp `_compute_proximity_indicators` (module.py, write-side) and `_boundary_proximity_strategy` (scenarios.py, read-side) to `[0, 2.0]`. Prevents negative proximity scores when GCC emergency spending produces a negative `land_use_pressure_index` delta via the fiscal→land-use elasticity (-0.1). Negative scores caused the composite to collapse at step 6.
- **Fix B** — Seed `land_use_pressure_index` in JOR (0.18) and EGY (0.24) `initial_attributes` of the Demo 4 Jordan Hormuz fixture. Eliminates the double one-step lag where the indicator appeared mid-scenario (step 6), changing the composite denominator from 1 indicator to 2 and halving the score. Values derived from FAO GFR 2020 MENA arid-economy synthetic estimates (Cherlet 2018).

Root cause investigation and agent panel (Chief Methodologist, Ecological Economist, UX Designer) documented in Issues #821–#824.

## Test plan

- [ ] `test_demo_jor_has_land_use_pressure_seed` — JOR 0.18 seed present
- [ ] `test_demo_egy_has_land_use_pressure_seed` — EGY 0.24 seed present
- [ ] `test_demo_land_use_pressure_is_ecological_framework` — measurement_framework=ecological
- [ ] `test_demo_land_use_pressure_is_ratio_variable_type` — variable_type=ratio
- [ ] CI full test suite passes
- [ ] Ecological composite shows stable denominator (2 indicators) from step 1 in Demo 4 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)