### PR TITLE
fix(e2e): update Zone 1B and mode-indicator tests for G7/G8b observable state changes (NM-044)

### DIFF
--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -2254,6 +2254,86 @@ an absence of a gate — not external infrastructure behaviour.
 
 ---
 
+## NM-044 — G7 and G8b Implementation Changed Observable Zone 1B and Mode Indicator State; Pre-Existing E2E Tests Not Updated; Merged With CI playwright-e2e Failing (Reactive)
+
+**Date:** 2026-06-15
+**Milestone:** M13 — Political Economy and Instrument Credibility
+**Detected by:** EL question at M13 exit ceremony — Playwright E2E CI job failure visible on recent PRs
+**Severity:** High — six failing E2E tests committed to release/m13 across multiple CI runs; would mislead future agents about Zone 1B and mode indicator observable state
+
+### What happened
+
+G7 (ADR-014, PR #936) replaced the Zone 1B MDA Alert Panel structure: the old
+`mda-alert-row` and `mda-no-alerts` testids were removed and replaced with
+`zone-1b-top-detail` (always-present persistent-detail slot) and `zone-1b-compact` rows.
+The container overflow model also changed — `zone-1b-mda-alerts` now uses `overflow: hidden`
+as part of the fixed-height persistent-detail design.
+
+G8b (PR #949) replaced `ModeIndicator` with `ModeSelector` in `App.tsx`. `ModeSelector`
+renders all three mode labels inside the `data-testid="mode-indicator"` container. A test
+asserting `toHaveText("Replay")` now receives `"Replay Simulation Active Control"`.
+
+Five pre-existing tests in `demo-advancement-flow.spec.ts`, `demo-legibility.spec.ts`, and
+`greece-integration.spec.ts` checked for the old `mda-alert-row` / `mda-no-alerts` testids
+or the old overflow contract. One test in `greece-integration.spec.ts` used strict `toHaveText`
+on the mode indicator. None were updated when G7 or G8b landed.
+
+The CI `playwright-e2e` job was failing on every CI run from G7 forward. PRs merged because
+the configured merge gate was `changes` (the status check), not `playwright-e2e`.
+
+### What was at risk
+
+- Six false-failing E2E tests remained in the repository for the full duration of G7 and G8b
+- A future implementing agent reading `demo-advancement-flow.spec.ts` would see `mda-no-alerts`
+  testid as the established Zone 1B contract — and implement or test against a removed interface
+- The persistent CI red on `playwright-e2e` created noise that could mask real future regressions
+
+### What caught it
+
+The EL noticed CI was failing on merged PRs and asked why. Caught at M13 exit ceremony
+(2026-06-15) — not at Step 4 Verify when G7 or G8b landed.
+
+This is a person catching what the process missed. The process had two gaps:
+1. Step 4 Verify (implementing agent self-attestation) verified new test cases from the
+   intent document but did not verify the full existing E2E suite still passed.
+2. The PR merge gate (`changes` status check) does not block on `playwright-e2e` failures.
+
+### Process improvement
+
+**Immediate (this session):** Six failing tests fixed in this session (PR on release/m13).
+Updated `demo-advancement-flow.spec.ts`, `demo-legibility.spec.ts`, and
+`greece-integration.spec.ts` to use the G7 Zone 1B testids (`zone-1b-top-detail`) and
+the G8b ModeSelector assertion pattern (`toContainText` instead of `toHaveText` on the
+mode-indicator container).
+
+**Structural gap 1 — Step 4 Verify scope:** The intent document specifies acceptance
+criteria for the *new* behavior. Step 4 Verify verifies those criteria. But it does not
+verify that the full existing E2E suite passes. When an implementation changes observable
+application state (removes or renames testids, changes text content, changes overflow model),
+existing tests that depended on the old state will fail silently at the Verify step.
+
+**Required improvement:** When an intent document's acceptance criteria involve changing
+or removing an observable application state that existing tests may reference, the implementing
+agent must run `npx playwright test` locally at Step 4 and confirm 0 failures across the full
+suite — not only the new test file. A Step 4 Verify that passes its intent-document criteria
+but leaves the overall Playwright suite red is not a complete Step 4 Verify.
+
+**Structural gap 2 — Merge gate configuration:** The `changes` status check is the only
+configured merge gate. `playwright-e2e` failures do not block autonomous PR merge. This means
+E2E regressions can reach the release branch without any agent-level gate catching them.
+
+**Recommended improvement:** Add `playwright-e2e` as a required status check for PRs targeting
+`release/m*` branches, or update the autonomous merge protocol to poll for `playwright-e2e`
+in addition to `changes`. The current design concentrates the CI role on build-time checks
+while treating E2E as advisory. For a codebase where the primary UX quality gate is the
+Playwright suite, this hierarchy is inverted.
+
+PI Agent determination: this is a near-miss (not a Known Issue). Both fixes require changes
+to our own process and configuration — not vendor fixes. The gap is a Step 4 Verify scope
+deficiency and a merge gate configuration gap.
+
+---
+
 ## Registry Maintenance
 
 ### How to add an entry

--- a/frontend/tests/e2e/demo-advancement-flow.spec.ts
+++ b/frontend/tests/e2e/demo-advancement-flow.spec.ts
@@ -166,19 +166,17 @@ test("demo flow: Zone 1B MDA panel is live and non-blank at every step", async (
       timeout: 15_000,
     });
 
-    // Zone 1B must settle into one of the two valid states
+    // Zone 1B must settle into the persistent-detail state (zone-1b-top-detail
+    // always present in the ADR-014 layout — shows empty text or active alert).
     await expect
       .poll(
         async () => {
-          const noAlerts = page.locator('[data-testid="mda-no-alerts"]');
-          const alertRow = page.locator('[data-testid="mda-alert-row"]');
-          const hasNoAlerts = await noAlerts.isVisible().catch(() => false);
-          const hasAlertRow = await alertRow.first().isVisible().catch(() => false);
-          return hasNoAlerts || hasAlertRow;
+          const topDetail = page.locator('[data-testid="zone-1b-top-detail"]');
+          return topDetail.isVisible().catch(() => false);
         },
         {
           timeout: 10_000,
-          message: `Zone 1B must show mda-no-alerts or mda-alert-row at step ${step}`,
+          message: `Zone 1B must show zone-1b-top-detail at step ${step}`,
         },
       )
       .toBe(true);

--- a/frontend/tests/e2e/demo-legibility.spec.ts
+++ b/frontend/tests/e2e/demo-legibility.spec.ts
@@ -241,39 +241,16 @@ test("legibility: Zone 1B MDA panel text is not overflow-clipped", async ({
   const panel = page.locator('[data-testid="zone-1b-mda-alerts"]');
   await expect(panel).toBeVisible({ timeout: 10_000 });
 
-  // Wait for the panel to settle into one of its two valid states
-  await expect
-    .poll(
-      async () => {
-        const noAlerts = page.locator('[data-testid="mda-no-alerts"]');
-        const alertRow = page.locator('[data-testid="mda-alert-row"]');
-        const hasNoAlerts = await noAlerts.isVisible().catch(() => false);
-        const hasAlertRow = await alertRow.first().isVisible().catch(() => false);
-        return hasNoAlerts || hasAlertRow;
-      },
-      { timeout: 10_000, message: "Zone 1B must settle into mda-no-alerts or mda-alert-row" },
-    )
-    .toBe(true);
+  // Wait for the persistent-detail slot to appear (ADR-014 layout: zone-1b-top-detail
+  // is always present — shows "No active threshold breaches." or active alert detail).
+  const topDetail = page.locator('[data-testid="zone-1b-top-detail"]');
+  await expect(topDetail).toBeVisible({ timeout: 10_000 });
 
-  const noAlertsEl = page.locator('[data-testid="mda-no-alerts"]');
-  const isNoAlerts = await noAlertsEl.isVisible().catch(() => false);
-
-  if (isNoAlerts) {
-    const isTruncated = await noAlertsEl.evaluate(
-      (el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).offsetWidth,
-    );
-    expect(isTruncated).toBe(false);
-  } else {
-    const alertLines = page.locator('[data-testid="alert-line-1"]');
-    const count = await alertLines.count();
-    for (let i = 0; i < count; i++) {
-      const line = alertLines.nth(i);
-      const isTruncated = await line.evaluate(
-        (el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).offsetWidth,
-      );
-      expect(isTruncated).toBe(false);
-    }
-  }
+  // Top-detail content must not be overflow-clipped (scrollWidth ≤ offsetWidth).
+  const isTruncated = await topDetail.evaluate(
+    (el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).offsetWidth,
+  );
+  expect(isTruncated).toBe(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -293,13 +270,16 @@ test("G1/AC-1 legibility: Zone 1B alert rows not clipped by container overflow a
   const panel = page.locator('[data-testid="zone-1b-mda-alerts"]');
   await expect(panel).toBeVisible({ timeout: 10_000 });
 
-  // The panel container must not have overflow:hidden that clips child rows.
-  // It should have overflow:auto or overflow:visible so scrolling or full
-  // visibility is possible.
-  const overflowStyle = await panel.evaluate(
-    (el) => window.getComputedStyle(el).overflow,
-  );
-  expect(overflowStyle).not.toBe("hidden");
+  // ADR-014 persistent-detail layout: the primary alert content lives in
+  // zone-1b-top-detail, which must be fully visible (positive bounding box
+  // with non-zero dimensions). The container overflow model changed in G7 —
+  // the container may use overflow:hidden for the compact list zone, but the
+  // top-detail slot must not be clipped.
+  const topDetail = panel.locator('[data-testid="zone-1b-top-detail"]');
+  await expect(topDetail).toBeVisible({ timeout: 5_000 });
+  const box = await topDetail.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThan(0);
 });
 
 test("G1/AC-4 legibility: Zone 1B alert rows still visible at 1024×768 (compact layout regression)", async ({

--- a/frontend/tests/e2e/greece-integration.spec.ts
+++ b/frontend/tests/e2e/greece-integration.spec.ts
@@ -96,12 +96,14 @@ test("Greece step-through: mode indicator shows Replay throughout Mode 1", async
 
   const indicator = page.locator('[data-testid="mode-indicator"]');
   await expect(indicator).toBeVisible({ timeout: 10_000 });
-  await expect(indicator).toHaveText("Replay");
+  // ModeSelector (G8b) renders all three labels inside mode-indicator container;
+  // use toContainText to check the active mode label is present.
+  await expect(indicator).toContainText("Replay");
   await expect(indicator).toHaveAttribute("data-mode", "MODE_1");
 
   // Advance step 1 — mode must remain Replay
   await advanceStep(page, 1, 3);
-  await expect(indicator).toHaveText("Replay");
+  await expect(indicator).toContainText("Replay");
   await expect(indicator).toHaveAttribute("data-mode", "MODE_1");
 });
 
@@ -205,12 +207,11 @@ test("Greece step-through: cluster consistent at all 3 steps", async ({
       page.locator('[data-testid="zone-1d-four-framework"]'),
     ).toBeVisible();
 
-    // Zone 1B must show either the no-alert state or alert rows — never a blank
-    const noAlerts = page.locator('[data-testid="mda-no-alerts"]');
-    const alertRow = page.locator('[data-testid="mda-alert-row"]');
-    const hasNoAlerts = await noAlerts.isVisible().catch(() => false);
-    const hasAlertRow = await alertRow.first().isVisible().catch(() => false);
-    expect(hasNoAlerts || hasAlertRow).toBe(true);
+    // Zone 1B must show the persistent-detail slot — never blank (ADR-014).
+    // zone-1b-top-detail is always present: shows empty text or active alert.
+    const topDetail = page.locator('[data-testid="zone-1b-top-detail"]');
+    const hasTopDetail = await topDetail.isVisible().catch(() => false);
+    expect(hasTopDetail).toBe(true);
 
     // All four framework rows must render
     for (const fw of [
@@ -284,18 +285,15 @@ test("Greece step-through: Zone 1B shows data-driven alert state after advance (
   // Advance to step 1 — measurement-output fetch should fire
   await advanceStep(page, 1, 3);
 
-  // Zone 1B must settle into one of two valid states: no-alerts or alert rows
-  // Use expect.poll to allow for the async fetch to complete
+  // Zone 1B must settle into the persistent-detail state (ADR-014 layout).
+  // zone-1b-top-detail is always present once measurement data loads.
   await expect
     .poll(
       async () => {
-        const noAlerts = page.locator('[data-testid="mda-no-alerts"]');
-        const alertRow = page.locator('[data-testid="mda-alert-row"]');
-        const hasNoAlerts = await noAlerts.isVisible().catch(() => false);
-        const hasAlertRow = await alertRow.first().isVisible().catch(() => false);
-        return hasNoAlerts || hasAlertRow;
+        const topDetail = page.locator('[data-testid="zone-1b-top-detail"]');
+        return topDetail.isVisible().catch(() => false);
       },
-      { timeout: 10_000, message: "Zone 1B must show either no-alerts or alert-row state" }
+      { timeout: 10_000, message: "Zone 1B must show zone-1b-top-detail state after advance" }
     )
     .toBe(true);
 


### PR DESCRIPTION
## Summary

Six Playwright E2E tests have been failing since G7 and G8b merged. This PR fixes them.

**Root cause 1 (G7 — ADR-014 Zone 1B):** `mda-alert-row` and `mda-no-alerts` testids were removed by G7 and replaced with `zone-1b-top-detail` (persistent-detail slot, always present). Five tests in three files were checking the old testids.

**Root cause 2 (G8b — ModeSelector):** `ModeSelector` renders all three mode labels inside `data-testid="mode-indicator"`. One test using strict `toHaveText("Replay")` received `"Replay Simulation Active Control"`.

**Why they merged:** The PR merge gate is the `changes` status check. `playwright-e2e` was failing but not a blocking gate.

## Changes

- `frontend/tests/e2e/demo-advancement-flow.spec.ts` — Zone 1B check uses `zone-1b-top-detail`
- `frontend/tests/e2e/demo-legibility.spec.ts` — overflow-clipped text test and G1/AC-1 test updated for ADR-014 layout
- `frontend/tests/e2e/greece-integration.spec.ts` — mode indicator uses `toContainText`; two Zone 1B checks use `zone-1b-top-detail`
- `docs/process/near-miss-registry.md` — NM-044 filed (Step 4 Verify scope gap + merge gate configuration gap)

## Near-miss

NM-044 identifies two structural gaps:
1. Step 4 Verify scope — implementing agents verified intent-document ACs but not the full existing E2E suite
2. Merge gate — `playwright-e2e` is not a required status check; only `changes` blocks merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)