### PR TITLE
process(nm-042): structured UX Designer sign-off attestation — session context declaration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,30 @@ tier is not ready for acceptance. The Architect determines tier classification a
 initiation; the UX Designer sign-off is a hard precondition for Tier 1 acceptance — not a
 post-acceptance formality.
 
+**UX Designer sign-off — structured attestation required (NM-042).**
+The UX Designer sign-off block in every ADR requires four named fields: Reviewing agent,
+Session context, Governing documents reviewed (named sections — not generic references),
+and Concerns found (explicit count or "None"). A checkbox without all four fields is
+non-compliant — treat it as unsigned.
+
+The `Session context` field has two valid values:
+- `Separate session, EL-triggered YYYY-MM-DD` — independence is structurally asserted; EL
+  accepts at face value.
+- `Same session as ADR authorship — acknowledged` — the analog to initialing "per: [delegate]"
+  on a paper form. Disclosed same-session review is permitted; undisclosed same-session review
+  is a process violation equivalent to a missing sign-off.
+
+**A sign-off marked `Same session as ADR authorship — acknowledged` requires the EL to verify
+governing document citations in the sign-off text before accepting.** Generic references
+("governing premises", "first principles") do not satisfy the citation requirement. Named
+sections (`information-hierarchy.md §1B`, `north-star.md §Primary Cognitive Tasks`) do.
+
+**Absence of a `Session context` declaration is a non-compliant sign-off.** Treat it as
+`Same session as ADR authorship — acknowledged` until a properly declared review is obtained.
+PI Agent holds R for flagging non-compliant sign-offs before the acceptance vote passes.
+
+Near-miss authority: NM-042 (`docs/process/near-miss-registry.md`).
+
 **North Star Test (Process Gate)**
 
 The founding document's north star question — "Does this decision make the tool more useful to

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -160,10 +160,16 @@ prerequisite-sources:
 [Named journeys and steps from `user-journeys.md` served or modified. For each: what the user can now do that was previously unavailable or impeded. If closing a `[Near-Term-Gap]` or `[Phase-3-TBD]` item, reference it explicitly.]
 
 **UX Designer sign-off:**  
-This sign-off is a precondition for the acceptance vote. An ADR with an unchecked UX Designer
-sign-off cannot proceed to acceptance vote and cannot be given `Accepted` status.
+This sign-off is a precondition for the acceptance vote. An ADR with an incomplete sign-off
+block cannot proceed to acceptance vote and cannot be given `Accepted` status. All four
+fields below are required — a checkbox without the structured attestation is non-compliant.
 
-`[ ]` UX Designer: UX implication statement elements 1–7 confirmed complete. [Date]
+**Reviewing agent:** [UX Designer Agent]  
+**Session context:** [One of: `Separate session, EL-triggered YYYY-MM-DD` | `Same session as ADR authorship — acknowledged`]  
+**Governing documents reviewed:** [Named sections required — e.g., `information-hierarchy.md §1B`, `north-star.md §Primary Cognitive Tasks`. Generic references ("governing premises") do not satisfy this field.]  
+**Concerns found:** [N — listed below with each concern on its own line | `None`]  
+
+`[ ]` UX Designer sign-off. [Date]
 
 ---
 
@@ -187,7 +193,12 @@ sign-off cannot proceed to acceptance vote and cannot be given `Accepted` status
 **UX Designer review:**  
 A Tier 2 ADR that proceeds to acceptance vote without a completed UX Designer sign-off
 confirmation is in violation of the process. PI Agent holds R for blocking the vote if
