### PR TITLE
docs(roadmap): update milestone references from M8/M11 era to M13 active

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # CLAUDE.md — WorldSim Project Context
 
-> Last significant revision: 2026-06-05
-> Updated against: M12 active — M11 closed (v0.11.0); release branch workflow added; PM Agent SPRINT mode added; sprint planning SOP codified (docs/process/sprint-planning-sop.md); .claude/settings.json pre-approved tool patterns added
-> Previous version context: 2026-05-30 — M11 active; matrix engine investigation primary M11 objective; political economy module M11 stretch goal (EL decision 2026-06-03)
+> Last significant revision: 2026-06-12
+> Updated against: M13 active — M12 closed (v0.12.1); matrix engine in production (ADR-009/012); ExternalSectorModule; Mode 3 Active Control; Demo 4 complete; Process Redesign Phase 0 endorsed; Phase A open
+> Previous version context: 2026-06-05 — M12 active; release branch workflow added; PM Agent SPRINT mode added; sprint planning SOP codified; north star test as formal process gate (FD-1 closed)
 
 > **Reader Orientation:** This is the permanent project constitution — read it in full before beginning any session. It contains the mission, architectural commitments, and process rules that govern all work in this repository. Anyone making a change in this codebase, human or agent, must have read this document first. Key must-read sections if time is short: Session Continuity (what to read and in what order), Guiding Principles (the values behind every technical decision), and §Architectural Principles for Claude Code Sessions (process gates including pre-push lint, PR merge gate, and file authority rules that will cause compliance violations if not followed).
 
@@ -272,22 +272,19 @@ Detailed domain profiles: `docs/agents/domain-intelligence-council.md`
 
 ## What We Are Building First
 
-M0–M10 complete (v0.1.0–v0.10.0). ADRs 001–007 current.
+M0–M12 complete (v0.1.0–v0.12.1). ADRs 001–012 current.
 See GitHub Releases for full delivery history.
 
-**Milestone 11 — Engine Investigation and Political Economy (Current)**
+**Milestone 13 — Political Economy and Instrument Credibility (Current)**
 
