### PR TITLE
docs(process): milestone exit ceremony SOP + demo prep gaps (NM-041)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -690,6 +690,35 @@ description.
 
 ---
 
+## Milestone Exit Ceremony
+
+Every milestone exit must complete the following steps in order before the exit checklist issue is closed. Each step is a named, mandatory gate — not a suggestion. The retrospective (§Milestone Retrospective Process) is also required and follows these steps.
+
+**Step 1 — Open issue audit (GitHub)**
+Run `gh issue list --milestone "Milestone {N}..."` and confirm that only the exit checklist issue remains open. Every other issue must be explicitly dispositioned — migrated to a future milestone, closed as delivered, or closed with won't-fix rationale — before the exit checklist closes. A milestone that closes with unexplained open issues has not completed its exit ceremony.
+
+**Step 2 — Milestone reference audit**
+Update the following three documents in the same PR as the exit SESSION_STATE update. They must not be deferred to a follow-up PR:
+- `README.md` — release badge, development status table row for the closing milestone, any stale axis/module descriptions
+- `CLAUDE.md` — "What We Are Building First" and "Milestone Roadmap" sections: current → closed, next → current
+- `docs/roadmap/worldsim-roadmap.md` — milestone registry table (closing milestone → Complete; new milestone → Current); "Where We Are" narrative; current milestone section heading (`*(current)*` → `*(complete)*`); new milestone section added if absent
+
+The roadmap has an explicit currency policy ("updated at every milestone close"). This step is the enforcement mechanism for that policy. M10, M11, M11.5, and M12 all closed without this step — the gap was caught at M13 kickoff and required PR #896 to repair. Near-miss: NM-041.
+
+**Step 3 — SESSION_STATE internal consistency check**
+Before committing the exit SESSION_STATE update, verify all four of the following:
+- [ ] All issue milestone dispositions in the disposition summary match their actual GitHub milestone assignments (run `gh issue view #{N}` to spot-check)
+- [ ] The exit checklist issue for the *new* milestone (M{N+1}) is listed in the Open Issues — M{N+1} table with `immediate | M{N+1} gate issue` notation
+- [ ] No stale status notes remain (e.g., "EL endorsement is next required action" after the endorsement was recorded; "active work stream" entries for work that completed mid-milestone)
+- [ ] Parallel-track relationships (e.g., Process Redesign phases) explicitly state whether they are blocking prerequisites or concurrent tracks for the new milestone
+
+**Step 4 — Fresh session continuity test**
+After all exit PRs are merged and main is current, run the fresh session test: reading *only* SESSION_STATE.md and CLAUDE.md, ask — "if a new Claude Code session opened tomorrow and was asked to kick off M{N+1}, what wrong assumptions would it make or what dependencies would it miss?" Fix any critical or high gaps in a SESSION_STATE-only PR before declaring the exit ceremony complete. This step is complete only when the test produces no critical or high findings.
+
+**The exit ceremony is the last action of the milestone.** It runs after all feature work is merged, after the release branch is merged to main, after the demo cycle (for even-numbered milestones) is complete, and after the retrospective. It is not a side task to be delegated to a follow-up session.
+
+---
+
 ## Milestone Retrospective Process
 
 Every milestone exit ceremony must include a retrospective. The retrospective

--- a/docs/process/demo-preparation-standard.md
+++ b/docs/process/demo-preparation-standard.md
@@ -138,6 +138,13 @@ are live, which are null, what the honest disclosures are, what the roadmap sect
 Do NOT update the North Star closing. It does not change.
 Do NOT update the backtesting credibility section unless new cases were added.
 
