### PR TITLE
feat(hcl): add bottom_quintile_consumption_capacity to Human Cost Ledger panel (closes #826)

### DIFF
--- a/frontend/src/components/CohortIndicatorsPanel.tsx
+++ b/frontend/src/components/CohortIndicatorsPanel.tsx
@@ -28,12 +28,14 @@ interface IndicatorConfig {
   direction: "higher_better" | "lower_better";
 }
 
-/** Priority order matches #747 acceptance criteria. */
-const PRIORITY_INDICATORS: IndicatorConfig[] = [
-  { key: "unemployment_rate",       direction: "lower_better"  },
-  { key: "poverty_headcount_ratio", direction: "lower_better"  },
-  { key: "income_share_q1",         direction: "higher_better" },
-  { key: "access_to_healthcare",    direction: "higher_better" },
+/** Priority order: bottom_quintile_consumption_capacity first (primary M12 HCL signal
+ *  from ExternalSectorModule ADR-012). Remainder matches #747 acceptance criteria. */
+export const PRIORITY_INDICATORS: IndicatorConfig[] = [
+  { key: "bottom_quintile_consumption_capacity", direction: "higher_better" },
+  { key: "unemployment_rate",                    direction: "lower_better"  },
+  { key: "poverty_headcount_ratio",              direction: "lower_better"  },
+  { key: "income_share_q1",                      direction: "higher_better" },
+  { key: "access_to_healthcare",                 direction: "higher_better" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/__tests__/CohortIndicatorsPanel.test.ts
+++ b/frontend/src/components/__tests__/CohortIndicatorsPanel.test.ts
@@ -13,6 +13,7 @@ import {
   computeDirection,
   directionGlyph,
   formatIndicatorValue,
+  PRIORITY_INDICATORS,
 } from "../CohortIndicatorsPanel";
 import type { QuantitySchema } from "../../types";
 
@@ -149,5 +150,42 @@ describe("formatIndicatorValue", () => {
     // value > 1 is not in the fraction conversion range
     const result = formatIndicatorValue(qty("1.5", "fraction"));
     expect(result).not.toContain("%");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRIORITY_INDICATORS — Issue #826 (DEMO4-005)
+// ---------------------------------------------------------------------------
+
+describe("PRIORITY_INDICATORS", () => {
+  it("includes bottom_quintile_consumption_capacity (primary M12 HCL signal)", () => {
+    const keys = PRIORITY_INDICATORS.map((i) => i.key);
+    expect(keys).toContain("bottom_quintile_consumption_capacity");
+  });
+
+  it("bottom_quintile_consumption_capacity is first (highest priority)", () => {
+    expect(PRIORITY_INDICATORS[0].key).toBe("bottom_quintile_consumption_capacity");
+  });
+
+  it("bottom_quintile_consumption_capacity polarity is higher_better", () => {
+    const entry = PRIORITY_INDICATORS.find(
+      (i) => i.key === "bottom_quintile_consumption_capacity",
+    );
+    expect(entry?.direction).toBe("higher_better");
+  });
+
+  it("decreasing bottom_quintile_consumption_capacity shows red down arrow", () => {
+    // Confirm the polarity × direction combination produces the expected bad signal.
+    const glyph = directionGlyph("down", "higher_better");
+    expect(glyph).not.toBeNull();
+    expect(glyph!.symbol).toBe("↓");
+    expect(glyph!.color).toBe("#c62828");
+  });
+
+  it("dimensionless unit value displays as decimal (not percentage)", () => {
+    // bottom_quintile_consumption_capacity uses unit="dimensionless"
+    const result = formatIndicatorValue(qty("-0.12", "dimensionless"));
+    expect(result).not.toContain("%");
+    expect(result).toBe("-0.12");
   });
 });

--- a/frontend/src/lib/indicatorDisplayNames.ts
+++ b/frontend/src/lib/indicatorDisplayNames.ts
@@ -23,6 +23,7 @@ const INDICATOR_DISPLAY_NAMES: Record<string, Record<string, string>> = {
     credit_growth: "Credit Growth",
   },
   human_development: {
+    bottom_quintile_consumption_capacity: "Bottom Quintile Consumption",
     poverty_headcount_ratio: "Poverty Headcount Ratio",
     gini_coefficient: "Gini Coefficient",
     life_expectancy: "Life Expectancy",


### PR DESCRIPTION
## Summary

- **`CohortIndicatorsPanel.tsx`** — Added `bottom_quintile_consumption_capacity` as first entry in `PRIORITY_INDICATORS` with `higher_better` polarity. Decreasing consumption capacity (the expected Demo 4 signal) shows as red ↓ arrow. Grid expands from 4 to 5 entries (2×3 layout, one cell in final row).
- **`indicatorDisplayNames.ts`** — Registered `"Bottom Quintile Consumption"` in the `human_development` block. No raw key surfaces in the UI.
- **`CohortIndicatorsPanel.test.ts`** — 5 new unit tests: key presence, priority position, polarity, glyph rendering for declining capacity, dimensionless unit formatting.

Renders "—" gracefully when ExternalSectorModule is not active (no JS error — existing `indicators?.[key]` guard).

## Test plan

- [ ] `PRIORITY_INDICATORS` includes `bottom_quintile_consumption_capacity` as first entry
- [ ] Direction polarity is `higher_better`
- [ ] Declining value → red ↓ glyph
- [ ] Display name resolves to "Bottom Quintile Consumption" (not raw key)
- [ ] `formatIndicatorValue` with `dimensionless` unit returns decimal (not %)
- [ ] Frontend build passes (TypeScript clean)
- [ ] CI full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)