-*Primary objective (M11 exit gate):*
-- ADR-009 authored and accepted — simulation engine computation model
-- Sparse matrix proof-of-concept — matrix engine running alongside iterative engine
-- Phase 2 A/B validation — output equivalence, performance comparison, full backtesting suite
-- Matrix interpretability tooling — contribution tracing, transformation visualization
+*Primary objective (M13 exit gate):*
+- ADR-013 authored and accepted — political economy module boundary
+- Political economy module — conditionality modelling, elite capture dynamics, political feasibility constraints
+- Alert panel UX (Zone 1B) — master-detail layout; ADR and frontend architecture review required before implementation (#852)
+- Instrument legibility improvements — Demo findings DEMO-059–064 resolved
+- Process Redesign Phase A deliverables
 
-*Stretch goal (ships if primary is complete with capacity remaining):*
-- Political economy module — political feasibility constraints, conditionality modelling, elite capture dynamics
-- Carries to M12 if not started in M11
-
-M11 closes when the matrix engine investigation track is complete. The political economy module does not block M11 closure. EL decision 2026-06-03.
+M13 closes when the political economy module is production-ready and instrument credibility meets first-class UX standards for negotiation-room use. Demo 5 is planned for M14.
 
 Each milestone is a vertical slice — working software at every stage,
 not infrastructure waiting for features.
@@ -296,16 +293,15 @@ not infrastructure waiting for features.
 
 ## Milestone Roadmap
 
-M0–M10 complete (v0.1.0–v0.10.0). M11 current. See GitHub Releases for full delivery history.
+M0–M12 complete (v0.1.0–v0.12.1). M13 current. See GitHub Releases for full delivery history.
 
-The full roadmap covering M11 through M13 — milestone deliverables, demo anchors, canonical users served, and the long-term resolution spectrum direction — is maintained at `docs/roadmap/worldsim-roadmap.md`. That document is the canonical reference. The summary below reflects current and next milestone only.
+The full roadmap covering M13 through M14 — milestone deliverables, demo anchors, canonical users served, and the long-term resolution spectrum direction — is maintained at `docs/roadmap/worldsim-roadmap.md`. That document is the canonical reference. The summary below reflects current and next milestone only.
 
-**Milestone 11 — Engine Investigation and Political Economy (Current)**
-Primary objective: ADR-009 (simulation engine computation model), sparse matrix proof-of-concept, Phase 2 A/B validation, matrix interpretability tooling. No demo. M11 closes when the matrix engine investigation track is complete.
-Stretch goal: Political economy module (conditionality, political feasibility, elite capture) — ships if primary objective is complete with capacity remaining; otherwise carries to M12. EL decision 2026-06-03.
+**Milestone 13 — Political Economy and Instrument Credibility (Current)**
+Primary objective: ADR-013 (political economy module boundary), political economy module (conditionality, elite capture, political feasibility), alert panel UX (ADR required), instrument legibility improvements. No demo — Demo 5 at M14.
 
-**Milestone 12 — Active Control and External Sector (Next)**
-Core deliverable: Matrix computation engine in production, external sector module, Mode 3 (Active Control). Demo 4.
+**Milestone 14 — Methodology Publication and External Validation (Next)**
+Core deliverable: Methodology publication, external validation by domain experts, live stakeholder demo with real external participants (#843), Technical Steering Committee formation. Public launch infrastructure.
 
 Full roadmap: `docs/roadmap/worldsim-roadmap.md`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/PublicEnemage/worldsim/actions/workflows/ci.yml/badge.svg)](https://github.com/PublicEnemage/worldsim/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
-[![Release](https://img.shields.io/badge/release-v0.8.0%20M8%20complete-green)](https://github.com/PublicEnemage/worldsim/releases/tag/v0.8.0)
+[![Release](https://img.shields.io/badge/release-v0.12.1%20M12%20complete-green)](https://github.com/PublicEnemage/worldsim/releases/tag/v0.12.1)
 
 **An open-source geopolitical-economic simulation platform for governments and
 vulnerable actors navigating high-stakes decisions under uncertainty.**
@@ -47,19 +47,20 @@ not show.
 **The simulation is a structured reasoning tool, not a prediction engine.** It
 is designed to produce distributions, not point estimates — outputs carry
 confidence tiers, uncertainty bounds are quantified and displayed, and the
-model's blindspots are documented and visible. Three of four measurement
-framework axes are live at Milestone 8 (financial, human development,
-ecological); governance renders as an honest-null axis pending module certification.
+model's blindspots are documented and visible. All four measurement framework
+axes are live at Milestone 12 (financial, human development, ecological,
+governance); Mode 3 Active Control enables counter-scenario branching for
+negotiation support.
 
 **This tool is in active pre-release development.** The working software
-described below reflects Milestone 8. It is not yet usable for consequential
-analysis.
+described below reflects Milestone 12 (Demo 4 complete — Jordan/Egypt Strait
+of Hormuz scenario). M13 is in active development.
 
 ---
 
 ## What's Built
 
-The working system at Milestone 8:
+The working system at Milestone 12 (core components — not exhaustive):
 
 - **Simulation engine** — Event-driven graph in Python. The `Quantity` type
   system tracks `value: Decimal`, unit, variable type (STOCK/FLOW/RATIO/
@@ -73,10 +74,10 @@ The working system at Milestone 8:
   above 15%). Processes FiscalPolicyInput, MonetaryRateInput, and
   EmergencyPolicyInput events.
 
-- **EcologicalModule** — Planetary boundary proximity scoring live at M8.
-  CO2 concentration tracked against the Rockström 2009 350 ppm boundary
-  (confidence tier 2). Land-use pressure index tracked against the Richardson
-  2023 boundary. Composite score: unweighted mean of boundary proximity scores.
+- **EcologicalModule** — Planetary boundary proximity scoring. CO2 concentration
+  tracked against the Rockström 2009 350 ppm boundary (confidence tier 2).
+  Land-use pressure index tracked against the Richardson 2023 boundary.
+  Composite score: unweighted mean of boundary proximity scores.
   STOCK delta path emits new absolute levels (not raw deltas) — the propagation
   engine replaces STOCK attributes.
 
@@ -112,24 +113,21 @@ The working system at Milestone 8:
   equal visual weight to financial indicators. MDA (Minimum Descent Altitude)
   threshold system fires WARNING/CRITICAL/TERMINAL alerts when indicators cross
   hard floors. Demographic cohort model produces indicators by income quintile,
-  age band, and employment sector. Governance composite score is honest-null
-  at M8 — the GovernanceModule is implemented but has not yet met its five
-  promotion criteria; it renders as a dashed axis labeled "Governance — in
-  validation" rather than showing zero (which would imply governance failure).
+  age band, and employment sector. GovernanceModule promoted to live axis at M10
+  (five promotion criteria met; V-Dem data; ADR-005 Amendment 4).
 
 - **Frontend** — React + MapLibre GL choropleth map; scenario panel and step
-  controls; EntityDetailDrawer with a four-axis radar chart, MDA alert panel,
-  and per-framework indicator tables. Zone 3A expandable ecological methodology
-  note. PMM (Policy Maneuver Margin) Zone 1C placeholder widget. Radar 250ms
-  animation with `prefers-reduced-motion` and null-axis guards. Delta
-  choropleth for side-by-side scenario comparison. Playwright E2E suite covers
-  the full create→advance→drawer flow.
+  controls; instrument cluster (Zone 1A TrajectoryView, Zone 1B MDA Alert Panel
+  with drill-in, Zone 1C PMM widget, Zone 1D four-framework composite display);
+  persistent scenario identity header; Mode 3 Active Control (branch-from-snapshot,
+  fiscal multiplier input, live A/B trajectory comparison); multi-country scenario
+  support; delta choropleth; Playwright E2E suite at 1440×900.
 
 ---
 
 ## Development Status
 
-**Active pre-release development. Not yet usable for analysis.**
+**Active pre-release development. Demo 4 delivered 2026-06-11. M13 in active development.**
 
 | Milestone | Status | Version | Description |
 |---|---|---|---|
@@ -142,7 +140,12 @@ The working system at Milestone 8:
 | M6 — Backtesting Coverage Expansion | ✅ Complete | v0.6.0 | EcologicalModule initial, HumanDevelopmentModule, Greece 2010–2015 fixture extension |
 | M7 — Technical Foundation | ✅ Complete | v0.7.0 | P0 technical debt resolved; compliance scan clean; defensive programming standards |
 | M8 — Ecological and Governance Frameworks | ✅ Complete | [v0.8.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.8.0) | Three live radar axes; honest-null governance; Greece 2010–2015 demo; Case B UX verdict |
-| M9 — Standards Foundation | 🔧 In progress | — | GovernanceModule promotion, UX architecture rethink, user personas, ADR-007 |
+| M9 — Standards Foundation | ✅ Complete | — | UX architecture (ADR-008/010); five user personas; instrument cluster specification; agent RACI |
+| M10 — Engine Integrity and Instrument Delivery | ✅ Complete | [v0.10.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.10.0) | Instrument cluster live; all four framework axes live; GovernanceModule promoted; Demo 3 |
+| M11 — Engine Investigation and Political Economy | ✅ Complete | [v0.11.0](https://github.com/PublicEnemage/worldsim/releases/tag/v0.11.0) | Matrix engine (ADR-009); PoliticalEconomyModule; non-linear propagation (ADR-011); snapshots/restore |
+| M11.5 — Usability Validation | ✅ Complete | — | Priority A usability sessions (3 personas); universal finding; M12 scope filed |
+| M12 — Active Control and External Sector | ✅ Complete | [v0.12.1](https://github.com/PublicEnemage/worldsim/releases/tag/v0.12.1) | Matrix engine production (ADR-012); ExternalSectorModule; Mode 3 Active Control; Demo 4 |
+| M13 — Political Economy and Instrument Credibility | 🔧 In progress | — | ADR-013; political economy integration; alert panel UX; instrument legibility |
 
 Full milestone history: [`CHANGELOG.md`](CHANGELOG.md). Live issue tracker:
 [GitHub Milestones](https://github.com/PublicEnemage/worldsim/milestones).
@@ -150,7 +153,7 @@ Full milestone history: [`CHANGELOG.md`](CHANGELOG.md). Live issue tracker:
 Development uses a structured multi-agent Claude Code workflow: a single
 Engineering Lead working with specialized agents (Architect, Implementation,
 QA, Security, DevOps, and a nine-member Domain Intelligence Council of domain
-experts). External contributor infrastructure is a Milestone 8 deliverable.
+experts). External contributor infrastructure is on the M13–M14 roadmap.
 
 ---
 
@@ -163,14 +166,14 @@ to the macroeconomic indicators. They are never cut for velocity, never treated
 as optional annotations on the real results.
 
 **Backtesting as epistemic discipline.** Every model relationship is validated
-against historical cases before being trusted for forward projection. Two cases
-are implemented: Greece 2010–2015 (fiscal multiplier estimation error — IMF
-assumed ~0.5, empirical ~1.5; extended to six steps at M8 with ecological CO2
-trajectory live) and Argentina 2001–2002 (Zero Deficit Plan pro-cyclical
-austerity and sovereign default). Both run DIRECTION_ONLY fidelity thresholds
-in CI. The gap between model prediction and historical outcome is not a failure
-— it is the primary signal for improvement. Mean-reversion channels and
-additional backtesting cases are Milestone 10 scope.
+against historical cases before being trusted for forward projection. Five cases are validated: Greece 2010–2015 (fiscal multiplier estimation
+error — IMF assumed ~0.5, empirical ~1.5), Argentina 2001–2002 (Zero Deficit
+Plan sovereign default; Argentina year 1 reaches MAGNITUDE calibration:
+−10.55% vs historical −10.9%), Lebanon, Thailand, and Ecuador. All five run
+in CI as a build gate — a backtesting regression is a build failure. Argentina
+year 1 is MAGNITUDE calibrated; remaining cases are DIRECTION_ONLY. The gap
+between model prediction and historical outcome is not a failure — it is the
+primary signal for improvement.
 
 **No false precision.** Outputs are designed to be distributions over scenarios
 conditional on stated assumptions, not point forecasts about the future.
@@ -260,7 +263,7 @@ standards at every milestone exit.
 
 External contribution infrastructure — documentation for non-agent contributors,
 public methodology review, and Technical Steering Committee formation — is
-roadmapped for M9–M13. **The project is not yet ready for general open-source
+roadmapped for M13–M14. **The project is not yet ready for general open-source
 contribution.**
 
 What is valuable now:

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -1,9 +1,11 @@
 # WorldSim Roadmap
 
-> Last significant revision: 2026-05-30
-> Next mandatory review: Milestone 10 close
-> Updated against: M10 kickoff gate — Argentina 2000–2002 confirmed as second country fixture; Phase 1 benchmarks moved to M10 per NM-020; GovernanceModule #556 filed; scope linkage issue numbers added; #221 conflict flagged pending EL decision
+> Last significant revision: 2026-06-12
+> Next mandatory review: Milestone 13 close
+> Updated against: M13 kickoff — M12 closed (v0.12.1; Demo 4 complete); M11/M11.5 closed; registry updated through M14; M13 canonical title corrected to Political Economy and Instrument Credibility; "Where We Are" updated from M8/M9 era
 > Canonical location: `docs/roadmap/worldsim-roadmap.md`
+
+*Note: This document was not updated at M10, M11, M11.5, or M12 close — a gap against the "Roadmap Currency" policy. Updates at those closes are now reflected in the registry and narrative sections.*
 
 *This document is directionally committed, not contractually precise. When scope changes materially, this document is updated with a dated rationale note — not silently overwritten. The change history is the accountability mechanism.*
 
@@ -26,19 +28,21 @@
 | M8 | Ecological and Governance Frameworks | Instrument cluster design, four-framework UX | Complete |
 | M9 | Standards Foundation | Standards framework, compliance scan, UX architecture | Complete |
 | M10 | Engine Integrity and Instrument Delivery | TrajectoryView, PMM, MDA alerts, matrix investigation groundwork | Complete |
-| M11 | Engine Investigation and Political Economy | ADR-009, sparse matrix PoC, Phase 2 A/B validation | Current |
-| M12 | Active Control and External Sector | Matrix engine production, external sector module, Mode 3 | Next |
-| M13 | Methodology Publication | External release preparation, methodology documentation | Planned |
+| M11 | Engine Investigation and Political Economy | ADR-009, sparse matrix PoC, Phase 2 A/B validation, PoliticalEconomyModule | Complete |
+| M11.5 | Usability Validation and Experience Audit | Priority A usability sessions; universal finding; M12 scope filed | Complete |
+| M12 | Active Control and External Sector | Matrix engine production, ExternalSectorModule (ADR-012), Mode 3, Demo 4 | Complete |
+| M13 | Political Economy and Instrument Credibility | ADR-013, political economy integration, alert panel UX, instrument legibility | Current |
+| M14 | Methodology Publication and External Validation | Methodology publication, external validation, live demo, TSC formation | Planned |
 
 ---
 
 ## Where We Are
 
-WorldSim v0.8.0 is released. Eight milestones of foundational work are complete: the simulation engine, the data architecture, the backtesting infrastructure, the four-framework measurement system (financial, human development, ecological, governance), the Greece 2010–2015 and Argentina 2001–2002 backtesting fixtures, the multi-agent development team, the governance and compliance framework, and the UX design foundation.
+WorldSim v0.12.1 is released. Thirteen milestones of foundational and delivery work are complete. The simulation engine runs multi-country scenarios with matrix computation. The external sector module enables bilateral trade shocks and commodity price cascades. Mode 3 Active Control lets a finance ministry analyst branch from any simulation step, apply policy instruments, and compare the resulting trajectory against the baseline in real time. All four measurement framework axes are live. Five historical backtesting cases are validated (Greece, Argentina, Lebanon, Thailand, Ecuador). Demo 4 — a Jordan/Egypt Strait of Hormuz closure scenario — has been presented to stakeholders.
 
-The tool is not yet ready for consequential use. The instrument cluster is being redesigned. The governance module is in validation. The simulation runs one country at a time. The canonical users have been formally defined but the tool has not yet been evaluated against their real-world use cases.
+M13 is the transition from demonstration to institutional readiness. The political economy module makes programme feasibility constraints and conditionality design analytically visible. Instrument legibility improvements make the tool credible in a live negotiation room. The alert panel UX makes the threshold crossing story readable without presenter narration.
 
-Milestone 9 is the transition from foundational infrastructure to a tool that looks right, works across all four frameworks, and has been evaluated against the historical cases that define its value proposition.
+The three questions a sophisticated negotiator would ask that remain unanswerable today — political feasibility, conditionality design, and medium-term horizon — are M13's primary scope.
 
 ---
 
@@ -86,7 +90,7 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 
 ## Milestone by Milestone
 
-### Milestone 9 — Standards Foundation *(current)*
+### Milestone 9 — Standards Foundation *(complete)*
 
 **Core deliverable:** A complete UX design foundation and instrument cluster specification that gates all M9–M10 implementation work.
 
@@ -198,7 +202,26 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 
 ---
 
-### Milestone 13 — Methodology Publication and Public Launch
+### Milestone 13 — Political Economy and Instrument Credibility *(current)*
+
+**Core deliverable:** The political economy module makes programme feasibility constraints and conditionality design analytically visible. Instrument legibility makes the tool credible in a live negotiation room without a technical presenter.
+
+**What ships:**
+- ADR-013 — political economy module boundary definition; panel composition and acceptance gate
+- Political economy module — conditionality modelling as structured scenario inputs, elite capture dynamics, programme survival probability (political feasibility constraints)
+- Alert panel UX (Zone 1B) — master-detail layout; ADR required before implementation; EL decision 2026-06-11: Frontend architecture review + UX Designer + Design Thinking agent input required → Issue #852
+- Instrument legibility improvements — DEMO-059–064 resolved; Demo 5 readiness
+- Process Redesign Phase A deliverables (parallel track)
+
+**Demo:** None (M13). Demo 5 at M14.
+
+**Canonical user primarily served:** Persona 2 (Finance Ministry Negotiator) in a live negotiation context — the three analytical gaps identified in Demo 4 close such that "Can this government actually deliver this programme?" becomes answerable at the table.
+
+**What M13 does not do:** M13 does not publish the methodology publicly. External validation and TSC formation are M14 scope. M13 does not deliver a live external demo — that gates M14 closure (#843).
+
+---
+
+### Milestone 14 — Methodology Publication and External Validation *(planned)*
 
 **Core deliverable:** WorldSim is ready for institutional adoption. The methodology is published, externally validated, and inspectable by anyone.
 
@@ -207,13 +230,14 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 - External validation — methodology reviewed by domain experts outside the project
 - Technical Steering Committee formation — first governance actor independent of the Engineering Lead
 - Goodhart's Law mitigation design — TSC owns the monitoring and response framework for parameterization gaming risk
+- Live stakeholder demo with real external participants — M14 closure gate → Issue #843
 - Public launch infrastructure — onboarding path for global south finance ministry analysts, accessibility validation on target hardware
 
-**Demo:** Public launch event. The audience shifts from invited stakeholders to the world.
+**Demo:** Demo 5 at M14 close. The audience shifts from invited stakeholders to the world.
 
 **Canonical user primarily served:** All five personas — anchored in the quinoa farmer's government. The tool's public availability is the moment the democratization mission becomes operational rather than aspirational.
 
-**What M13 does not do:** M13 does not complete the entity template library. That work begins at M13 and continues beyond it as a permanent capability improvement program.
+**What M14 does not do:** M14 does not complete the entity template library. That work begins at M14 and continues beyond it as a permanent capability improvement program.
 
 ---
 


### PR DESCRIPTION
## Summary

Three files had stale milestone references that would mislead readers about the current project state. All were last updated during M8–M11 and not refreshed at subsequent milestone closes.

**README.md** (5 milestones behind — badge still showed v0.8.0):
- Release badge: v0.8.0 → v0.12.1
- "Three of four axes" → all four live; governance honest-null description removed (GovernanceModule promoted M10)
- "Not yet usable for consequential analysis" updated to reflect Demo 4 complete
- Frontend description: M8-era EntityDetailDrawer/radar → M12 instrument cluster + Mode 3
- Development status table: M9 updated to Complete; M10/M11/M11.5/M12 rows added; M13 added as In Progress
- Backtesting: two cases → five validated cases; "Milestone 10 scope" reference removed

**CLAUDE.md** (claimed M11 as current):
- Header revision date and "Updated against" updated
- "What We Are Building First": M11 (Current) → M13 (Current)
- "Milestone Roadmap": M11/M12 summary → M13/M14 summary

**docs/roadmap/worldsim-roadmap.md** (not updated since M10 kickoff — 2026-05-30):
- Acknowledged four missed milestone-close updates in header (gap against Roadmap Currency policy)
- Milestone registry: M11→Complete; M11.5 added Complete; M12→Complete; M13 title corrected to "Political Economy and Instrument Credibility" (had "Methodology Publication" — title changed at M13 GitHub milestone creation); M14 added as Planned
- "Where We Are": M8/M9-era narrative replaced with M12/M13 state description
- M9 heading: *(current)* → *(complete)*
- M13 section: replaced old Methodology Publication content with correct M13 scope; old content moved into a new M14 section

## Test plan
- [ ] README.md renders correctly on GitHub — badge links to v0.12.1 release page
- [ ] CLAUDE.md milestone section correctly identifies M13 as current
- [ ] roadmap.md milestone registry table matches SESSION_STATE.md milestone assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)