### PR TITLE
feat(g8b): Mode 1→2 step preservation — ModeSelector, ModeTransitionModal, setMode (#393)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import ChoroplethMap from "./components/ChoroplethMap";
 import DeltaChoropleth from "./components/DeltaChoropleth";
 import EntityDetailDrawer from "./components/EntityDetailDrawer";
 import FidelityDashboard from "./components/FidelityDashboard";
-import { ModeIndicator } from "./components/ModeIndicator";
+import { ModeSelector } from "./components/ModeSelector";
 import { ScenarioIdentityHeader } from "./components/ScenarioIdentityHeader";
 import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
 import ScenarioControls from "./components/ScenarioControls";
@@ -221,7 +221,7 @@ export default function App() {
                 {selectedScenarioName}
               </span>
             )}
-            <ModeIndicator />
+            <ModeSelector />
             <button
               data-testid="mode3-toggle"
               onClick={() => setMode3Active((v) => !v)}

--- a/frontend/src/components/ModeSelector.tsx
+++ b/frontend/src/components/ModeSelector.tsx
@@ -1,0 +1,88 @@
+/**
+ * ModeSelector — interactive mode selector replacing ModeIndicator in App.tsx.
+ *
+ * Three clickable labels: Replay | Simulation | Active Control.
+ * Active mode label tap is a no-op. Inactive label tap:
+ *   - At current_step === 0: direct setMode call, no modal.
+ *   - At current_step > 0: ModeTransitionModal confirms before mode changes (SF-2 guard).
+ *
+ * data-testid="mode-indicator" and data-mode on the outer container are
+ * retained for backward compatibility with existing tests (US-026, atomicity-rtl).
+ *
+ * Design authority: G8b intent document §7.2; Gap 5 of
+ * worldsim-ux-architecture-first-principles-depth.md.
+ */
+import { useState } from "react";
+import { useScenarioStepStore } from "../store/scenarioStepStore";
+import { getModeLabel } from "./ModeIndicator";
+import { ModeTransitionModal } from "./ModeTransitionModal";
+
+type Mode = "MODE_1" | "MODE_2" | "MODE_3";
+const MODES: Mode[] = ["MODE_1", "MODE_2", "MODE_3"];
+
+export function ModeSelector() {
+  const { mode, current_step, setMode } = useScenarioStepStore();
+  const [pendingMode, setPendingMode] = useState<Mode | null>(null);
+
+  function handleLabelClick(target: Mode) {
+    if (target === mode) return;
+    if (current_step > 0) {
+      setPendingMode(target);
+    } else {
+      setMode(target);
+    }
+  }
+
+  function handleConfirm() {
+    if (pendingMode) {
+      setMode(pendingMode);
+      setPendingMode(null);
+    }
+  }
+
+  function handleCancel() {
+    setPendingMode(null);
+  }
+
+  return (
+    <div
+      data-testid="mode-indicator"
+      data-mode={mode}
+      style={{ position: "relative", display: "inline-flex", gap: 2 }}
+    >
+      {MODES.map((m) => {
+        const isActive = m === mode;
+        return (
+          <span
+            key={m}
+            data-testid={`mode-selector-label-${m}`}
+            onClick={() => handleLabelClick(m)}
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              letterSpacing: 0.3,
+              padding: "2px 8px",
+              borderRadius: 3,
+              cursor: isActive ? "default" : "pointer",
+              background: isActive ? "#4f6ef7" : "#f4f4f4",
+              color: isActive ? "#fff" : "#666",
+              border: isActive ? "1px solid #4f6ef7" : "1px solid #ddd",
+              userSelect: "none",
+              transition: "background 0.1s",
+            }}
+          >
+            {getModeLabel(m)}
+          </span>
+        );
+      })}
+      {pendingMode && (
+        <ModeTransitionModal
+          targetMode={pendingMode}
+          currentStep={current_step}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ModeTransitionModal.tsx
+++ b/frontend/src/components/ModeTransitionModal.tsx
@@ -1,0 +1,94 @@
+/**
+ * ModeTransitionModal — confirmation dialog for explicit mode transitions.
+ *
+ * Shown when the user taps an inactive mode label in ModeSelector and the
+ * current step is > 0. Names the preserved state (step position + entity
+ * configuration) and the changed state (replay event annotations) per
+ * G8b intent document §7.3 AC-3.
+ *
+ * Not full-screen. No backdrop or scroll lock — Gap 5 "single non-modal
+ * confirmation" pattern.
+ */
+
+const TARGET_LABELS: Record<"MODE_1" | "MODE_2" | "MODE_3", string> = {
+  MODE_1: "Replay",
+  MODE_2: "Simulation",
+  MODE_3: "Active Control",
+};
+
+interface ModeTransitionModalProps {
+  targetMode: "MODE_1" | "MODE_2" | "MODE_3";
+  currentStep: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ModeTransitionModal({
+  targetMode,
+  currentStep,
+  onConfirm,
+  onCancel,
+}: ModeTransitionModalProps) {
+  const targetLabel = TARGET_LABELS[targetMode];
+
+  return (
+    <div
+      data-testid="mode-transition-modal"
+      style={{
+        position: "absolute",
+        top: "calc(100% + 6px)",
+        left: 0,
+        zIndex: 100,
+        background: "#fff",
+        border: "1px solid #ccc",
+        borderRadius: 6,
+        padding: "12px 14px",
+        minWidth: 300,
+        maxWidth: 360,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+        fontSize: 13,
+        lineHeight: 1.5,
+        color: "#333",
+      }}
+    >
+      <p style={{ margin: "0 0 10px" }}>
+        Switching to <strong>{targetLabel}</strong> mode. Your current{" "}
+        <strong>step position</strong> (step {currentStep}) and{" "}
+        <strong>entity configuration</strong> are preserved. Replay event
+        annotations will not be shown in {targetLabel} mode.
+      </p>
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button
+          data-testid="mode-transition-modal-cancel"
+          onClick={onCancel}
+          style={{
+            padding: "4px 10px",
+            fontSize: 12,
+            border: "1px solid #ccc",
+            borderRadius: 4,
+            background: "#f5f5f5",
+            cursor: "pointer",
+          }}
+        >
+          Stay in Replay
+        </button>
+        <button
+          data-testid="mode-transition-modal-confirm"
+          onClick={onConfirm}
+          style={{
+            padding: "4px 10px",
+            fontSize: 12,
+            border: "1px solid #4f6ef7",
+            borderRadius: 4,
+            background: "#4f6ef7",
+            color: "#fff",
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Switch to {targetLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ScenarioControls.tsx
+++ b/frontend/src/components/ScenarioControls.tsx
@@ -44,7 +44,7 @@ export default function ScenarioControls({ scenarioId, totalSteps, onStepChange 
 
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 14 }}>
-      <span style={{ fontWeight: 600 }}>
+      <span data-testid="current-step-display" style={{ fontWeight: 600 }}>
         Step {currentStep} / {totalSteps}
         {isComplete && " — Complete"}
       </span>

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -128,6 +128,8 @@ interface ScenarioStepState {
   setBranchFailed: () => void;
   /** Reset Mode 3 branch state — called on session exit or scenario change. */
   resetBranch: () => void;
+  /** Set mode only — does not reset current_step or any other state (SF-1 guard, G8b intent §7.1). */
+  setMode: (mode: "MODE_1" | "MODE_2" | "MODE_3") => void;
   reset: () => void;
 }
 
@@ -219,6 +221,8 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
       branchStepsComputed: 0,
       recomputeStatus: "idle",
     }),
+
+  setMode: (mode) => set({ mode }),
 
   reset: () =>
     set({


### PR DESCRIPTION
## Summary

- **`setMode` store action** (`scenarioStepStore.ts`): mode-only update; does not reset `current_step`, `trajectory`, or `scenario_id` — SF-1 guard (silent failure: step reset to 0 on transition)
- **`ModeSelector.tsx`**: three clickable labels (Replay | Simulation | Active Control); shows `ModeTransitionModal` when an inactive label is tapped at `current_step > 0`; direct `setMode` at step 0 (no modal needed); `data-testid="mode-indicator"` + `data-mode` retained for backward compat with existing tests
- **`ModeTransitionModal.tsx`**: names preserved state items ("step position" + "entity configuration") per AC-3; `confirm`/`cancel` buttons with required testids; non-blocking dialog positioned near mode selector (Gap 5 pattern)
- **`ScenarioControls.tsx`**: `data-testid="current-step-display"` added to step counter span (AC-7)
- **`App.tsx`**: `ModeIndicator` → `ModeSelector` swap

## Test plan

- [x] All 31 G8b unit tests pass (`mode-selector.test.tsx`) — `getModeLabel` regression, `setMode` SF-1 guard, modal gate at step 3, cancel leaves step unchanged, direct transition at step 0
- [x] Full frontend suite: 264/264 passing — no regressions in existing tests
- [x] Frontend build gate: `tsc -b && vite build` exits 0
- [ ] E2E (Playwright): `mode-transition.spec.ts` — requires dev server + backend (Step 4 Verify, post-merge)

## Intent document

`docs/process/intents/G8b-2026-06-13-mode-transition-step-preservation.md`

Targets: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)