### PR TITLE
feat(m13): EL approval — sprint plan + entry doc approved

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-12 (M13 kickoff complete — release/m13 cut; sprint plan and entry doc filed; ADR backlog updated; EL approval awaited before implementation begins)**
+**Last updated: 2026-06-12 (M13 kickoff complete — release/m13 cut; sprint plan + entry doc EL-approved (PR #911); Wave 1 implementation open)**
 **Current milestone:** M13 — Political Economy and Instrument Credibility (GitHub Milestone 9)
 **Previous milestone:** M12 — Active Control and External Sector (formally closed 2026-06-11; Issue #263 closed; GitHub Milestone 13 closed; tagged v0.12.1)
 
@@ -13,29 +13,34 @@
 
 ## Active Work Streams — M13
 
-**Kickoff complete 2026-06-12.** Sprint plan and entry document filed. Awaiting EL approval before any implementation PR opens (CLAUDE.md §Entry and Exit Invariants — hard stop).
+**Kickoff complete 2026-06-12. EL approval recorded 2026-06-12 (PR #911).** Wave 1 implementation is open. Intent documents must be filed before each group's implementation PR opens (Phase A lifecycle).
 
 **M13 kickoff status:**
 1. ✅ PM Agent cuts `release/m13` from `main` — DONE 2026-06-12
 2. ✅ PM Agent authors `docs/process/sprint-plans/m13-sprint-plan.md` — DONE 2026-06-12
 3. ✅ ADR-013 confirmed ASSIGNED (number 13, panel confirmed) — ready to author; ARCH-007 milestone note updated M12→M13
 4. ✅ #852 sequencing confirmed — blocked on alert panel ADR (new issue #908 filed; ARCH-008 PENDING_NUMBER in backlog)
-5. ✅ #264 (M13 Exit Checklist) — kickoff comment posted
+5. ✅ #264 (M13 Exit Checklist) — kickoff comment posted; EL approval comment posted
 6. ✅ Process Redesign Sequence (Phases 0–D) — COMPLETE; no further redesign phases
-7. ⏳ Sprint entry document filed — `docs/process/sprint-plans/m13-sprint-1-entry.md` — **awaiting EL approval**
-8. ⏳ Sprint plan EL approval — **awaiting; comment on #264**
+7. ✅ Sprint entry document filed — `docs/process/sprint-plans/m13-sprint-1-entry.md` — EL-approved 2026-06-12
+8. ✅ Sprint plan EL approval — **recorded 2026-06-12 (PR #911)**
 
-**Next required action: EL reviews and approves sprint plan + entry document. No implementation PR opens before EL approval.**
+**Next actions (any order, Wave 1 groups are parallel):**
+- G5: Architect Agent begins ADR-013 authorship (#792) — critical path
+- G1: Author intent doc → QA tests → implement (#872, #874)
+- G2: Author intent doc → QA tests → implement (#871, #873, #875, #876)
+- G3: Author intent doc → QA tests → implement (#799)
+- G4: Author intent doc → implement (#27, #822, #847)
 
 ### Sprint Group Status
 
 | Group | Issues | Wave | ADR gate | Status |
 |---|---|---|---|---|
-| G1 — DEMO legibility | #872, #874 | Wave 1 | None | Awaiting EL sprint approval |
-| G2 — DEMO trajectory/Mode 3 | #871, #873, #875, #876 | Wave 1 | None | Awaiting EL sprint approval |
-| G3 — Engine fix (reserves floor) | #799 | Wave 1 | None | Awaiting EL sprint approval |
-| G4 — Documentation | #27, #822, #847 | Wave 1 | None | Awaiting EL sprint approval |
-| G5 — ADR-013 authorship | #792 | Wave 1 | N/A | Awaiting EL sprint approval |
+| G1 — DEMO legibility | #872, #874 | Wave 1 | None | **OPEN — intent doc required first** |
+| G2 — DEMO trajectory/Mode 3 | #871, #873, #875, #876 | Wave 1 | None | **OPEN — intent doc required first** |
+| G3 — Engine fix (reserves floor) | #799 | Wave 1 | None | **OPEN — intent doc required first** |
+| G4 — Documentation | #27, #822, #847 | Wave 1 | None | **OPEN — intent doc required first** |
+| G5 — ADR-013 authorship | #792 | Wave 1 | N/A | **OPEN — begin immediately** |
 | G6 — Political economy integration | #392 | Wave 2 | BLOCKED_ADR — ADR-013 | BLOCKED |
 | G7 — Alert panel master-detail | #852 | Blocked | BLOCKED_ADR — #908 ADR | BLOCKED |
 
@@ -50,7 +55,9 @@
 
 | PR | Title | Target | Status |
 |---|---|---|---|
-| (opening) | feat(m13): kickoff — sprint plan, entry doc, ADR backlog | release/m13 | Opening 2026-06-12 |
+| #909 ✅ | feat(m13): kickoff — sprint plan, entry doc, ADR backlog | release/m13 | Merged 2026-06-12 |
+| #910 ✅ | chore(state): M13 kickoff session state | release/m13 | Merged 2026-06-12 |
+| #911 ✅ | feat(m13): EL approval recorded — sprint plan + entry doc | release/m13 | Merged 2026-06-12 |
 
 ## M11 Work Streams — 2026-06-04 Sprint
 

--- a/docs/process/sprint-plans/m13-sprint-1-entry.md
+++ b/docs/process/sprint-plans/m13-sprint-1-entry.md
@@ -3,17 +3,17 @@ name: m13-sprint-1-entry
 type: sprint-entry
 milestone: M13 — Political Economy and Instrument Credibility
 sprint-group: G1, G2, G3, G4, G5, G6, G7 (all M13 groups)
-status: Filed — awaiting EL approval before implementation begins
+status: Approved — implementation of Wave 1 groups may begin
 authored-by: PM Agent
 authored-date: 2026-06-12
-el-approved: false
+el-approved: 2026-06-12
 release-branch: release/m13
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M13, Sprint 1
 
-**Status:** Filed — awaiting EL approval before implementation begins
+**Status:** Approved — Wave 1 implementation may begin
 **Date authored:** 2026-06-12
 **Release branch:** `release/m13`
 **Sprint plan:** `docs/process/sprint-plans/m13-sprint-plan.md`
@@ -47,7 +47,7 @@ An unchecked invariant blocks the sprint from opening.*
 - [x] **Release branch exists:** `release/m13` cut from `main` at 2026-06-12
 - [x] **CI trigger verified:** `.github/workflows/ci.yml` `pull_request: branches` includes
   `release/m*` — confirmed 2026-06-12 (pre-existing fix from NM-035)
-- [ ] **Sprint plan EL-approved:** Awaiting EL approval of `docs/process/sprint-plans/m13-sprint-plan.md`
+- [x] **Sprint plan EL-approved:** `docs/process/sprint-plans/m13-sprint-plan.md` approved 2026-06-12
 
 ### 2.2 — ADR prerequisite gate
 
@@ -187,13 +187,15 @@ added (PENDING_NUMBER) at kickoff commit. GitHub issue to be filed for the alert
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** Recorded 2026-06-12
 
 *EL review checklist:*
-- [ ] Groupings are reasonable
-- [ ] Sequencing and wave assignments are correct
-- [ ] No scope items missing from the plan (verify against roadmap and CLAUDE.md)
-- [ ] Structural gates in Section 2.1 are satisfied
+- [x] Groupings are reasonable
+- [x] Sequencing and wave assignments are correct
+- [x] No scope items missing from the plan (verify against roadmap and CLAUDE.md)
+- [x] Structural gates in Section 2.1 are satisfied
 
-> EL approval statement — to be filled at approval time
-> — @PublicEnemage ({date})
+> Sprint plan and entry document approved. Wave 1 groups (G1–G5) may proceed immediately
+> once intent documents are filed per the Phase A execution lifecycle. G6 is blocked on
+> ADR-013 acceptance; G7 is blocked on alert panel ADR (#908) acceptance.
+> — @PublicEnemage (2026-06-12)

--- a/docs/process/sprint-plans/m13-sprint-plan.md
+++ b/docs/process/sprint-plans/m13-sprint-plan.md
@@ -2,10 +2,10 @@
 name: m13-sprint-plan
 type: sprint-plan
 milestone: M13 — Political Economy and Instrument Credibility
-status: Draft — awaiting EL approval
+status: Approved
 authored-by: PM Agent
 authored-date: 2026-06-12
-el-approved: false
+el-approved: 2026-06-12
 consulted-agents:
   - Business Product Owner (value prioritization)
   - Frontend Architect (file area grouping)
@@ -374,7 +374,9 @@ G5 should begin immediately and run in parallel with G1–G4.
 
 ## EL Approval Record
 
-**Status:** Pending — no implementation PR may open before EL approves this plan
+**Status:** Approved 2026-06-12
 
-> EL approval statement — to be filled at approval time
-> — @PublicEnemage ({date})
+> Sprint plan approved. Wave 1 groups (G1–G5) may proceed once intent documents are filed
+> per the Phase A execution lifecycle. G6 implementation is blocked pending ADR-013 acceptance.
+> G7 is blocked pending alert panel ADR (#908) acceptance. Critical path is G5 → G6.
+> — @PublicEnemage (2026-06-12)


### PR DESCRIPTION
Records EL approval of m13-sprint-plan.md and m13-sprint-1-entry.md. Wave 1 implementation is now open.