### PR TITLE
process(phase-b): Business PO acceptance protocol — per-type verification criteria, exception path, sprint exit gate

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-12 (Process Redesign Phase A complete — EL endorsed PR #900; execution lifecycle, intent template, rejection artifact, Layer 3 gate (FD-2), Kryptonite constraint (FD-3) all encoded in CLAUDE.md; Phase B now open.)**
+**Last updated: 2026-06-12 (Process Redesign Phase B complete — acceptance-protocol.md filed; per-work-type verification criteria + exception path authored; ACCEPT mode added to agents.md §Business PO; Sprint Exit Gate added to sprint-planning-sop.md; Phase B exit artifact + Phase C sprint entry filed. Awaiting EL endorsement.)**
 **Current milestone:** M13 — Political Economy and Instrument Credibility (GitHub Milestone 9)
 **Previous milestone:** M12 — Active Control and External Sector (formally closed 2026-06-11; Issue #263 closed; GitHub Milestone 13 closed; tagged v0.12.1)
 
@@ -118,7 +118,9 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 | 5 — Enforcement review + exit artifact | PI Agent + PM Agent | `docs/process/sprint-plans/process-redesign-phaseA-exit.md` | #900 | ✅ Merged 2026-06-12 |
 | 6 — EL endorsement | EL | `docs/process/sprint-plans/process-redesign-phaseA-exit.md §Part VII` | #900 | ✅ Endorsed 2026-06-12 |
 
-**Phase B sprint entry filed:** `docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md` — **Phase B is now open.**
+**Phase B sprint entry filed:** `docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md` — **Phase B outputs filed 2026-06-12. Awaiting EL endorsement.**
+
+**Phase C sprint entry filed:** `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md` — **Phase C opens when EL endorses Phase B.**
 
 **Gaps closed by Phase A:**
 
@@ -129,6 +131,25 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 | **FD-2** — Layer 3 self-interpreting output has no process owner | Customer Agent Layer 3 gate at Validate step | `CLAUDE.md §Agent Execution Lifecycle — Layer 3 Quality Gate` |
 | **FD-3** — Kryptonite frame never governs tradeoffs | Kryptonite design constraint at Intent authorship + Validate | `CLAUDE.md §Agent Execution Lifecycle — Kryptonite Design Constraint` |
 | Intent document format gap — no standard for Implementation Intent | Canonical template with observable application state + Kryptonite check | `docs/process/intent-template.md` |
+
+## Process Redesign Sprint — Phase B Status
+
+**Phase B: Business PO Acceptance Protocol**
+**Status:** OUTPUTS FILED 2026-06-12 — awaiting EL endorsement (PR pending).
+
+| Step | Agent | Output | Status |
+|---|---|---|---|
+| 1 — Per-work-type verification criteria (frontend, backend, docs, analytics) | Business PO | `docs/process/acceptance-protocol.md §Part 1` | ✅ Filed 2026-06-12 |
+| 2 — Exception path specification + enforcement review | PI Agent | `docs/process/acceptance-protocol.md §Part 2` | ✅ Filed 2026-06-12 |
+| 2b — ACCEPT mode in agents.md §Business PO | Business PO | `docs/process/agents.md §Business Product Owner Agent` | ✅ Filed 2026-06-12 |
+| 2c — Sprint Exit Gate in sprint-planning-sop.md | PM Agent | `docs/process/sprint-planning-sop.md §Sprint Exit Gate` | ✅ Filed 2026-06-12 |
+| 3 — Phase B exit artifact + Phase C sprint entry | PM Agent | `docs/process/sprint-plans/process-redesign-phaseB-exit.md`; `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md` | ✅ Filed 2026-06-12 |
+| 4 — EL endorsement | EL | `docs/process/sprint-plans/process-redesign-phaseB-exit.md §Part VII` | ⏳ Pending |
+
+**What Phase B produced:**
+- **`docs/process/acceptance-protocol.md`** — per-type verification checklists (frontend, backend, docs, analytics); DEMO4 class check explicit in backend protocol; asymmetry test operationalizes FD-3 at Validate step; Customer Agent Layer 3 as precondition (not follow-up); rejection artifact triggers + format + re-acceptance process + EL exception path; PI enforcement review embedded
+- **`docs/process/agents.md` amendment** — `PO: ACCEPT` activation mode with canonical protocol reference
+- **`docs/process/sprint-planning-sop.md` amendment** — §Sprint Exit Gate: exit conditions, agent responsibilities at exit, what "CI green" does not substitute for, sprint exit artifact format
 
 ---
 
@@ -173,7 +194,8 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 
 **Awaiting EL action:**
 - ~~Phase 0 EL endorsement~~ — **RECORDED 2026-06-11** (`docs/process/sprint-plans/process-redesign-phase0-exit.md §Part VI`). XD-1, XD-2, FD-1 closed.
-- ~~Phase A EL endorsement~~ — **RECORDED 2026-06-12** (PR #900; `docs/process/sprint-plans/process-redesign-phaseA-exit.md §Part VII`). Execution lifecycle gap, FD-2, FD-3 closed. **Phase B is now open.** Entry: `docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md`.
+- ~~Phase A EL endorsement~~ — **RECORDED 2026-06-12** (PR #900; `docs/process/sprint-plans/process-redesign-phaseA-exit.md §Part VII`). Execution lifecycle gap, FD-2, FD-3 closed. **Phase B outputs filed.** Entry: `docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md`.
+- **Phase B EL endorsement** — **PENDING** (`docs/process/sprint-plans/process-redesign-phaseB-exit.md §Part VII`). Acceptance protocol, per-type verification criteria, exception path, ACCEPT mode in agents.md, Sprint Exit Gate in SOP all filed. Review and endorse when ready. Phase C entry filed at `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md`.
 - ~~Step 6c gate~~ — **PASS (2026-06-11)**: PR #880 resolved DEMO-070/071/081/090; DEMO-080 accepted as-is by EL (tablet scale, out of scope for 1440×900 live demo). Audience simulation review updated. Step 9 unblocked.
 - ~~Step 9 simulated session~~ — **COMPLETE (2026-06-11)**. North star verdict: PASS. Aicha: "The conditionality dispute is about who absorbs the employment cost — the reserve crisis happens either way. That argument is now quantified." Artifact: `docs/demo/m12/reviews/2026-06-11-v0.12.1-stakeholder-review.md` (PR #886). Screenshots recaptured with PR #880 UI changes (PR #883). Two new M13 issues: #884 (reserve value not on screen), #885 (Exploratory tier on baseline vs. projection). Per-entity curves (#845) confirmed as primary unresolved UX gap.
 - ~~#843 M12 live external demo~~ — **DEFERRED TO M14** (EL decision 2026-06-11). Issue repurposed as M14 closure gate: live stakeholder demo with real external participants, timed to coincide with methodology publication. M12 simulated session (north star PASS) stands as M12 closure evidence. M12 is now formally complete pending only the exit checklist (#263).

--- a/docs/process/acceptance-protocol.md
+++ b/docs/process/acceptance-protocol.md
@@ -1,0 +1,397 @@
+---
+name: acceptance-protocol
+type: process-protocol
+phase: Phase B — Business PO Acceptance Protocol
+status: Active
+authored-by: Business PO (Part 1 — Steps 1–2); PI Agent (Part 2 — exception path)
+authored-date: 2026-06-12
+el-endorsement-required: true
+phase-entry: docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md
+phaseA-inputs:
+  - CLAUDE.md §Agent Execution Lifecycle (Step 5 — Validate)
+  - CLAUDE.md §Agent Execution Lifecycle — When Verify or Validate fails
+  - CLAUDE.md §Agent Execution Lifecycle — Layer 3 Quality Gate
+  - CLAUDE.md §Agent Execution Lifecycle — Kryptonite Design Constraint
+  - docs/process/intent-template.md
+deliberation-source: docs/process/design/2026-06-08-sprint-cadence-acceptance-gates-deliberation.md §Phase B
+---
+
+# Business PO Acceptance Protocol — WorldSim
+
+**Owner:** Business Product Owner (R)
+**Enforcer:** PI Agent (R — sprint exit confirmation; near-miss filing on rejection)
+**Accountable:** Engineering Lead
+**Authority:** `CLAUDE.md §Agent Execution Lifecycle — Step 5 (Validate)`
+
+This document specifies what Business PO acceptance looks like for each work type, what
+constitutes a passing validation, and what the exception path is when acceptance is rejected.
+It makes the Validate step (Step 5 of the Agent Execution Lifecycle) repeatable rather than
+improvised. Every sprint containing a user-facing deliverable uses this protocol — it is not
+optional, and it is not a judgment call that varies by sprint.
+
+**Activation:** `PO: ACCEPT — [intent document path or PR number]`
+
+---
+
+## Part 1 — Per-Work-Type Verification Criteria
+
+*Authored by Business PO. Authority: CLAUDE.md §Agent Execution Lifecycle — Step 5.*
+
+### 1.1 Frontend Feature
+
+**What the Business PO does:**
+
+1. **Reads the intent document** (Section 3 — Observable Application State; Section 2 — Persona
+   Trace). Identifies the fixture scenario, viewport, zone, step, and specific value or element
+   that constitute the observable state for this feature.
+
+2. **Opens the running application** at the fixture scenario named in Section 3.1. The fixture
+   scenario is the canonical test context — the Business PO does not substitute a different
+   scenario unless Section 3 explicitly permits it. If the fixture scenario is not loaded, the
+   validation cannot proceed.
+
+3. **Sets viewport to 1440×900** unless the intent document specifies a different viewport. This
+   is the canonical demo viewport. Viewport is set before starting the validation clock.
+
+4. **Navigates from the application's natural entry state** to the observable state using only
+   UI elements. No direct API calls, no developer tools, no URL manipulation that bypasses normal
+   navigation. The navigation path must be the path Persona 2 in a Reactive entry state would
+   follow — not a developer shortcut.
+
+5. **Confirms the time ceiling.** The P-4 time ceiling in the intent document is the maximum
+   elapsed time from entry state to observable state. If reaching the observable state requires
+   longer than P-4, the time ceiling check fails even if the observable state is eventually
+   reached. A capability that passes the observable state check but exceeds P-4 has not passed
+   the Validate step.
+
+6. **Confirms the observable state** named in Section 3.1 of the intent document is visually
+   present in the running application. "Visually present" means: readable without developer
+   tooling, on-screen and interpretable, in the zone specified. A value that appears only in
+   browser devtools or in an API response not surfaced in the UI is not present in the observable
+   state for a frontend feature.
+
+7. **Confirms silent failure is absent.** The Business PO checks the silent failure condition
+   named in Section 3.3 — verifying that the observable state is genuine output, not a frozen
+   or default value. For any output that should change over the scenario's steps, the Business PO
+   confirms the value at step N differs from the value at step 0.
+
+8. **Obtains the Customer Agent Layer 3 assessment** before delivering the verdict, for any
+   capability serving Personas 2, 3, or 5. This assessment is a required input to the verdict —
+   not a consultation the Business PO may skip. A verdict delivered without the Layer 3
+   assessment for a Persona 2/3/5 capability is a process violation.
+
+**What constitutes a passing verdict:**
+
+The Business PO must answer YES to all of the following:
+- [ ] The named persona can reach the observable state within the P-4 time ceiling navigating only UI elements from the natural entry state
+- [ ] The observable state named in Section 3.1 is visually present in the running application at the named fixture scenario, viewport, and step
+- [ ] The silent failure indicators in Section 3.3 are absent — the output value differs from the step-0 value at the step named in Section 3
+- [ ] For Persona 2/3/5 capabilities: the Customer Agent Layer 3 assessment is on record and returns PASS
+- [ ] Section 5 (Kryptonite Constraint) is satisfied — the observable state does not require specialist mediation for Persona 2 in the Reactive entry state
+
+**Passing verdict artifact:**
+
+Filed as a PR comment or appended to the intent document:
+
+> VALIDATED — [date]. Persona [N] reached [observable state from Section 3.1] in [M] seconds at
+> 1440×900 with [fixture scenario name] active. Silent failure check: value at step [N] = [X],
+> differs from step-0 value [Y]. Customer Agent Layer 3: [PASS / N/A — Persona 1/4/6+].
+> Kryptonite check: PASS. Verdict: ACCEPT.
+
+---
+
+### 1.2 Backend Capability
+
+**What the Business PO does:**
+
+1. **Reads the intent document** (Section 3 — Observable Application State). Identifies the
+   specific API endpoint(s), fixture scenario(s), step(s), and field values that constitute the
+   observable state for this capability.
+
+2. **Requests the implementing agent** to execute the API calls in the Business PO's review
+   context. The Business PO reviews the responses; the implementing agent executes the calls.
+   The implementing agent must use the fixture scenario and parameters named in Section 3 — not
+   a substitute scenario.
+
+3. **Confirms the specific field values** named in Section 3 are present in the API response.
+   "Present" means: the field is non-null, the value is within the range the intent document
+   specified, and the value changes across scenario steps — it is not frozen at the initial state.
+   The DEMO4 class check is mandatory: the field value at step N must differ from the value at
+   step 0 for any output representing a dynamic state. A frozen output is a silent failure
+   regardless of CI status.
+
+4. **Confirms the analytical intent.** The Business PO asks: does this API response change what
+   the named persona can argue at the negotiating table? The Business PO must produce a specific
+   answer — naming the persona, the argument, and why this argument was unavailable before.
+   "Improves situational awareness" is not an answer. "The Zambian ministry analyst can now
+   quantify that the foreign-currency rollover threshold was breached at step 3, and cite the
+   specific MDA threshold in the restructuring session" is an answer.
+
+5. **Confirms silent failure distinguishability.** The Business PO validates at least one
+   scenario variant where the expected field value is non-trivially different from the initial
+   state. If the implementation shows the same value under all scenario conditions, the Business
+   PO cannot distinguish genuine output from a silent failure — the check fails.
+
+**What constitutes a passing verdict:**
+
+The Business PO must answer YES to all of the following:
+- [ ] The API response contains the field(s) named in Section 3 with non-null values for the named fixture scenario and step(s)
+- [ ] DEMO4 class check: the field value at step N differs from the value at step 0 for any dynamic-state output
+- [ ] The Business PO can name a specific argument the named persona can now make that was unavailable before this implementation
+- [ ] The argument passes the asymmetry test: usable by a ministry team with three economists, without specialist mediation the creditor side provides that the ministry side cannot
+
+**Passing verdict artifact:**
+
+> VALIDATED — [date]. API: [endpoint]. Fixture: [scenario name]. Field [name] = [value] at
+> step [N], differs from step-0 value [Y]. DEMO4 check: PASS. Analytical intent: [named persona]
+> can now argue: "[specific argument]". Prior limitation: [what was absent]. Asymmetry test:
+> PASS. Verdict: ACCEPT.
+
+---
+
+### 1.3 Documentation
+
+**What the Business PO does:**
+
+1. **Identifies the canonical entry point.** The intent document's Section 3.1 names the entry
+   point — the path a first-time reader follows to discover this document (e.g., CLAUDE.md
+   §section → linked document → key finding). If no canonical entry point is named in the
+   intent document, the Business PO looks for the natural navigation path from the project's
+   standard entry points (CLAUDE.md, SESSION_STATE.md, agents.md).
+
+2. **Navigates from the entry point to the document.** The Business PO follows the link chain
+   from the named entry point as if discovering the document for the first time — without using
+   the document's file path directly. If there is no navigation path from a canonical entry point
+   to the document, the navigability test has failed before the five-minute clock starts. A
+   document with no inbound links from any project navigation entry point is not discoverable.
+
+3. **Starts a five-minute clock** from the entry point. The clock runs until the Business PO
+   locates and reads the key finding named in the intent document's Section 3.
+
+4. **Evaluates navigability.** Can a non-author navigate to the key finding from the entry point
+   in under five minutes? The non-author simulation: the Business PO navigates as if the document
+   is unknown — no prior knowledge of its existence, no shortcut to the file path.
+
+**What constitutes a passing verdict:**
+
+The Business PO must answer YES to all of the following:
+- [ ] A navigation path exists from a canonical entry point (CLAUDE.md, SESSION_STATE.md, or agents.md) to this document — not just a direct file path
+- [ ] The key finding named in Section 3.1 is reachable in under five minutes from the entry point
+- [ ] The key finding is explicitly named or headed in the document — it does not require section-by-section reading to locate
+
+**Passing verdict artifact:**
+
+> VALIDATED — [date]. Navigation path: [entry point] → [link/section] → [document name].
+> Key finding "[finding description]" reached in [M] minutes. Verdict: ACCEPT.
+
+---
+
+### 1.4 Analytics
+
+**What the Business PO does:**
+
+1. **Reads the analytical output** named in the intent document's Section 3 — the indicator
+   value, composite score, trajectory, or model result.
+
+2. **Applies the Kryptonite frame.** Does this output change what the named persona can argue
+   at the negotiating table? The Business PO must name:
+   - The specific persona (by name and number from `docs/ux/personas.md` — not "a user")
+   - The specific argument: a concrete, citable claim, not a capability description
+   - Why this argument was unavailable before: what was the prior limitation — absent indicator,
+     unavailable disaggregation, opaque causal chain, or unquantified uncertainty?
+
+3. **Applies the asymmetry test.** Could the ministry team with three economists use this
+   argument at the table, or does deploying it require specialist mediation that the creditor
+   side can provide and the ministry side cannot? If specialist mediation is required and no EL
+   exception exists, the Kryptonite constraint is not satisfied. "This is as complex as the
+   domain allows" does not satisfy the constraint — the constraint is satisfied when the output
+   is interpretable by a finance ministry economist without further translation.
+
+4. **Requests a Customer Agent AUDIT** if the output is user-facing — before delivering the
+   verdict. The AUDIT must confirm Layer 3 usability: the output tells the user what the number
+   means, not only displays the number.
+
+**What constitutes a passing verdict:**
+
+The Business PO must answer YES to all of the following:
+- [ ] The analytical output is present and matches the observable state named in Section 3
+- [ ] The Business PO can name the specific argument the named persona can make — not aspirational, not "improves situational awareness"
+- [ ] The argument passes the asymmetry test: usable by the ministry team without specialist mediation the creditor side can provide and the ministry side cannot
+- [ ] For user-facing output: Customer Agent AUDIT is on record and confirms Layer 3 usability
+
+**Passing verdict artifact:**
+
+> VALIDATED — [date]. Persona [N] ([name]): can now argue "[specific citable argument]".
+> Prior limitation: [what was absent]. Asymmetry test: PASS — usable without specialist mediation.
+> Customer Agent Layer 3: [PASS / N/A — infrastructure]. Verdict: ACCEPT.
+
+---
+
+## Part 2 — Exception Path Specification
+
+*Authored by PI Agent. Authority: CLAUDE.md §Agent Execution Lifecycle — When Verify or Validate
+fails; deliberation source §Phase B PI Agent Finding 3.*
+
+### 2.1 When the Business PO Triggers a Rejection
+
+A rejection is triggered when the Business PO cannot answer YES to all passing checklist items
+for the relevant work type in Part 1. The threshold is binary: the passing checklist is either
+complete or it is not. There is no partial pass.
+
+The Business PO does not reject for reasons outside the passing checklist. If the implementation
+passes all checklist items, the Business PO accepts — even if the Business PO has opinions about
+design or quality not captured in the checklist. Those opinions are backlog scope items routed
+to PM Agent, not rejection grounds. The checklist is repeatable precisely because it is not a
+judgment call.
+
+**Rejection triggers by work type:**
+
+| Work type | Rejection triggers |
+|---|---|
+| Frontend feature | Observable state absent or incorrect; time ceiling exceeded; silent failure present (output frozen at step-0 value); Customer Agent Layer 3 FAIL without EL exception; Kryptonite constraint violated without EL exception |
+| Backend capability | API field null or frozen at initial value (DEMO4 class failure); analytical intent (P-7) cannot be stated specifically; asymmetry test fails without EL exception |
+| Documentation | No canonical navigation path from any project entry point; key finding not reachable in under five minutes |
+| Analytics | Specific argument cannot be named; argument requires specialist mediation without EL exception; Customer Agent Layer 3 FAIL for user-facing output without EL exception |
+
+### 2.2 Rejection Artifact Requirements
+
+When a rejection is triggered, the Business PO produces a rejection artifact per
+`CLAUDE.md §Agent Execution Lifecycle — When Verify or Validate fails`.
+
+**Location:** `docs/process/rejections/REJECT-NNN-YYYY-MM-DD-short-description.md`
+(NNN is the next sequential rejection number from the rejections directory)
+
+**Required contents common to all work types:**
+- Source intent document (ADR reference + intent document path)
+- Which acceptance criterion failed (reference the checklist item number from Part 1)
+- What was expected vs. what was observed
+- Whether the gap is in the intent document (imprecise specification) or the implementation
+  (implementation did not satisfy the intent)
+- Remediation scope: what must change; which step the implementing agent returns to (Step 1 —
+  Intent authorship; not Step 3 — Implementation)
+- Re-acceptance condition: the specific, named check the Business PO will execute at re-acceptance
+
+**Additional required content by work type:**
+
+*Frontend feature:*
+- The observable state expected: exact quote from Section 3.1 of the intent document
+- What the Business PO observed in the running application at the named fixture scenario, viewport, and step
+- Customer Agent Layer 3 finding on record (presence required even when not the primary rejection reason)
+
+*Backend capability:*
+- The API endpoint called, the fixture scenario loaded, and the actual field value returned
+- DEMO4 class check result: whether the field value was frozen (same as initial state)
+
+*Documentation:*
+- The navigation path attempted and where the chain broke
+- Whether the gap is a missing inbound link (not discoverable) or a navigability failure (link chain exists but key finding not reachable in five minutes)
+
+*Analytics:*
+- The specific argument that could not be named, or the mediation required to deploy the argument
+- Whether the Kryptonite constraint is the primary failure
+
+**Near-miss entry requirement:** Every rejection artifact requires a near-miss registry entry
+filed by the PI Agent in the same session. The near-miss records: what happened, what was at
+risk, what caught it, and what process improvement resulted. A rejection that produces no
+near-miss entry has not been properly processed institutionally — the intent-to-implementation
+gap it evidenced must become permanent institutional memory.
+
+### 2.3 Re-Acceptance Process
+
+**Return-to-Step-1 requirement:** Per `CLAUDE.md §Agent Execution Lifecycle`, the implementing
+agent returns to Intent authorship (Step 1), not Implementation (Step 3). A Verify or Validate
+failure is evidence that the intent-to-implementation chain had a gap. The intent must be
+re-examined before the code is corrected — the intent may be the source of the gap.
+
+**Re-acceptance gate:** The implementing agent and Business PO use the re-acceptance condition
+named in the rejection artifact as the only acceptance criterion at re-acceptance. The Business
+PO does not introduce new requirements at re-acceptance that were not in the original passing
+checklist. New requirements belong in a new intent document for a new scope.
+
+**Re-acceptance verdict artifact:** The Business PO files a re-acceptance verdict in the same
+format as the original verdict, with this appended line:
+> "RE-ACCEPTED — [date]. Rejection [REJECT-NNN] resolved. Re-acceptance condition satisfied:
+> [condition from rejection artifact]."
+
+**Sprint exit block:** The sprint cannot close until the Business PO re-acceptance verdict
+artifact is filed and the PI Agent confirms the rejection is resolved. PI Agent holds R for
+confirming resolution before the sprint exit gate passes.
+
+### 2.4 EL Exception Path
+
+If the Engineering Lead determines that proceeding despite a rejection is necessary (scope
+constraint, milestone pressure, or known acceptable limitation at this milestone):
+
+1. **EL appends an exception** to the rejection artifact in a new section:
+   > "EL Exception — [date]. Reason: [why the rejection is accepted as-is]. Accepted limitation:
+   > [what the limitation is and why it is acceptable]. Forward trace: [milestone and capability
+   > that will address this limitation]."
+
+2. **The exception substitutes for re-acceptance.** The sprint may close with the exception on
+   record. The rejection artifact is not deleted or modified — the exception is appended to it.
+
+3. **The exception is not a verdict reversal.** The Business PO's rejection finding is permanent
+   institutional record. The EL exception acknowledges the project is proceeding with a known
+   limitation — and that the limitation is documented with a forward trace.
+
+4. **PI Agent files a near-miss** referencing the EL exception in the same session. An
+   exception-closed rejection is still institutional evidence of a process gap; the near-miss
+   entry ensures it becomes a systemic prompt rather than an isolated incident.
+
+### 2.5 PI Agent Enforcement Review
+
+This protocol has teeth if and only if:
+
+1. **The passing checklist items are observable, not interpretable.** Each checklist item in Part 1
+   names a specific, confirmable condition — not a quality judgment. "The observable state is
+   visually present" is confirmable; "the feature is well-implemented" is not. The protocol's
+   specificity is its enforcement mechanism.
+
+2. **The rejection artifact format is mandatory, not suggested.** A Business PO finding that is
+   not filed as a rejection artifact (e.g., communicated verbally, recorded only in a PR comment
+   without the canonical location and sequential number) has not satisfied the format requirement.
+   PI Agent holds R for confirming that every rejection is filed at the canonical location.
+
+3. **The near-miss entry is filed in the same session as the rejection.** A near-miss entry filed
+   in a subsequent session is not the same as one filed in the session the gap was found — the
+   institutional evidence trail depends on the near-miss being tied to the session that produced it.
+
+4. **The re-acceptance condition names a specific check.** "Address the Business PO's concerns"
+   is not a re-acceptance condition. "GET /api/v1/scenarios/{id}/trajectory returns
+   reserve_coverage_months ≠ 7.1 at step 3 for the JOR entity with the Hormuz fixture" is a
+   re-acceptance condition. The specificity is what makes re-acceptance a gate rather than
+   a renegotiation.
+
+**PI Agent verdict on Part 2:** Enforcement language is obligation, not aspiration. Each gate
+names who enforces it. Rejection artifacts have teeth: they block sprint exit, require near-miss
+entries, and mandate return to Step 1. The exception path preserves the Business PO's finding
+as institutional record while providing the EL an explicit override path. This protocol is
+adequate for Phase B exit.
+
+---
+
+## Application Notes
+
+**This protocol applies to every sprint containing a user-facing deliverable.** It does not apply
+to pure infrastructure work (Tier 3 ADRs with no direct user-visible output). When in doubt about
+work type, the Business PO asks the implementing agent to confirm the ADR tier.
+
+**Multiple work types in one sprint:** A sprint containing frontend features, backend capabilities,
+documentation, and analytics work applies this protocol per-deliverable. The sprint exit gate does
+not close until all deliverables have received a Business PO verdict.
+
+**The Customer Agent Layer 3 assessment is a precondition, not a follow-up.** For Persona 2/3/5
+capabilities, the Business PO requests the Customer Agent AUDIT before the Business PO Validate
+step begins — not after. A verdict delivered without it is a process violation.
+
+**This protocol is the gate, not the relationship.** The Business PO and implementing agent may
+have aligned views on quality; the protocol exists for the case when they do not. Applying it
+consistently — accepting when the checklist is complete, rejecting when it is not — is what
+makes sprint exit a gate rather than a rubber stamp.
+
+---
+
+*This document is the canonical Phase B output. It references Phase A outputs
+(`CLAUDE.md §Agent Execution Lifecycle`) and feeds Phase C (sprint cadence formalization via
+the sprint exit gate reference in `docs/process/sprint-planning-sop.md §Sprint Exit Gate`).
+Changes require Business PO and PI Agent review and EL endorsement.*

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -665,7 +665,15 @@ PO: STORIES [scope]
 PO: PRIORITIZE
 PO: DEMO REVIEW [milestone]
 PO: BRIEF
+PO: ACCEPT — [intent document path or PR number]
 ```
+
+`PO: ACCEPT` executes the Business PO Validate step (Step 5 of the Agent Execution Lifecycle)
+for a specific implementation. The Business PO reads the intent document, identifies the work
+type (frontend, backend, documentation, analytics), follows the per-type verification protocol
+in `docs/process/acceptance-protocol.md`, and produces a written verdict artifact. A verdict
+without the per-type passing checklist complete is a rejection. Rejection produces a rejection
+artifact at `docs/process/rejections/REJECT-NNN-YYYY-MM-DD-short-description.md`.
 
 ### Working Agreement
 

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -156,3 +156,72 @@ If scope changes materially after kickoff:
 - EL must confirm any wave reassignment that changes the critical path
 
 Sprint plan documents are not silently overwritten. Changes are visible through the revision markers and git history.
+
+---
+
+## Sprint Exit Gate
+
+*Authority: `docs/process/acceptance-protocol.md` (Phase B output).
+Updated 2026-06-12 per Phase B. Changes to this section require PI Agent review and EL endorsement.*
+
+A sprint does not close when all implementation groups are merged and CI is green. A sprint
+closes when the following conditions are all satisfied:
+
+### Exit Conditions
+
+1. **All implementation groups are merged to the release branch** with CI green on the release
+   branch. This is necessary but not sufficient.
+
+2. **Business PO acceptance is recorded for every user-facing deliverable.** For each sprint
+   group whose primary output is a frontend feature, backend capability, documentation, or
+   analytics output, the Business PO must have executed the Validate step (Step 5 of the Agent
+   Execution Lifecycle) using the per-type verification protocol in
+   `docs/process/acceptance-protocol.md`. The Business PO verdict artifact (ACCEPT or REJECT)
+   must be filed and on record before the sprint exit gate passes.
+
+3. **No open rejections.** If any Business PO verdict is REJECT, the rejection artifact must be
+   resolved — either by re-acceptance (Business PO files re-acceptance verdict) or by EL
+   exception (EL appends exception to rejection artifact). A sprint with an unresolved rejection
+   artifact does not exit.
+
+4. **Customer Agent Layer 3 assessment on record** for any deliverable serving Personas 2, 3,
+   or 5. This is a precondition for the Business PO verdict, but PI Agent confirms it is present
+   before signing off the sprint exit.
+
+5. **PI Agent sprint exit confirmation.** PI Agent reviews the exit conditions and confirms all
+   are satisfied before the sprint exit checklist issue is closed. PI Agent does not produce the
+   verdicts — PI Agent confirms they exist and are complete.
+
+### Who Closes the Sprint Exit Gate
+
+| Role | Responsibility at exit |
+|---|---|
+| Business PO | Produces ACCEPT/REJECT verdicts for all user-facing deliverables |
+| Customer Agent | Produces Layer 3 assessment for Persona 2/3/5 deliverables (before Business PO verdict) |
+| PI Agent | Confirms all exit conditions are satisfied; files near-miss for any rejection; blocks exit if any condition is unmet |
+| Engineering Lead | Approves EL exceptions for any unresolved rejections; closes the milestone exit checklist issue |
+
+### What "CI Green" Does Not Substitute For
+
+- CI green does not substitute for a Business PO ACCEPT verdict.
+- A passing unit test suite does not substitute for the observable application state check.
+- A passing Playwright test does not substitute for the Business PO confirming the named persona
+  can reach the observable state within the P-4 time ceiling.
+
+These checks are complementary, not substitutable. CI confirms implementation correctness.
+Business PO acceptance confirms mission alignment. Both are required before sprint exit.
+
+### Sprint Exit Artifact
+
+The sprint exit artifact is the proof that all exit conditions were satisfied. For process
+redesign sprints, see the phase exit document pattern (e.g., `process-redesign-phaseA-exit.md`).
+For M{N} milestone sprints, the sprint exit artifact is the milestone exit checklist issue
+comment on GitHub, which must include:
+
+- [ ] All implementation groups merged; CI green on release branch
+- [ ] Business PO ACCEPT verdict filed for each user-facing deliverable (or EL exception on record)
+- [ ] Customer Agent Layer 3 assessment on record for Persona 2/3/5 deliverables
+- [ ] No open rejection artifacts
+- [ ] PI Agent sprint exit confirmation
+
+The PI Agent reviews this checklist before confirming exit.

--- a/docs/process/sprint-plans/process-redesign-phaseB-exit.md
+++ b/docs/process/sprint-plans/process-redesign-phaseB-exit.md
@@ -1,0 +1,221 @@
+---
+name: process-redesign-phaseB-exit
+type: sprint-exit
+phase: Phase B — Business PO Acceptance Protocol
+status: Filed — awaiting EL endorsement
+authored-by: PM Agent (orchestration); PI Agent (exit gate confirmation + enforcement review)
+date: 2026-06-12
+sprint-entry: docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md
+phaseA-exit: docs/process/sprint-plans/process-redesign-phaseA-exit.md
+---
+
+# Phase B Exit Artifact — Business PO Acceptance Protocol
+
+**Status:** Filed — awaiting EL endorsement
+**Date produced:** 2026-06-12
+**PI Agent enforcement review:** Below (Part III)
+**EL endorsement:** Pending — see Part VII
+
+---
+
+## Part I — Primary Outputs Delivered
+
+All primary output artifacts are filed at their canonical locations per
+`docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md §Output Artifact Canonical Locations`.
+
+| Output | Status | Canonical location | Authored by |
+|---|---|---|---|
+| Per-work-type verification criteria — frontend (Step 1) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 1 §1.1` | Business PO |
+| Per-work-type verification criteria — backend (Step 1) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 1 §1.2` | Business PO |
+| Per-work-type verification criteria — documentation (Step 1) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 1 §1.3` | Business PO |
+| Per-work-type verification criteria — analytics (Step 1) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 1 §1.4` | Business PO |
+| Exception path specification — rejection triggers (Step 2) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 2 §2.1` | PI Agent |
+| Exception path specification — rejection artifact requirements (Step 2) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 2 §2.2` | PI Agent |
+| Exception path specification — re-acceptance process (Step 2) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 2 §2.3` | PI Agent |
+| Exception path specification — EL exception path (Step 2) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 2 §2.4` | PI Agent |
+| PI enforcement review within acceptance-protocol.md (Step 2) | ✅ Filed | `docs/process/acceptance-protocol.md §Part 2 §2.5` | PI Agent |
+| ACCEPT mode in agents.md §Business Product Owner Agent | ✅ Filed | `docs/process/agents.md §Business Product Owner Agent — Activation prompt reference` | Business PO |
+| Sprint Exit Gate in sprint-planning-sop.md | ✅ Filed | `docs/process/sprint-planning-sop.md §Sprint Exit Gate` | PM Agent |
+| PI enforcement review (this document Part III) | ✅ Below | `docs/process/sprint-plans/process-redesign-phaseB-exit.md §Part III` | PI Agent |
+| Phase B exit artifact (this document) | ✅ Filed | `docs/process/sprint-plans/process-redesign-phaseB-exit.md` | PM Agent |
+| Phase C sprint entry (Step 3) | ✅ Filed | `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md` | PM Agent |
+
+---
+
+## Part II — What Phase B Delivered and Why It Matters
+
+Phase B was tasked with making the Validate step (Step 5 of the Agent Execution Lifecycle)
+repeatable rather than improvised. The core gap: Phase A defined the execution lifecycle
+including the Validate step, but left the Business PO with four under-specified questions:
+
+1. What does the Business PO actually do for a frontend feature Validate step?
+2. What constitutes evidence of analytical intent satisfied for a backend capability?
+3. What is the standard for "navigability in under five minutes" for documentation?
+4. What does "names the specific argument" mean for analytics?
+
+Phase B answers all four with concrete, per-type verification protocols. The protocols are
+repeatable because each uses a binary passing checklist rather than a quality judgment. A
+checklist item is either true or false; it does not vary by Business PO preference or by session.
+
+**Three structural decisions embedded in the protocol:**
+
+1. **The checklist is the gate, not the relationship.** When the Business PO and implementing
+   agent have aligned views, the protocol is fast. When they diverge, the protocol is what
+   makes the disagreement visible and resolvable rather than suppressed. This is the protocol's
+   primary value — it performs best when relationships are under pressure.
+
+2. **The Customer Agent Layer 3 assessment is a precondition, not a follow-up.** For Persona 2/3/5
+   capabilities, the Business PO requests the Layer 3 assessment before executing the Validate
+   step. This sequencing prevents the pattern of validating then discovering the output requires
+   specialist mediation — a pattern that forces re-validation or acceptance of a known weakness.
+
+3. **The DEMO4 class check is explicit in the backend protocol.** The frozen-value silent failure
+   (DEMO4-001/002) is now a named, mandatory check at the Validate step. It is not implicit in
+   "confirm the field is non-null." The check explicitly requires that the value at step N differs
+   from the value at step 0 for any dynamic-state output.
+
+---
+
+## Part III — PI Agent Enforcement Review
+
+*PI Agent produces this review independently. Engineering Lead reads this review as part of the
+endorsement decision.*
+
+**Finding 1 — Enforcement language is obligation, not aspiration.**
+
+The passing checklists in Part 1 use language that creates an observable obligation:
+- "The Business PO must answer YES to all of the following" — not "should generally confirm"
+- "The exception path has a mandatory near-miss entry" — not "consider filing a near-miss"
+- "A verdict delivered without the Layer 3 assessment for a Persona 2/3/5 capability is a
+  process violation" — not "the Layer 3 assessment is recommended"
+
+The sprint exit gate in sprint-planning-sop.md uses the same enforcement pattern as the
+pre-push lint gate and PR merge gate already in CLAUDE.md: it names who enforces (PI Agent
+holds R for sprint exit confirmation), what blocks exit (open rejections, absent Customer Agent
+assessments), and the consequence of proceeding without it (process violation, not advisory).
+
+**Finding 2 — The rejection artifact has teeth.**
+
+Per the Phase B sprint entry §Secondary Output and the PI Agent's deliberation Finding 3
+requirement ("a rejected sprint must produce a written rejection artifact ... before any work in
+the next sprint group begins"), the rejection protocol satisfies:
+
+- The rejection blocks sprint exit until resolved ✅ (§2.3 sprint exit block)
+- The rejection requires a near-miss entry in the same session ✅ (§2.2 near-miss requirement)
+- The rejection artifact is at a canonical location with a sequential number ✅ (§2.2 location)
+- The implementing agent returns to Step 1 (intent authorship), not Step 3 (implementation) ✅ (§2.3 return-to-Step-1)
+- The re-acceptance condition is named specifically in the rejection artifact ✅ (§2.2 re-acceptance condition)
+
+The EL exception path preserves the Business PO's finding as permanent institutional record
+while giving the EL an explicit override mechanism. This matches the deliberation's requirement:
+the sprint may proceed, but the finding does not evaporate and the forward trace is mandatory.
+
+**Finding 3 — The DEMO4 class check is institutionally embedded.**
+
+The frozen-value silent failure pattern (DEMO4-001: reserves frozen at 7.1 months) now has a
+named mandatory check at the Validate step for backend capabilities (§1.2, checklist item 2:
+"DEMO4 class check: the field value at step N differs from the value at step 0"). This pattern
+was previously implicit in "the feature is working" — it is now explicit in the passing checklist.
+A future implementing agent cannot pass the Validate step with a frozen output by claiming CI is
+green. The check is observable and binary.
+
+**Finding 4 — The asymmetry test closes the gap between "technical correctness" and "mission alignment."**
+
+The backend capability and analytics protocols both include an asymmetry test: can the ministry
+team with three economists use this argument at the table, or does it require specialist mediation
+the creditor side has and the ministry side lacks? This test operationalizes the Kryptonite
+Design Constraint (FD-3) at the Validate step for these work types. A technically correct
+analytical capability that requires a PhD to interpret and cite fails the asymmetry test even if
+it passes all other checklist items.
+
+**Finding 5 — One structural limitation remains (scope for Phase C).**
+
+The sprint exit gate is defined in this phase's sprint-planning-sop.md amendment, but the
+sprint entry protocol (what must exist before implementation begins) is not yet formalized.
+Phase C will encode the sprint entry gate — the mirror image of the exit gate. Until Phase C
+is complete, the entry side of the sprint boundary depends on the existing PM Agent sprint
+planning SOP and the Phase A lifecycle's Step 1 requirement (intent document before
+implementation). This is an appropriate Phase C scope item, not a Phase B gap.
+
+**PI Agent verdict:** Enforcement language is adequate for Phase B exit. The acceptance protocol's
+per-type passing checklists are observable and binary. The rejection artifact protocol has teeth.
+The DEMO4 class check is explicitly embedded. The asymmetry test operationalizes FD-3 at Validate.
+One structural limitation (sprint entry gate) is correctly deferred to Phase C. Phase B may close
+and Phase C may open.
+
+---
+
+## Part IV — Exit Gate Checklist
+
+Per `docs/process/sprint-plans/process-redesign-phaseB-sprint-entry.md §Exit Gate`:
+
+| # | Condition | Status |
+|---|---|---|
+| 1 | `docs/process/acceptance-protocol.md` filed with per-work-type verification criteria | ✅ Confirmed — all four work types specified |
+| 2 | PI Agent confirms enforcement language is adequate (obligation, not aspiration) | ✅ Confirmed — Part III Findings 1–4 |
+| 3 | EL endorses Phase B outputs | Pending — see Part VII |
+| 4 | Phase C sprint entry document is filed | ✅ Filed — `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md` |
+| 5 | SESSION_STATE.md updated to reflect Phase B complete and Phase C entry filed | Pending — will update with EL endorsement PR |
+| 6 | Any deferred items explicitly listed with rationale | ✅ See Part III Finding 5 — sprint entry gate deferred to Phase C |
+
+**Gate status: 4 of 6 conditions confirmed. Gates 3 and 5 pending EL endorsement.**
+
+---
+
+## Part V — North Star Validation Question
+
+Per CLAUDE.md §North Star Test (Process Gate):
+
+*"If the Zambian finance ministry analyst is using WorldSim to prepare for a restructuring
+session and the implementing agent delivers the political economy module's conditionality
+constraint output — does the Business PO Acceptance Protocol ensure that output is usable
+in that room before the sprint closes?"*
+
+**Answer: Yes, in two specific ways.**
+
+First: the analytics validation protocol (§1.4) requires the Business PO to name the specific
+argument the Zambian ministry analyst can make at the table — not that the feature is delivered,
+but that the argument is nameable and citable. "The conditionality constraint model shows that
+the IMF's wage-cut terms reduce implementation capacity by 23% in the first year" is a citable
+argument. "The model is working" is not.
+
+Second: the asymmetry test (§1.2 and §1.4) requires confirming the argument is usable without
+specialist mediation the creditor side can provide and the ministry side cannot. If the argument
+can only be deployed by a PhD econometrician and the ministry team has three generalist
+economists, the Validate step fails even if the output is technically correct. This is the
+Kryptonite constraint at the Validate step, not only at intent authorship.
+
+**Validation verdict:** Phase B outputs are sufficient to confirm mission alignment at the sprint
+exit gate for the political economy module and for subsequent M13 deliverables.
+
+---
+
+## Part VI — Known Limitations
+
+| Limitation | Mitigation in place | Forward path |
+|---|---|---|
+| Sprint entry gate not yet formalized: the entry side of the sprint boundary (what must exist before implementation begins) is not in this phase's scope | Phase A lifecycle Step 1 requirement (intent document before implementation) covers the pre-implementation gate; PM Agent sprint planning SOP covers entry consultation | Phase C formalizes the sprint entry gate to mirror the sprint exit gate encoded here |
+| Business PO ACCEPT mode activation is described but its output filing location is not yet part of a sprint exit checklist template | sprint-planning-sop.md §Sprint Exit Gate names the conditions; Phase C will produce sprint exit checklist template that encodes these conditions as checkboxes | Phase C sprint exit template |
+| The EL exception path depends on the EL being available in the session the rejection occurs | PI Agent near-miss entry and the sprint exit block provide a fallback: the sprint cannot close without either re-acceptance or EL exception, so the EL's availability gates the sprint close rather than the exception | No process fix available — this is a single-principal governance limitation documented in CLAUDE.md §Governance |
+
+---
+
+## Part VII — EL Endorsement Space
+
+The Engineering Lead reviews this exit artifact and all primary outputs listed in Part I.
+Endorsement constitutes approval that:
+1. The per-work-type verification criteria in `docs/process/acceptance-protocol.md` are adequate
+2. The exception path in `docs/process/acceptance-protocol.md §Part 2` is accepted
+3. The PI enforcement review in Part III is accepted
+4. The north star validation finding in Part V is accepted
+5. The known limitations in Part VI are acceptable for this phase
+6. Phase C may open using `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md`
+
+**EL endorsement:**
+
+> [Pending — to be recorded when EL reviews this artifact]
+
+---
+
+*This artifact is the canonical exit record for Phase B. It must not be modified after EL
+endorsement except to add the endorsement itself and update SESSION_STATE.md.*

--- a/docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md
+++ b/docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md
@@ -1,0 +1,201 @@
+---
+name: process-redesign-phaseC-sprint-entry
+type: sprint-entry
+phase: Phase C — Sprint Cadence Formalization
+status: Filed — awaiting Phase B EL endorsement before opening
+authored-by: PM Agent (derived from deliberation document, 2026-06-08, and Phase B outputs)
+authored-date: 2026-06-12
+el-endorsement-required: true
+prerequisite: Phase B exit artifact endorsed — docs/process/sprint-plans/process-redesign-phaseB-exit.md
+deliberation-source: docs/process/design/2026-06-08-sprint-cadence-acceptance-gates-deliberation.md §Phase C
+phaseB-inputs:
+  - docs/process/acceptance-protocol.md (Business PO acceptance protocol — per-type criteria and exception path)
+  - docs/process/sprint-planning-sop.md §Sprint Exit Gate (Business PO acceptance attestation requirement)
+  - CLAUDE.md §Agent Execution Lifecycle (five-step lifecycle — Steps 1 and 5 are the sprint boundary reference points)
+gates-phases:
+  - Phase D — Session Boundary Discipline
+---
+
+# Phase C Sprint Entry — Sprint Cadence Formalization
+
+**Status:** Filed — awaiting Phase B EL endorsement
+**Date authored:** 2026-06-12
+**Opens when:** EL endorses Phase B exit artifact (`docs/process/sprint-plans/process-redesign-phaseB-exit.md §Part VII`)
+**Deliberation source:** `docs/process/design/2026-06-08-sprint-cadence-acceptance-gates-deliberation.md §Phase C`
+
+---
+
+## Why Phase C Exists
+
+Phase A defined the execution lifecycle — what each implementation step is and what gates each
+transition. Phase B defined the Business PO acceptance protocol — what validation looks like
+for each work type and what the exception path is. Phase C encodes the sprint boundary: when
+those steps run relative to sprint entry and exit, and what must exist at each boundary.
+
+Without Phase C, sprint entry and exit remain informally bounded:
+- Sprint entry: implementation begins when issues exist and a sprint plan is drafted — but
+  there is no document template that makes the entry conditions explicit and checkable
+- Sprint exit: the sprint-planning-sop.md §Sprint Exit Gate now names the conditions, but
+  the exit conditions are not yet in a template that an implementing agent can follow at
+  every sprint without reading the SOP each time
+
+Phase C produces the templates and PM Agent role language that make the sprint boundaries
+consistent across sprints — not dependent on re-reading the SOP, but encoded in artifacts
+that are filed at each sprint's start and close.
+
+---
+
+## Entry Invariants
+
+This sprint does not open until:
+
+1. **Phase B EL endorsement is complete.** The acceptance protocol (Phase B output) is the
+   prerequisite — the sprint exit template references the Business PO acceptance attestation
+   and the acceptance protocol defines what that attestation contains. Phase C cannot produce
+   a meaningful exit template without an accepted acceptance protocol to reference.
+
+2. **All Phase B primary outputs are confirmed accessible:**
+   - `docs/process/acceptance-protocol.md`
+   - `docs/process/sprint-planning-sop.md §Sprint Exit Gate`
+
+3. **Mandatory reading before session opens:**
+   - `docs/process/sprint-plans/process-redesign-phaseB-exit.md` — Phase B summary
+   - `docs/process/acceptance-protocol.md` — the sprint exit template references this
+   - `docs/process/sprint-planning-sop.md` — the SOP this phase amends
+   - `docs/process/design/2026-06-08-sprint-cadence-acceptance-gates-deliberation.md §Phase C`
+   - `SESSION_STATE.md`, `CLAUDE.md`, `docs/process/agents.md` — standard session protocol
+
+---
+
+## What Phase C Delivers
+
+### Primary Output — Sprint Entry and Exit Document Templates
+
+**Sprint entry template** (`docs/process/sprint-plans/templates/sprint-entry-template.md`):
+
+A structured template that any PM Agent session fills out at sprint kickoff to confirm the
+sprint is properly bounded before implementation begins. Required sections:
+
+1. Sprint identification (milestone, sprint group, issue list, release branch)
+2. Entry invariants checklist:
+   - [ ] ADR accepted for each group requiring an ADR (per sprint-planning-sop.md §Grouping Criteria #5)
+   - [ ] Intent document filed for each user-facing deliverable (per CLAUDE.md §Agent Execution Lifecycle Step 1)
+   - [ ] QA tests authored for each user-facing deliverable (per CLAUDE.md §Agent Execution Lifecycle Step 2)
+   - [ ] CI trigger verified on release branch (per sprint-planning-sop.md §Relationship to Release Branch)
+3. Scope declaration: the issues in this sprint; any issues explicitly out of scope with rationale
+4. ADR prerequisite table: which groups are BLOCKED_ADR and what ADR must be accepted first
+5. Near-miss sweep: any process gaps identified since the previous sprint close
+
+**Sprint exit template** (`docs/process/sprint-plans/templates/sprint-exit-template.md`):
+
+A structured template that PM Agent fills out at sprint close to confirm all exit conditions
+are satisfied. Required sections:
+
+1. Sprint identification and date
+2. Implementation status: all groups merged; CI green on release branch
+3. Business PO acceptance table: one row per user-facing deliverable, with verdict (ACCEPT/REJECT),
+   verdict artifact location, and Customer Agent Layer 3 assessment reference
+4. Open rejections: any REJECT verdicts and their resolution status (re-accepted, EL exception,
+   or blocking)
+5. PI Agent sprint exit confirmation: PI Agent confirms all conditions are satisfied
+
+The sprint exit template is filed at `docs/process/sprint-plans/{milestone-slug}-sprint-{N}-exit.md`
+alongside the sprint plan.
+
+### Secondary Output — PM Agent Role Amendment
+
+An amendment to `docs/process/agents.md §PM Agent` adding:
+
+- The PM Agent's obligation at sprint entry: fill out the sprint entry template before any
+  implementation PR is opened. A sprint that opens without a sprint entry template is a process
+  deviation — the PM Agent may not authorize implementation to begin without the entry template
+  complete and EL-approved.
+- The PM Agent's obligation at sprint exit: fill out the sprint exit template, confirm Business
+  PO acceptance is on record for all user-facing deliverables, and route to PI Agent for sprint
+  exit confirmation.
+
+### Tertiary Output — PI Agent Role Amendment
+
+An amendment to `docs/process/agents.md §Process Integrity Agent` adding:
+
+- The PI Agent's obligation when a sprint opens without a complete entry document: file a
+  near-miss entry immediately. A sprint that begins implementation without a sprint entry
+  template is a process gap — the near-miss is filed whether or not implementation ultimately
+  succeeds.
+- The PI Agent's role in the sprint exit gate: confirm all exit conditions in the sprint exit
+  template are satisfied before the sprint exit checklist issue is closed.
+
+### Quaternary Output — Sprint Planning SOP Amendment (sprint entry section)
+
+An amendment to `docs/process/sprint-planning-sop.md` adding a §Sprint Entry Gate section
+that mirrors the §Sprint Exit Gate added in Phase B. The sprint entry gate specifies what must
+be true before implementation begins — the intent document, the QA test file, the ADR — so
+that the sprint has both a defined entry and a defined exit.
+
+---
+
+## Participating Agents
+
+| Agent | Phase C role |
+|---|---|
+| **PM Agent** | Authors sprint entry and exit templates; authors PM Agent role amendment; orchestrates; produces Phase C exit artifact |
+| **PI Agent** | Authors PI Agent role amendment; confirms enforcement language has teeth; produces Phase C exit artifact enforcement review |
+| **QA Lead** | Consulted on sprint entry template — specifically, the test authorship entry invariant (does the entry template format make it easy to confirm tests exist before implementation?) |
+
+---
+
+## Work Sequence Within Phase C
+
+```
+Step 1 — PM Agent: sprint entry and exit document templates
+    Produces: docs/process/sprint-plans/templates/sprint-entry-template.md
+              docs/process/sprint-plans/templates/sprint-exit-template.md
+    Prerequisite for: Step 2
+
+Step 2 — PM Agent + PI Agent: role amendments
+    Produces: Amendment to docs/process/agents.md §PM Agent (sprint boundary obligations)
+              Amendment to docs/process/agents.md §Process Integrity Agent (sprint entry near-miss obligation)
+              Amendment to docs/process/sprint-planning-sop.md §Sprint Entry Gate
+    Prerequisite for: Step 3
+
+Step 3 — PM Agent: Phase C exit artifact + Phase D sprint entry filed
+    Produces: Phase C exit artifact (docs/process/sprint-plans/process-redesign-phaseC-exit.md)
+              Phase D sprint entry (docs/process/sprint-plans/process-redesign-phaseD-sprint-entry.md)
+    Prerequisite for: Phase D opens
+
+Step 4 — EL endorsement
+    Produces: Signed endorsement in Phase C exit artifact
+    Prerequisite for: Phase D sprint entry may be opened
+```
+
+---
+
+## Output Artifact Canonical Locations
+
+| Artifact | Canonical location | Authored by |
+|---|---|---|
+| Sprint entry template | `docs/process/sprint-plans/templates/sprint-entry-template.md` | PM Agent |
+| Sprint exit template | `docs/process/sprint-plans/templates/sprint-exit-template.md` | PM Agent |
+| PM Agent role amendment | Appended to `docs/process/agents.md §PM Agent` | PM Agent |
+| PI Agent role amendment | Appended to `docs/process/agents.md §Process Integrity Agent` | PI Agent |
+| Sprint Entry Gate SOP amendment | `docs/process/sprint-planning-sop.md §Sprint Entry Gate` | PM Agent |
+| Phase C exit artifact | `docs/process/sprint-plans/process-redesign-phaseC-exit.md` | PM Agent |
+| Phase D sprint entry | `docs/process/sprint-plans/process-redesign-phaseD-sprint-entry.md` | PM Agent |
+
+---
+
+## Exit Gate
+
+Phase C closes when:
+1. Sprint entry and exit templates are filed at canonical locations
+2. PM Agent and PI Agent role amendments are filed in agents.md
+3. Sprint Entry Gate section added to sprint-planning-sop.md
+4. PI Agent confirms enforcement language is adequate (obligation, not aspiration)
+5. EL endorses Phase C outputs
+6. Phase D sprint entry document is filed
+7. SESSION_STATE.md updated
+8. Any deferred items explicitly listed with rationale
+
+---
+
+*This document is filed as Phase B exit gate condition 4. Phase C opens when the EL endorses Phase B.*


### PR DESCRIPTION
## Summary

- **Phase B of the Process Redesign sprint cadence** — makes the Validate step (Step 5 of the Agent Execution Lifecycle) repeatable rather than improvised
- **`docs/process/acceptance-protocol.md`** — per-work-type verification checklists (frontend, backend, documentation, analytics); DEMO4 class check explicitly embedded in backend protocol; asymmetry test operationalizes FD-3 (Kryptonite constraint) at the Validate step; Customer Agent Layer 3 assessment as a precondition to the Business PO verdict (not a follow-up); rejection triggers, artifact format, re-acceptance process, EL exception path; PI enforcement review embedded in the document
- **`docs/process/agents.md`** — `PO: ACCEPT` activation mode added to Business PO section with canonical protocol reference
- **`docs/process/sprint-planning-sop.md §Sprint Exit Gate`** — sprint exit conditions, agent responsibilities, explicit statement of what "CI green" does not substitute for, sprint exit artifact format
- **`docs/process/sprint-plans/process-redesign-phaseB-exit.md`** — Phase B exit artifact with PI enforcement review and north star validation (Zambian ministry analyst conditionality argument test); awaiting EL endorsement in Part VII
- **`docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md`** — Phase C sprint entry (sprint cadence formalization — templates + PM/PI Agent role amendments); opens when EL endorses Phase B

## EL Action Required

Review `docs/process/sprint-plans/process-redesign-phaseB-exit.md §Part VII` and add endorsement text to open Phase C. Phase C entry is already filed at `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md`.

## Test plan

- [ ] `docs/process/acceptance-protocol.md` exists with all four work-type sections and both Part 1 and Part 2
- [ ] `docs/process/agents.md §Business Product Owner Agent` contains `PO: ACCEPT` mode
- [ ] `docs/process/sprint-planning-sop.md` contains `§Sprint Exit Gate` section
- [ ] `docs/process/sprint-plans/process-redesign-phaseB-exit.md` exists with Part I–VII structure (Part VII pending EL endorsement)
- [ ] `docs/process/sprint-plans/process-redesign-phaseC-sprint-entry.md` exists
- [ ] `SESSION_STATE.md` updated with Phase B status section and Phase B EL endorsement in Awaiting EL action

🤖 Generated with [Claude Code](https://claude.com/claude-code)