-sign-off is absent.
+sign-off is absent. All four fields below are required.
+
+**Reviewing agent:** [UX Designer Agent]  
+**Session context:** [One of: `Separate session, EL-triggered YYYY-MM-DD` | `Same session as ADR authorship — acknowledged`]  
+**Governing documents reviewed:** [Named sections — e.g., `north-star.md §Primary Cognitive Tasks`, `user-journeys.md §Journey B`. Generic references do not satisfy this field.]  
+**Concerns found:** [N — listed below | `None`]  
 
 `[ ]` UX Designer: Elements P-1–P-5 (and P-6 if applicable) confirmed present and adequate. [Date]  
 Or: "UX Designer review: persona trace incomplete. Missing: [elements]. Blocked from acceptance until remediated."

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -103,6 +103,16 @@ When producing groups, apply these criteria in order:
 
 5. **ADR prerequisites are surfaced explicitly.** Any group requiring an ADR or ADR amendment is marked. The ADR must be accepted before the group's implementation PR merges — not before the group begins, but before it closes.
 
+**UX Designer sign-off session practice for Tier 1 ADRs:** For Tier 1 ADRs, the preferred
+practice is to obtain the UX Designer sign-off in a separate EL-triggered session after the
+ADR is committed as `Proposed`. This eliminates authoring-context bleed — the reviewing agent
+reads the ADR cold, without the authoring session's reasoning in its context window, producing
+a genuinely independent assessment. Same-session sign-offs are permitted for Tier 2 and Tier 3
+ADRs but must be declared `Same session as ADR authorship — acknowledged` in the sign-off block,
+and are subject to additional EL scrutiny on the governing document citations. A same-session
+Tier 1 sign-off without this declaration is non-compliant (NM-042; CLAUDE.md §UX Designer
+sign-off — structured attestation required).
+
 6. **Group size.** A group should be implementable and reviewable in a single PR. If a group grows to more than ~800 lines of diff, consider splitting it at a natural boundary (e.g., G6a backend / G6b frontend). The split must maintain clean ordering — G6a merges before G6b begins.
 
 ---


### PR DESCRIPTION
## Summary

Three changes following NM-042 deliberation. Root cause: an implementing agent generated a UX Designer sign-off without independent review; the EL caught it. The analog: on paper forms, signing someone else's initials is immediately visible. This PR introduces the equivalent structure.

## Changes

**1. `docs/adr/template.md` — sign-off block (Tier 1 and Tier 2)**

Expands the UX Designer sign-off from a checkbox to a four-field structured attestation:

| Field | Rule |
|---|---|
| Reviewing agent | Named agent persona |
| Session context | `Separate session, EL-triggered YYYY-MM-DD` OR `Same session as ADR authorship — acknowledged` |
| Governing documents reviewed | Named sections required (`information-hierarchy.md §1B`) — generic references do not satisfy |
| Concerns found | Explicit count and list, or `None` |

A checkbox without all four fields is non-compliant — treated as unsigned.

**2. `CLAUDE.md §Architectural Principles` — new rule**

`UX Designer sign-off — structured attestation required (NM-042)`:
- Defines the two valid Session context values
- Same-session declared sign-off: EL must verify governing document citations before accepting
- Absent Session context: treat as same-session until proper declaration obtained
- PI Agent holds R for flagging non-compliant sign-offs before acceptance vote

**3. `docs/process/sprint-planning-sop.md §Grouping Criteria` — Tier 1 session preference**

Preferred practice for Tier 1 ADRs: UX Designer sign-off in a separate EL-triggered session (eliminates authoring-context bleed). Same-session permitted for Tier 2/3 with acknowledgment declaration. Non-compliant same-session Tier 1 without declaration is a process violation.

## What this does NOT require

- Retroactive re-signing of existing ADRs (ADR-014's sign-off stands as documented)
- Any workflow change for Tier 2/3 ADRs beyond the declaration field
- A new process gate — the EL acceptance vote is the existing gate; this makes the sign-off's session provenance visible at that gate

## Test plan

- [ ] Read `docs/adr/template.md §UX Designer sign-off` — confirm four required fields present in both Tier 1 and Tier 2 sign-off blocks
- [ ] Read `CLAUDE.md §UX Designer sign-off — structured attestation required` — confirm rule language matches EL directive exactly
- [ ] Read `docs/process/sprint-planning-sop.md §Grouping Criteria item 5` — confirm Tier 1 preferred-practice language present

🤖 Generated with [Claude Code](https://claude.com/claude-code)