### PR TITLE
fix(demo): entity identification in narration + demo config testMatch guard (DEMO-054, DEMO-055)

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-11 (PR #848 merged — IR review artifact, PENDING stakeholder-review placeholder, CLAUDE.md artifact table split, demo-preparation-standard IR/stakeholder distinction, milestone-exit-checklist demo section. EL filed three additional issues: #850 DEMO-052 narration spatial reference, #851 DEMO-053 zone label visibility, #852 alert panel master-detail UX. Board clear. Open: DEMO-039 (#842), DEMO-041 (#841), DEMO-052 (#850), DEMO-053 (#851), #852, live stakeholder demo (#843).)**
+**Last updated: 2026-06-11 (PR #854 merged — DEMO-039/041/052/053 resolved; all five M12 demo screenshots recaptured at step 3; walkthrough zone label and spatial reference fixes; Exploratory tier disclosure added to Step 4 SYNTHESIS. Issues #841/#842/#850/#851 closed. EL pre-demo rehearsal identified concurrent TTS narration (DEMO-054, #855, root cause: playwright.demo.config.ts no testMatch guard; NM-040 filed) and entity identification gap in narration (DEMO-055, #856). PR #857 open: entity priming language in narration + testMatch guard + NM-040. Open: #852 alert panel master-detail UX, #856 DEMO-055, live stakeholder demo (#843), Phase 0 EL endorsement.)**
 **Current milestone:** M12 — Active Control and External Sector (GitHub Milestone 13)
 **Previous milestone:** M11.5 — Usability Validation and Experience Audit (formally closed 2026-06-04; Issue #720 closed; GitHub Milestone 14 closed)
 
@@ -77,7 +77,9 @@ M9 formally closed. Issue #213 (M9 Exit Checklist) closed 2026-05-24. M10 milest
 
 ## Open PRs
 
-No open PRs — board clear as of 2026-06-11 (post PR #848 merge).
+| PR | Branch | Title | Gate |
+|---|---|---|---|
+| #857 | feat/demo-narration-entity-identity | fix(demo): entity narration identity + testMatch guard + NM-040 | Awaiting CI + EL merge |
 
 ## M11 Work Streams — 2026-06-04 Sprint
 
@@ -204,13 +206,18 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 
 **Awaiting EL action:**
 - **EL endorsement of Phase 0 exit artifact** — `docs/process/sprint-plans/process-redesign-phase0-exit.md §Part VI`. Phase A cannot open until endorsement is recorded. This is exit gate condition 3.
-- **Live stakeholder demo** (#843) — M12 closure gate (EL decision 2026-06-10). Preconditions before demo runs: DEMO-039 (#842 Frame C recapture), DEMO-041 (#841 walkthrough narration gap), DEMO-052 (#850 spatial reference fix), DEMO-053 (#851 zone label narration fix — Path B minimum). Produces `YYYY-MM-DD-v0.12.0-stakeholder-review.md` artifact.
-- **EL issues from walkthrough review (2026-06-11):**
-  - #850 DEMO-052 `documentation` — walkthrough references "panel on left" not visible in rendered layout; blocks live demo
-  - #851 DEMO-053 `enhancement` — zone labels (Zone 1A/1B/1C/1D) in narration not visible in UI; Path B (plain-language narration fix) blocks live demo; Path A (UI labels) is preferred longer-term
-  - #852 `enhancement` — alert panel master-detail UX: TERMINAL alerts not surfaced without scrolling; detail pane appears below fold; requires redesign to first-class instrument layout
+- **Live stakeholder demo** (#843) — M12 closure gate (EL decision 2026-06-10). Pre-demo blockers resolved (PR #854 merged): DEMO-039, DEMO-041, DEMO-052, DEMO-053, DEMO-054 (testMatch guard, PR #857 pending). DEMO-055 (entity narration fix, PR #857 pending). Remaining open: #852 alert panel master-detail UX. Produces `YYYY-MM-DD-v0.12.0-stakeholder-review.md` artifact.
+- **Merge PR #857** (feat/demo-narration-entity-identity) — entity priming language in narration, testMatch guard, NM-040. CI must pass first.
+- **#852** `enhancement` — alert panel master-detail UX: TERMINAL alerts not surfaced without scrolling; detail pane appears below fold; requires redesign to first-class instrument layout. Tracked at #852.
+- **#855** DEMO-054 `bug` — playwright.demo.config.ts testMatch guard (resolved in PR #857 pending merge).
+- **#856** DEMO-055 `enhancement` — entity identification narration gap (resolved in PR #857 pending merge).
+- ~~#841 DEMO-041~~ — **CLOSED** (PR #854)
+- ~~#842 DEMO-039~~ — **CLOSED** (PR #854)
+- ~~#850 DEMO-052~~ — **CLOSED** (PR #854)
+- ~~#851 DEMO-053~~ — **CLOSED** (PR #854)
 - ~~Merge PR #848~~ — **DONE** (2026-06-11)
-- ~~UI screenshot capture~~ — **COMPLETE** (2026-06-10): all five frames in `docs/demo/m12/screenshots/` including Frame E
+- ~~Merge PR #854~~ — **DONE** (2026-06-11)
+- ~~UI screenshot capture~~ — **COMPLETE** (2026-06-11): all five frames recaptured at correct steps
 - ~~Playwright legibility gates~~ — **PASSED** (2026-06-10): 11/11 at 1440×900
 - ~~IR review~~ — **COMPLETE** (2026-06-10): 13 findings DEMO-039–051; `docs/demo/m12/reviews/2026-06-10-v0.12.0-ir-review.md`
 - ~~Merge `release/m12` → `main`~~ — **DONE** (PR #839, 2026-06-10)
@@ -329,6 +336,8 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 
 | PR | Title | Date |
 |---|---|---|
+| #854 | fix(demo): pre-demo walkthrough fixes — DEMO-039, DEMO-041, DEMO-052, DEMO-053 | 2026-06-11 |
+| #848 | docs(process): IR/stakeholder review distinction — demo-preparation-standard, exit checklist, CLAUDE.md | 2026-06-11 |
 | #836 | docs(demo): walkthrough Section 4 — capability-gaps reframe (political feasibility, conditionality design, medium-term horizon; M14 cadence caveat) | 2026-06-10 |
 | #835 | docs(demo): walkthrough conditionality framing — clawback reading, branch mechanics, reserve invariant caveat | 2026-06-10 |
 | #834 | docs(demo): walkthrough pre-IR revision — two-act structure, human moment opening, NARRATION-RULING-1, Greece/Argentina framing | 2026-06-10 |

--- a/docs/demo/m12/stakeholder-walkthrough.md
+++ b/docs/demo/m12/stakeholder-walkthrough.md
@@ -251,6 +251,11 @@ selector shows step 1 of 8. The step label reads 2024.
 >
 > This is the two-country argument. Watch what happens to each country's
 > trajectory as the same shock accumulates.
+>
+> On the trajectory chart, Jordan's primary curve tracks reserve coverage —
+> it starts healthy and will decline over six steps under fuel import pressure.
+> Egypt's primary curve tracks governance — it starts already far below its
+> minimum floor, before the shock adds a single step of pressure.
 
 **FACTS:**
 
@@ -410,14 +415,14 @@ CRITICAL breach for Jordan with consecutive breach count.
 > The alert panel shows a CRITICAL alert: reserve_coverage_months, step 5,
 > first CRITICAL breach. The alert reads the finding, not a prediction.
 >
-> The trajectory chart also carries a second reading at step 5, on the
+> The trajectory chart also carries a second reading at step 5, on Jordan's
 > unemployment curve. At step 4, the GCC emergency support — arriving at step 3 with a
-> one-step lag — drove unemployment from 17.73% down to 16.59%. At step 5,
+> one-step lag — drove Jordan's unemployment from 17.73% down to 16.59%. At step 5,
 > the IMF conditionality fires with its own one-step lag: the spending
-> reduction scheduled at step 4 hits the growth trajectory, and unemployment
+> reduction scheduled at step 4 hits the growth trajectory, and Jordan's unemployment
 > reverses back to 17.25%. The GCC support improved things. The conditionality
 > clawed back most of the gain within a single step. Both movements are visible
-> on the same curve.
+> on Jordan's curve.
 
 **SYNTHESIS:**
 
@@ -513,10 +518,10 @@ being answered in real time.
 > The branch models "we accept the programme; we negotiate away the spending
 > cut."
 >
-> The primary divergence between the two curves appears at step 5, not step 4.
+> The primary divergence between Jordan's two curves appears at step 5, not step 4.
 > The GCC multiplier alone adds approximately +0.68pp GDP at step 4. The
 > absence of conditionality adds approximately +1.70pp GDP at step 5 — more
-> than twice the multiplier effect. Watch step 5 on the unemployment curves,
+> than twice the multiplier effect. Watch step 5 on Jordan's unemployment curves,
 > not just the GDP curves: the baseline reverses, the branch does not.
 
 **SYNTHESIS:**
@@ -581,13 +586,16 @@ Ecological (CO2 accumulation, independent of the Hormuz crisis), Governance
 
 **FACTS:**
 
-> The four-framework overview shows all four composite scores simultaneously at step 5. Financial:
-> reserve-linked divergence between Jordan and Egypt is the primary driver.
+> The four-framework overview shows all four composite scores simultaneously at step 5,
+> with Jordan and Egypt visible separately in each axis. Financial:
+> Jordan's score reflects reserve-linked stress; Egypt's reflects the food import
+> cost impact — the divergence between them is the primary driver.
 > Human Development: the bottom-quintile consumption capacity indicator —
 > the primary human cost ledger signal — shows the commodity price transmission
-> reaching the most vulnerable income cohort. Ecological: CO2 accumulation
-> continues its trajectory independent of the Hormuz crisis — global carbon
-> dynamics are not paused by a regional commodity shock. Governance: Egypt
+> reaching the most vulnerable income cohort in both countries.
+> Ecological: CO2 accumulation continues its trajectory independent of the Hormuz
+> crisis — global carbon dynamics are not paused by a regional commodity shock;
+> Jordan and Egypt track nearly identically on this axis. Governance: Egypt
 > far below the floor from step 1; Jordan stable on governance while under
 > financial pressure.
 >

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -2054,6 +2054,37 @@ The first Playwright execution attempt in the session. No downstream artifacts w
 
 ---
 
+## NM-040 — playwright.demo.config.ts Had No testMatch Guard; Pattern Invocation Triggered Concurrent TTS from Four Specs (Reactive)
+
+**Date:** 2026-06-11
+**Milestone:** M12 — Active Control and External Sector
+**Detected by:** M12 pre-demo rehearsal — four overlapping TTS narration streams fired simultaneously
+**Severity:** Medium
+
+### What happened
+
+During M12 pre-demo rehearsal, the narrated spec was invoked using a pattern argument (`npx playwright test --config playwright.demo.config.ts "demo-narrated" --headed`) instead of the full spec path. `playwright.demo.config.ts` had `testDir: "./tests/e2e"` with no `testMatch` restriction, so the pattern matched all four spec files containing "demo-narrated" in their name: `demo-narrated-m6.spec.ts`, `demo-narrated-m8.spec.ts`, `demo-narrated-m10.spec.ts`, and `demo-narrated.spec.ts` (M12). All four ran in parallel. Each spec calls `speak.sh`, producing four concurrent TTS narration streams during what was intended to be a single-spec rehearsal run.
+
+`scripts/demo.sh --run` was already correct — it invokes the spec by full path with `--project=chromium`. The concurrent invocation occurred when bypassing the shell script and running Playwright directly with a pattern.
+
+### What was at risk
+
+A presenter running a rehearsal using the pattern form would hear overlapping narration from M6, M8, M10, and M12 simultaneously — an unrecoverable rehearsal disruption. More critically, a presenter who did not know to use `demo.sh --run` and reached for `npx playwright test ... "demo-narrated"` before a live demo would trigger the same failure in front of stakeholders, with no fast recovery path.
+
+The config offered no protection against the pattern invocation. The correct form was documented in the spec header comment and in `demo.sh`, but was not enforced by the config itself.
+
+### What caught it
+
+Pre-demo rehearsal 2026-06-11. The failure was immediately recognizable (four narrations competing). No live stakeholder was present.
+
+### Process improvement
+
+1. **Immediate fix:** `testMatch: ["**/demo-narrated.spec.ts"]` added to `playwright.demo.config.ts` (PR #857, Issue #855). The config now ignores any spec not matching this pattern regardless of the pattern passed on the command line. Archived specs (`demo-narrated-m6.spec.ts`, etc.) are tested via `playwright.config.ts` (CI), not the demo config.
+
+2. **Root cause:** The config was written to restrict by `testDir` only, relying on correct invocation discipline. The process improvement is to make configs self-protecting: a config whose purpose is to run one specific spec should restrict to that spec by `testMatch`, not rely on callers to provide the correct pattern.
+
+---
+
 ## Registry Maintenance
 
 ### How to add an entry

--- a/frontend/playwright.demo.config.ts
+++ b/frontend/playwright.demo.config.ts
@@ -17,6 +17,11 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  // Restrict to the current milestone's demo spec only. Without this, any
+  // pattern-based invocation matches all demo-narrated-*.spec.ts files and
+  // triggers concurrent TTS narration from M6/M8/M10/M12 simultaneously.
+  // NM-040 / Issue #855.
+  testMatch: ["**/demo-narrated.spec.ts"],
   timeout: 60_000,
   reporter: [["list"]],
   use: {

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -301,7 +301,11 @@ test(
       "of twenty-five percent sustained over six steps. " +
       "Food supply chains follow in year two. " +
       "Jordan imports forty-two percent of its fuel. Egypt imports thirty-five percent of its food. " +
-      "Same shock. Different import structures. Different crises.",
+      "Same shock. Different import structures. Different crises. " +
+      "On the trajectory chart, Jordan's primary indicator is reserve coverage — " +
+      "it starts at seven point one months and will decline over the arc. " +
+      "Egypt's primary indicator is governance — " +
+      "it starts already far below the minimum floor before the shock begins.",
     );
 
     const scenarioRow = page.locator(".scenario-row").filter({ hasText: DEMO_SCENARIO_NAME });
@@ -330,7 +334,9 @@ test(
       "propagates through the ExternalSector module. " +
       "Look at the four-framework overview — four axes, all live: financial, human development, ecological, governance. " +
       "This is the first demonstration in the tool's history where all four composite scores " +
-      "are computed simultaneously.",
+      "are computed simultaneously. " +
+      "Jordan and Egypt are both present in every axis. " +
+      "Watch the financial axis for Jordan's reserve stress, and the governance axis for Egypt's pre-existing deficit.",
     );
 
     // Frame A: Full Zone 1 instrument cluster at step 1.
@@ -368,7 +374,7 @@ test(
       "GCC partners have provided budget support — three precedents in the last decade. " +
       "This is the thesis frame. " +
       "Jordan reserves: five months, down from seven point one. " +
-      "The reserve curve is burning at approximately one point two months per step. " +
+      "Jordan's reserve curve is burning at approximately one point two months per step. " +
       "Pause here. Read what the instruments are telling you before we test a counter-proposal. " +
       "One note on the governance alert for Egypt: it carries an Exploratory confidence tier. " +
       "The direction of deterioration is consistent with V-Dem historical data. " +
@@ -423,9 +429,9 @@ test(
       "The austerity conditionality at step four does not enter the branch. " +
       "The question being asked is: what does that negotiating outcome cost the IMF, " +
       "and what does it give Jordan? " +
-      "Look at the trajectory chart. The divergence is not yet visible at step three — " +
+      "Look at the trajectory chart. Jordan's baseline and branch curves are not yet diverging at step three — " +
       "the GCC multiplier effect appears at step four. " +
-      "Advance to step five to see where the trajectories separate.",
+      "Advance to step five to see where Jordan's two trajectories separate.",
     );
 
     // Frame D: Mode 3 active, branch anchor visible, step 3.
@@ -452,9 +458,9 @@ test(
       "percent at step four, then conditionality reversed it to seventeen point two " +
       "percent at step five. In the branch, unemployment continues declining. " +
       "One step. One conditionality term. The direction of the unemployment curve reverses. " +
-      "Now look at the reserve curve. " +
-      "Both trajectories reach zero reserves by step seven. " +
-      "Better conditionality terms improved the GDP and unemployment trajectory. " +
+      "Now look at Jordan's reserve curve. " +
+      "Both of Jordan's trajectories — baseline and branch — reach zero reserves by step seven. " +
+      "Better conditionality terms improved Jordan's GDP and unemployment trajectory. " +
       "They did not change Jordan's structural fuel import dependency during a live Hormuz disruption. " +
       "The reserve crisis is survived under better internal conditions. It is not avoided. " +
       "The minister should know this before she uses this finding at the table.",


### PR DESCRIPTION
## Summary

- **DEMO-055 (#856)**: Entity identification gap in narration — audience cannot distinguish Jordan from Egypt without instrument labels (structural fix tracked at #845 for M13). Immediate workaround: narration now primes the audience at scenario load with which entity owns which primary indicator, and every bare curve reference ("the reserve curve", "the two curves") is entity-attributed throughout the walkthrough and spec.
- **DEMO-054 (#855)**: `playwright.demo.config.ts` had no `testMatch` guard. Pattern-based invocation matched all four `demo-narrated-*.spec.ts` specs and triggered concurrent TTS narration from M6/M8/M10/M12 simultaneously. Fix: `testMatch: ["**/demo-narrated.spec.ts"]` added — config is now self-protecting.
- **NM-040**: Near-miss entry filed in `docs/process/near-miss-registry.md`.

## Files changed

- `frontend/tests/e2e/demo-narrated.spec.ts` — entity priming at scenario load; entity-attributed curve references in Frame A, C, D, E narration
- `docs/demo/m12/stakeholder-walkthrough.md` — entity priming paragraph in Step 2 UMBRELLA; entity-attributed FACTS in Steps 5, 6, 7
- `frontend/playwright.demo.config.ts` — `testMatch: ["**/demo-narrated.spec.ts"]`
- `docs/process/near-miss-registry.md` — NM-040
- `SESSION_STATE.md` — state update

## Test plan

- [x] `npm run build` passes (TypeScript clean)
- [x] `grep -n "the reserve curve\|the two curves\|the trajectory chart.*two curves" demo-narrated.spec.ts stakeholder-walkthrough.md` — zero remaining bare unattributed entity references
- [x] `grep -n "testMatch" playwright.demo.config.ts` — guard confirmed present
- [ ] Issues #855 and #856 to be closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)