### PR TITLE
fix(demo): Step 6c gate — four annotation fixes to unblock Step 9 (closes #879)

### DIFF
--- a/docs/demo/m12/stakeholder-walkthrough.md
+++ b/docs/demo/m12/stakeholder-walkthrough.md
@@ -601,9 +601,30 @@ Ecological (CO2 accumulation, independent of the Hormuz crisis), Governance
 >
 > No axis is null. No axis is dashed. All four frameworks are live and
 > concurrent.
+>
+> Uncertainty calibration: the confidence tier for each framework is visible in
+> the MDA alert panel. Tier 1–2 findings are cite-ready. Tier 3 carries a
+> caveat. Tier 4–5 are early estimates requiring confirmation before citing. The
+> trajectory view renders confidence interval bands as shaded regions around each
+> curve when CI calibration data is loaded; in this demo, the confidence tier
+> labels are the active uncertainty representation.
+
+**[PRESENTER BEAT — point to the MDA alert panel]** Read one alert's confidence
+tier label aloud. For Egypt's governance alert, read: "Early estimate — confirm
+before citing." Explain: that is the instrument naming what it does not yet know.
+It is honest analysis, not a weakness in the finding. The ministry team sees the
+confidence tier before they cite the finding at the table.
 
 **SYNTHESIS:**
 
+> Returning to the Exploratory disclosure from Step 4: Egypt's governance alert
+> carried that label then, and it holds now in the four-axis view. The direction
+> of deterioration is calibrated to V-Dem historical patterns. The magnitude is
+> pending further validation. When the ministry team runs this scenario with their
+> own calibration data, the Exploratory label is the honest marker of exactly what
+> they need to provide. The instrument does not hide what it does not know — it
+> names it, so the ministry team can act on it.
+>
 > For the first time, a finance ministry team can look at a single instrument
 > and see that the financial trajectory is moving in one direction while the
 > human development trajectory is moving in another. Those are not the same

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -77,7 +77,7 @@ export function sortAlerts(alerts: Zone1BAlert[]): Zone1BAlert[] {
 export function getNegotiationLabel(tier: number): string {
   if (tier <= 2) return "High confidence — cite directly";
   if (tier === 3) return "Moderate confidence — cite with caveat";
-  return "Exploratory — do not cite";
+  return "Early estimate — confirm before citing";
 }
 
 /**
@@ -515,7 +515,9 @@ function FullDensityAlertRow({ alert, mode, isFocused, onClick }: FullDensityRow
             letterSpacing: 0.5,
           }}
         >
-          {alert.severity}
+          {alert.severity === "TERMINAL"
+            ? `${alert.severity} (threshold crossed)`
+            : alert.severity}
         </span>
         <span
           data-testid="alert-framework-source"

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -220,7 +220,11 @@ function CustomStepTick({ x = 0, y = 0, payload, data, entityIds }: CustomTickPr
 // TrajectoryView legend formatter
 // ---------------------------------------------------------------------------
 
-function legendFormatter(framework: FrameworkKey, scoringBasis: string): string {
+function legendFormatter(
+  framework: FrameworkKey,
+  scoringBasis: string,
+  entityIds?: string[],
+): string {
   const names: Record<FrameworkKey, string> = {
     financial: "Financial",
     human_development: "Human Development",
@@ -230,6 +234,9 @@ function legendFormatter(framework: FrameworkKey, scoringBasis: string): string 
   const base = names[framework];
   if (scoringBasis === "normalized_absolute") {
     return `${base} (single-country index)`;
+  }
+  if (entityIds && entityIds.length === 2) {
+    return `${base} (${entityIds[0]} · ${entityIds[1]})`;
   }
   return base;
 }
@@ -466,13 +473,28 @@ export function TrajectoryView({
                 strokeDasharray={isDashed ? "8 3" : undefined}
                 dot={false}
                 connectNulls={CONNECT_NULLS}
-                name={legendFormatter(fw, scoringBasis) as never}
+                name={legendFormatter(fw, scoringBasis, entityIds) as never}
                 isAnimationActive={false}
               />
             );
           })}
         </ComposedChart>
       </ResponsiveContainer>
+
+      {/* Multi-entity composite note — shown when two entities present */}
+      {!isSingleEntity && entityIds && entityIds.length === 2 && (
+        <div
+          style={{
+            fontSize: 11,
+            color: "#888",
+            marginTop: 4,
+            padding: "4px 8px",
+            borderLeft: "2px solid #ddd",
+          }}
+        >
+          Each curve is a framework composite across {entityIds[0]} and {entityIds[1]}. Both entities contribute to each trajectory.
+        </div>
+      )}
 
       {/* Single-entity methodology note (Zone 3, Path A — EL Decision B) */}
       {isSingleEntity && (


### PR DESCRIPTION
## Summary

- `TrajectoryView.tsx`: Legend now shows entity IDs `(JOR · EGY)` alongside each framework name when two entities are present; adds a multi-entity composite note strip below the chart (addresses DEMO-081 — curves indistinguishable by entity)
- `MDAAlertPanelZone1B.tsx`: `getNegotiationLabel` tier ≥ 4 changed from `"Exploratory — do not cite"` to `"Early estimate — confirm before citing"` — plain language, actionable (addresses DEMO-070/090 — Exploratory contradiction)
- `MDAAlertPanelZone1B.tsx`: `FullDensityAlertRow` TERMINAL severity badge appends `(threshold crossed)` — makes threshold semantics self-explanatory without explanation (addresses DEMO-072)
- `stakeholder-walkthrough.md`: Step 7 FACTS block adds uncertainty calibration beat + `[PRESENTER BEAT]` instruction to read a confidence tier label aloud (addresses DEMO-071 — uncertainty bands never shown)
- `stakeholder-walkthrough.md`: Step 7 SYNTHESIS opens with Exploratory callback reconnecting to Step 4 disclosure (addresses DEMO-070 — no callback from Step 7 to Step 4 Exploratory narration)

## Test plan

- [ ] Frontend build passes (`npm run build` — confirmed green locally)
- [ ] `getNegotiationLabel(4)` returns `"Early estimate — confirm before citing"` — verify in `MDAAlertPanelZone1B.test.ts`
- [ ] `legendFormatter("financial", "percentile_rank", ["JOR", "EGY"])` returns `"Financial (JOR · EGY)"` — verify in `TrajectoryView.test.ts`
- [ ] TERMINAL badge text includes `(threshold crossed)` in FullDensityAlertRow
- [ ] Walkthrough Step 7 contains the `[PRESENTER BEAT]` instruction and Exploratory callback paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)