### PR TITLE
fix(ci): enforce CI gate on release/m* via Ruleset; remove --admin bypass (#970)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,17 +407,22 @@ merge and Claude Code has executed `git pull origin main`.
 
 **Exception — PRs targeting a release branch (`release/m{N}`).** Release branch
 PRs are pre-authorized for autonomous merge. Claude Code polls `gh pr checks`
-until the `changes` status check passes, then executes `gh pr merge <number>
---merge` and pulls from the release branch without waiting for user confirmation.
-`release/m{N}` is an unprotected integration branch — admin bypass is not
-required. See §Release Branch Workflow below.
+until all checks have reached a terminal state (pass or skipped — no pending),
+then executes `gh pr merge <number> --merge` only if no check has failed.
+If any check has failed, stop and report to the user — do not attempt the merge.
+`release/m{N}` branches are protected by the `release-branch-ci-gate` Ruleset —
+a failed required check will block the merge at the server regardless.
+See §Release Branch Workflow below.
 
 **Exception — `SESSION_STATE.md`-only PRs.** End-of-session state updates that
 touch only `SESSION_STATE.md` are pre-authorized for auto-merge. Claude Code will
-poll `gh pr checks` until the `changes` status check passes, then execute
-`gh pr merge <number> --admin --merge` and `git pull origin main` without waiting
-for user confirmation. If the PR contains any file other than `SESSION_STATE.md`,
-the standard gate applies regardless of the other file's content.
+poll `gh pr checks` until all checks have reached a terminal state (pass or
+skipped — no pending), then execute `gh pr merge <number> --merge` and
+`git pull origin main` without waiting for user confirmation. SESSION_STATE-only
+PRs touch no frontend or backend files; all path-filtered checks will skip and
+the Ruleset treats skipped as passing — `--admin` is not required and must not
+be used. If the PR contains any file other than `SESSION_STATE.md`, the standard
+gate applies regardless of the other file's content.
 
 **Release Branch Workflow.**
 Each milestone has a release branch (`release/m{N}`) cut from `main` at
@@ -427,7 +432,7 @@ during the milestone uses this pattern:
 1. Cut feature branch from `release/m{N}`: `git checkout -b feat/g1-xxx release/m12`
 2. Implement, run pre-push gates (lint, build), push feature branch
 3. Open PR targeting `release/m{N}` (not `main`)
-4. Poll CI; merge autonomously once `changes` passes: `gh pr merge <number> --merge`
+4. Poll CI; merge autonomously once all checks are terminal (pass or skipped, none failed): `gh pr merge <number> --merge`
 5. Pull from release branch: `git pull origin release/m{N}`
 6. Continue with next feature branch
 
@@ -436,9 +441,9 @@ The release branch is never merged to `main` by Claude Code — that merge is
 always the Engineering Lead's action.
 
 `SESSION_STATE.md` updates during an active milestone target the release branch
-and follow the same autonomous merge rule as above (no `--admin` needed since
-the branch is unprotected). The auto-merge exception's `--admin` flag is needed
-only when the PR targets `main`.
+and follow the same autonomous merge rule as above (no `--admin` needed — the
+`release-branch-ci-gate` Ruleset treats skipped checks as passing, so
+SESSION_STATE-only PRs merge without any bypass flag).
 
 **Backend pre-push lint gate — mandatory before any `git push` touching Python files.**
 Before pushing any branch that modifies files under `backend/`, run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,15 +414,16 @@ If any check has failed, stop and report to the user — do not attempt the merg
 a failed required check will block the merge at the server regardless.
 See §Release Branch Workflow below.
 
-**Exception — `SESSION_STATE.md`-only PRs.** End-of-session state updates that
-touch only `SESSION_STATE.md` are pre-authorized for auto-merge. Claude Code will
-poll `gh pr checks` until all checks have reached a terminal state (pass or
-skipped — no pending), then execute `gh pr merge <number> --merge` and
-`git pull origin main` without waiting for user confirmation. SESSION_STATE-only
-PRs touch no frontend or backend files; all path-filtered checks will skip and
-the Ruleset treats skipped as passing — `--admin` is not required and must not
-be used. If the PR contains any file other than `SESSION_STATE.md`, the standard
-gate applies regardless of the other file's content.
+**Exception — `SESSION_STATE.md`-only PRs targeting `main`.** End-of-session
+state updates that touch only `SESSION_STATE.md` and target `main` are handled
+automatically by the `auto-merge-session-state` GitHub Actions workflow
+(`.github/workflows/auto-merge-session-state.yml`). Claude Code must open the
+PR and then stop — do not poll, do not call `gh pr merge`, do not use `--admin`.
+The workflow verifies that `SESSION_STATE.md` is the only changed file, then
+calls `gh pr merge --auto --squash`. All CI jobs are skipped for root-file-only
+changes; GitHub branch protection treats skipped as passing. If the PR contains
+any file other than `SESSION_STATE.md`, the standard gate applies — the workflow
+will not fire and EL must merge manually.
 
 **Release Branch Workflow.**
 Each milestone has a release branch (`release/m{N}`) cut from `main` at
@@ -440,10 +441,12 @@ At milestone close, EL performs one admin bypass: `release/m{N}` → `main`.
 The release branch is never merged to `main` by Claude Code — that merge is
 always the Engineering Lead's action.
 
-`SESSION_STATE.md` updates during an active milestone target the release branch
-and follow the same autonomous merge rule as above (no `--admin` needed — the
-`release-branch-ci-gate` Ruleset treats skipped checks as passing, so
-SESSION_STATE-only PRs merge without any bypass flag).
+`SESSION_STATE.md` updates during an active milestone target the release branch,
+not `main`, and follow the same autonomous merge rule as all release branch PRs:
+poll until all checks are terminal (pass or skipped, none failed), then
+`gh pr merge <number> --merge`. No `--admin` needed — the `release-branch-ci-gate`
+Ruleset treats skipped checks as passing. The `auto-merge-session-state` workflow
+only fires on PRs targeting `main` and does not apply here.
 
 **Backend pre-push lint gate — mandatory before any `git push` touching Python files.**
 Before pushing any branch that modifies files under `backend/`, run:


### PR DESCRIPTION
## What

Closes #970. Implements the NM-044 Structural Gap 2 recommendation.

## Test result

PR #971 (now closed) confirmed that GitHub Rulesets treat a skipped `playwright-e2e` job as passing the required status check. A docs-only PR to `release/m14` with a Ruleset requiring `playwright-e2e` showed a green merge button after CI completed with only `changes` passing and all other checks skipped. **`ci-gate` is not needed — the Ruleset handles the skip-as-pass case natively.**

## Changes

**GitHub infrastructure (no file change — done via API):**
- Ruleset `release-branch-ci-gate` (ID 17751852) created, targeting `refs/heads/release/m*`
- Requires: `changes`, `lint`, `test-backend`, `playwright-e2e`, `compliance-scan` (same five as `main`)
- Skipped checks treated as passing — docs-only and SESSION_STATE PRs merge without bypass

**`CLAUDE.md` — three locations updated:**
1. Release branch exception: poll condition changed from "until `changes` passes" to "until all checks terminal (pass or skipped), none failed"
2. SESSION_STATE exception: `--admin` removed; poll condition updated to match; explicit note that `--admin` must not be used
3. Release Branch Workflow step 4: poll condition updated to match

## Before / After

| Scenario | Before | After |
|---|---|---|
| Feature PR to `release/m*` with failing `playwright-e2e` | Merged silently | Blocked by Ruleset |
| SESSION_STATE PR to `main` | `--admin` bypassed all required checks | No bypass; path-filtered checks skip and Ruleset passes them |
| Docs-only PR to `release/m*` | Merged (no protection) | Ruleset runs; skipped checks treated as passing; merges cleanly |

## Near-miss reference

NM-044 (`docs/process/near-miss-registry.md`) — filed 2026-06-15. This PR closes Structural Gap 2 of that entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)