+**Syntax validation gate (mandatory — NM-041):**
+After any edit to `scripts/demo.sh`, run:
+```bash
+bash -n scripts/demo.sh
+```
+The command must exit 0 before the file is committed. A syntax error in `demo.sh` makes the entire stack startup sequence inaccessible — the presenter guide, all timed narration cues, and the stack-ready confirmation all live inside this script. Root cause: M12 — a missing `)` closing a `$(bold ...)` command substitution on line 208 was undetected throughout M12 development and only surfaced when attempting to record the post-closure screen recording (PR #890, NM-041).
+
 **ExternalSector + Mode 3 reserve invariant — mandatory disclosure (M12 forward):**
 If the demo scenario uses `ExternalSectorModule` (ADR-012) and Mode 3 Active Control
 simultaneously, the honest disclosures section of `demo.sh` MUST include the following caveat:
@@ -552,6 +559,17 @@ Create the stakeholder-review placeholder if it does not already exist:
 `docs/demo/m{N}/reviews/PENDING-v{version}-stakeholder-review.md`
 (Use the template in `docs/templates/` or follow the structure of the M12 instance.)
 
+**GitHub release page completeness check (mandatory — demo-cycle milestones):**
+Verify the GitHub release page for the current version tag is self-contained. If the current tag is a patch release (`v{N}.{N}.1`) that supersedes an earlier tag (`v{N}.{N}.0`) without a public release page, the patch page must cover the full milestone arc — not just the delta since the prior tag.
+
+Checklist:
+- [ ] Release title includes the milestone name and demo theme
+- [ ] Body documents all major deliverables (not only since last tag)
+- [ ] Demo recording URL is present (add once Step 9b is complete)
+- [ ] Verify with: `gh release view v{N}.{N}.{P}`
+
+If the page is incomplete, use `gh release edit v{N}.{N}.{P} --notes "..."` to rewrite it before Step 9. Reference: v0.12.1 release page was rewritten at M12 exit after it was found to describe only the patch delta; no v0.12.0 release page existed (PR #896 context, M12 exit ceremony gap).
+
 ### Step 9 — Live stakeholder session
 
 Use `docs/demo/m{N}/stakeholder-walkthrough.md` as the presenter script.
@@ -570,6 +588,28 @@ Fill in: date, attendees, questions raised, most compelling moment, most questio
 north star test answer (specific — not aspirational), and follow-up actions. File GitHub
 issues for any new capability gaps named by real stakeholders. Update SESSION_STATE.md to
 record the demo as complete and cite the stakeholder-review artifact path.
+
+### Step 9b — Screen recording and release upload (demo-cycle milestones)
+
+A screen recording of the demo walkthrough is a required artifact for every even-numbered milestone demo cycle. It is the permanent visual record of what the tool could do at that milestone — future sessions, external reviewers, and potential institutional users cannot reconstruct the live application state from screenshots alone.
+
+**When to record:** After all post-Step-9 UI fixes are merged and main is current. The recording reflects the final shipped state, not a rehearsal.
+
+**What to record:** Use `scripts/demo.sh` to start the stack (the presenter guide printout should be visible in the terminal), then `scripts/demo.sh --run` for the Playwright walkthrough. Screen-record from launch through the final Zone 1D composite frame. Audio narration is optional but the terminal presenter guide must be visible during the startup phase so the recording is self-explanatory without live narration.
+
+**Upload and link:**
+```bash
+gh release upload v{N}.{N}.{P} /path/to/recording.mp4
+```
+Then edit the release body to include a direct link:
+```bash
+gh release edit v{N}.{N}.{P} --notes-file /path/to/updated-notes.md
+```
+
+**Record in SESSION_STATE:** Add to the SESSION_STATE M{N} block:
+`**Demo screen recording uploaded to GitHub release v{N}.{N}.{P}** — [URL]`
+
+Reference: M12 screen recording uploaded to `github.com/PublicEnemage/worldsim/releases/tag/v0.12.1` (2026-06-11). Recording was only possible after fixing the demo.sh syntax error (PR #890, NM-041) — the bash -n gate in Step 3 closes this gap for future milestones.
 
 ---
 

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -2085,6 +2085,46 @@ Pre-demo rehearsal 2026-06-11. The failure was immediately recognizable (four na
 
 ---
 
+## NM-041 — demo.sh Syntax Error Undetected Through Full Milestone Lifecycle; Blocked Post-Closure Screen Recording (Reactive)
+
+**Date:** 2026-06-11 (detected) / 2026-06-12 (NM filed)
+**Milestone:** M12 — Active Control and External Sector
+**Detected by:** EL attempting to record a screen capture of the demo after M12 formally closed; terminal printed `unexpected EOF while looking for matching '\''` at line 300 — the script had been running in a malformed quoted context since line 208
+**Severity:** High
+
+### What happened
+
+`scripts/demo.sh` contained a missing `)` closing a `$(bold '...')` command substitution on line 208. The broken line:
+
+```bash
+echo "          '$(bold 'The reserve crisis is survived under better conditions, not avoided.'"
+```
+
+Bash entered a single-quoted context inside the unclosed `$(` and read through to EOF (line 300), producing `unexpected EOF while looking for matching '\''`. The script cannot be executed in this state — `set -euo pipefail` exits immediately on the syntax error, making the presenter guide, stack startup, and all timed narration cues inaccessible.
+
+The syntax error was introduced during M12 development (PR #838, 2026-06-10 — demo prep Step 3). It passed code review, CI, and all M12 exit ceremony steps. It was only caught on 2026-06-11 when the EL attempted to record the demo after the milestone formally closed.
+
+### What was at risk
+
+1. **The screen recording** — the primary immediate consequence. The post-closure recording was only possible after PR #890 (fix) was merged, adding a delay and an extra PR to the exit ceremony.
+
+2. **A live stakeholder session** — if the M12 simulated session had run against the live stack (it ran via the Python demo script `demo_hormuz_jordan.py`, not `demo.sh`), the syntax error would have been invisible until a presenter ran `./scripts/demo.sh` immediately before or during the live demo. Recovery time at that moment: unknown.
+
+3. **Future milestone demos** — `scripts/demo.sh` is updated in-place each milestone. Without a syntax check gate, the same failure class can recur at any demo cycle.
+
+### What caught it
+
+The Engineering Lead — not the process. The M12 demo preparation standard (Step 3, Step 6) instructed the agent to update and run `demo.sh` but contained no syntax validation gate. The internal review, IR Agent, and audience simulation all ran against screenshots — none of them ran `demo.sh` directly. CI does not run `demo.sh`. The syntax error was invisible to every automated and agent-based gate.
+
+### Process improvement
+
+1. **Immediate fix:** PR #890 — missing `)` added on line 208. `bash -n scripts/demo.sh` verified clean.
+
+2. **Structural fix:** `bash -n scripts/demo.sh` added as a mandatory named gate at Step 3 of the Demo Preparation Standard (`docs/process/demo-preparation-standard.md §Step 3 — Syntax validation gate`). The gate runs after any edit to `demo.sh` and must exit 0 before the file is committed. This converts a person-caught gap to a process-caught gate.
+
+3. **Exit ceremony fix:** The milestone exit ceremony (CLAUDE.md §Milestone Exit Ceremony) codified as a named SOP for the first time, closing the broader gap that no formal exit ceremony checklist existed beyond the retrospective. The four exit ceremony steps (open issue audit, milestone reference audit, SESSION_STATE consistency check, fresh session continuity test) ensure the next milestone's session does not inherit stale state.
+
+---
 
 ## Registry Maintenance
 


### PR DESCRIPTION
## Summary

Institutionalises seven process gaps identified during the M12 exit and M13 kickoff session into formal SOP language across three documents.

**Root cause:** No formal milestone exit ceremony SOP existed. The only named post-feature-work steps were the demo preparation standard (for even milestones) and the retrospective. This left four recurring gaps — stale milestone references, open issues on the closing milestone, SESSION_STATE inconsistencies, and stale fresh-session state — with no owner and no process home.

## Changes

**CLAUDE.md — new §Milestone Exit Ceremony section** (inserted before §Milestone Retrospective Process):
- Four mandatory named steps every milestone must complete before the exit checklist closes:
  1. Open issue audit (`gh issue list --milestone`) — confirms only the exit checklist remains
  2. Milestone reference audit — README.md badge/table, CLAUDE.md current/next milestone sections, roadmap.md registry + "Where We Are" + section headings
  3. SESSION_STATE internal consistency check — four specific assertions (dispositions match GitHub; new milestone exit checklist listed; no stale status notes; parallel tracks labeled as blocking or concurrent)
  4. Fresh session continuity test — read only SESSION_STATE + CLAUDE.md, identify wrong assumptions a new session would make, fix all critical/high gaps before declaring exit complete
- Explicitly notes M10–M12 roadmap currency gap as the canonical failure this section closes

**docs/process/demo-preparation-standard.md — three additions:**
- **Step 3 (syntax gate):** `bash -n scripts/demo.sh` must exit 0 before committing any change to the script. References NM-041 as root cause.
- **Step 8 (release page check):** Verify GitHub release page covers full milestone arc (not just patch delta). References v0.12.1 rewrite as canonical instance.
- **Step 9b (screen recording):** New step — screen recording is a required artifact for every even-numbered milestone demo cycle. Defines when to record, what to capture, upload command, and SESSION_STATE record format.

**docs/process/near-miss-registry.md — NM-041:**
- `demo.sh` syntax error (missing `)` on line 208) introduced in PR #838, passed all M12 gates including internal review, IR Agent, and audience simulation, caught only post-closure when EL attempted screen recording
- Risk: a presenter running `./scripts/demo.sh` before a live stakeholder session with an unfixed syntax error has no fast recovery path
- Process improvement: bash -n gate (Step 3) + exit ceremony SOP (CLAUDE.md §Milestone Exit Ceremony)

## Test plan
- [ ] CLAUDE.md §Milestone Exit Ceremony section reads correctly and is positioned before §Milestone Retrospective Process
- [ ] demo-preparation-standard.md Step 3 has the bash -n gate; Step 8 has the release page check; Step 9b is a new titled section
- [ ] NM-041 is appended at the end of the NM entries (before §Registry Maintenance) and numbered sequentially after NM-040

🤖 Generated with [Claude Code](https://claude.com/claude-code)