### PR TITLE
feat(ci): enforce milestone-scoped branch naming on release/m* PRs (#978)

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,56 @@
+name: branch-naming
+
+# Enforces milestone-scoped branch naming for PRs targeting release/m* branches.
+#
+# Problem: sprint group identifiers (G1, G2, …) are reused across every milestone.
+# A branch named feat/g1-bugs is ambiguous — it could belong to M13, M14, or M15.
+# Stale branches from prior milestones create collision and confusion risks.
+#
+# Rule: any branch targeting release/m{N} must contain "m{N}" in its name.
+#   PASS: feat/m14-g1-prerequisite-bugs  → release/m14
+#   FAIL: feat/g1-prerequisite-bugs      → release/m14  (missing m14)
+#   FAIL: feat/m13-g1-prerequisite-bugs  → release/m14  (wrong milestone)
+#
+# The check name "branch-naming" is a required status check in the
+# release-branch-ci-gate Ruleset — a failure blocks the merge server-side.
+
+on:
+  pull_request:
+    branches:
+      - release/m*
+    types: [opened, synchronize, reopened]
+
+jobs:
+  branch-naming:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate milestone prefix in branch name
+        env:
+          TARGET_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          # Extract milestone prefix from target branch: "release/m14" → "m14"
+          MILESTONE="${TARGET_BRANCH##release/}"
+
+          echo "Target branch : $TARGET_BRANCH"
+          echo "Head branch   : $HEAD_BRANCH"
+          echo "Required prefix: $MILESTONE"
+
+          if echo "$HEAD_BRANCH" | grep -qF "$MILESTONE"; then
+            echo ""
+            echo "✓ Branch '$HEAD_BRANCH' contains milestone prefix '$MILESTONE'."
+            exit 0
+          else
+            echo ""
+            echo "✗ Branch '$HEAD_BRANCH' does not include milestone prefix '$MILESTONE'."
+            echo ""
+            echo "  All branches targeting '$TARGET_BRANCH' must contain '$MILESTONE' in their name."
+            echo "  Rename this branch to include the milestone, for example:"
+            echo ""
+            echo "    git branch -m $HEAD_BRANCH ${HEAD_BRANCH/\//\/${MILESTONE}-}"
+            echo ""
+            echo "  Suggested name: $(echo "$HEAD_BRANCH" | sed "s|/|/${MILESTONE}-|")"
+            echo ""
+            echo "  See CLAUDE.md §Release Branch Workflow for the full naming convention."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,11 @@ Each milestone has a release branch (`release/m{N}`) cut from `main` at
 milestone kickoff by the PM Agent as part of sprint planning. All feature work
 during the milestone uses this pattern:
 
-1. Cut feature branch from `release/m{N}`: `git checkout -b feat/g1-xxx release/m12`
+1. Cut feature branch from `release/m{N}` using a **milestone-scoped name**:
+   `git checkout -b feat/m{N}-g{N}-short-description release/m{N}`
+   The branch name must contain the milestone prefix (e.g. `m14`). Sprint group
+   numbers (G1, G2, …) are reused across milestones — `feat/g1-bugs` is ambiguous
+   and will be rejected by the `branch-naming` CI check. Use `feat/m14-g1-bugs`.
 2. Implement, run pre-push gates (lint, build), push feature branch
 3. Open PR targeting `release/m{N}` (not `main`)
 4. Poll CI; merge autonomously once all checks are terminal (pass or skipped, none failed): `gh pr merge <number> --merge`


### PR DESCRIPTION
## What

Closes #978. Enforces that every feature branch targeting a `release/m*` branch
contains the milestone number in its name, preventing sprint group number reuse
from causing branch name ambiguity or stale branch confusion across milestones.

## Three-layer implementation

**1 — `.github/workflows/branch-naming.yml` (new)**
Fires on `pull_request` events targeting `release/m*`. Extracts the milestone
prefix from the target branch (`release/m14` → `m14`) and fails if the head
branch name does not contain that prefix. On failure, emits a clear rename
suggestion including the corrected branch name.

```
PASS: feat/m14-g1-prerequisite-bugs → release/m14
FAIL: feat/g1-prerequisite-bugs     → release/m14  (missing m14)
FAIL: feat/m13-g1-prerequisite-bugs → release/m14  (wrong milestone)
```

**2 — `CLAUDE.md §Release Branch Workflow` step 1 (updated)**
Documents the required convention: `feat/m{N}-g{N}-short-description`.
Explains why the milestone prefix is required (G-numbers reused across milestones).

**3 — `release-branch-ci-gate` Ruleset (updated via API)**
`branch-naming` added as a sixth required status check alongside `changes`,
`lint`, `test-backend`, `playwright-e2e`, `compliance-scan`. A non-conforming
branch name is now a hard merge blocker server-side.

## Note on this PR's own branch name

This PR is cut from `release/m14` as `feat/m14-g7-branch-naming-enforcement` —
already conforming to the convention it introduces.

Closes #978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)