### PR TITLE
test(ci): docs-only PR — verify Ruleset skipped-check behavior (#970)

### DIFF
--- a/docs/process/ruleset-skip-test.md
+++ b/docs/process/ruleset-skip-test.md
@@ -1,0 +1,7 @@
+# Ruleset skip-behavior test
+
+Temporary file — safe to delete after Issue #970 test is complete.
+
+Purpose: docs-only commit to verify GitHub Ruleset "skipped = pass" behavior
+for `playwright-e2e` on `release/m14`. No frontend or backend files changed;
+CI path filter will skip `playwright-e2e`. Test passes if the PR is mergeable.


### PR DESCRIPTION
**Test PR — safe to close/delete after Issue #970 test is complete.**

This PR exists to verify whether GitHub Rulesets treat a skipped `playwright-e2e`
job as "passing" the required status check. No frontend or backend files are changed;
the CI path filter will skip `playwright-e2e`.

**Expected result if Ruleset skip-handling works:** PR shows as mergeable after CI completes.  
**Expected result if `ci-gate` is needed:** PR is blocked despite CI completing.

Tracking: #970

File added: `docs/process/ruleset-skip-test.md` (will be deleted after the test).