### PR TITLE
docs(m14): record EL approval of G1 sprint entry document

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-16 (G1 sprint entry document filed (PR #993) — awaiting EL approval; intent doc + QA tests required before G1 implementation PR opens. M14 sprint plan EL approved (PR #992). Milestone planning panel complete — M15–M18 defined; demo arc through Demo 7; 17 issues reallocated; 5 new issues (#986–#990).)**
+**Last updated: 2026-06-16 (G1 sprint entry document EL Approved 2026-06-16 (PR #996). Intent doc + QA tests BLOCKING before G1 implementation PR opens. docs/insights-log.md created — pre-GitHub inbox, PM Agent HORIZON obligation added to CLAUDE.md (PR #995). M14 sprint plan EL approved (PR #992). Milestone planning panel complete — M15–M18 defined; demo arc through Demo 7; 17 issues reallocated; 5 new issues (#986–#990).)**
 **Current milestone:** M14 — Methodology Publication and External Validation (GitHub Milestone 15)
 **Previous milestone:** M13 — Political Economy and Instrument Credibility (formally closed 2026-06-15; release/m13 → main merged by EL; #264 closed)
 
@@ -103,7 +103,7 @@
 | ADR-015 — Evidence Thread Architecture | Proposed | **EL acceptance is Wave 2 gate** — review §Decisions Required in ADR-015 |
 | M14 sprint plan | ✅ **EL APPROVED 2026-06-16** — `docs/process/sprint-plans/m14-sprint-plan.md` | Sprint entry document required per group before implementation PR opens |
 | release/m14 branch | ✅ Cut 2026-06-16 from main | Ready for feature PRs — sprint entry document required first |
-| G1 sprint entry document | ✅ Filed 2026-06-16 — `docs/process/sprint-plans/m14-g1-sprint-entry.md` (PR #993) | **Awaiting EL approval**; intent doc + QA tests BLOCKING before implementation PR opens |
+| G1 sprint entry document | ✅ Filed 2026-06-16 — `docs/process/sprint-plans/m14-g1-sprint-entry.md` (PR #993) | **EL Approved 2026-06-16** (PR #996); intent doc + QA tests BLOCKING before implementation PR opens |
 | M14 Exit Checklist | ✅ Filed 2026-06-16 — **#968** (closure gate: #843) | Tracks all M14 deliverables |
 | CI merge gate enforcement (#970) | ✅ CLOSED 2026-06-16 | `release-branch-ci-gate` Ruleset (ID 17751852) live — 6 required checks: `changes`, `lint`, `test-backend`, `playwright-e2e`, `compliance-scan`, `branch-naming`; `--admin` removed from SESSION_STATE merge rule |
 | Branch naming enforcement (#978) | ✅ CLOSED 2026-06-16 | `.github/workflows/branch-naming.yml` (PR #979); KI-003 filed (PR #980) |

--- a/docs/process/sprint-plans/m14-g1-sprint-entry.md
+++ b/docs/process/sprint-plans/m14-g1-sprint-entry.md
@@ -3,17 +3,17 @@ name: m14-g1-sprint-entry
 type: sprint-entry
 milestone: M14 — Methodology Publication and External Validation
 sprint-group: G1
-status: Filed — EL approval required before implementation PR opens
+status: EL Approved — implementation may begin once intent document and QA tests are filed
 authored-by: PM Agent
 authored-date: 2026-06-16
-el-approved: false
+el-approved: 2026-06-16
 release-branch: release/m14
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M14, G1: Prerequisite Bug Fixes
 
-**Status:** Filed — EL approval required before implementation PR opens
+**Status:** EL Approved 2026-06-16 — implementation may begin once intent document and QA tests are filed
 **Date authored:** 2026-06-16
 **Release branch:** `release/m14`
 **Sprint plan:** `docs/process/sprint-plans/m14-sprint-plan.md` (EL Approved 2026-06-16)
@@ -167,7 +167,7 @@ application states. G1 does not gate G3/G4 — G3 and G6 may proceed in parallel
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-16
 
-> {EL approval statement}
-> — @PublicEnemage ({date})
+> G1 sprint entry approved. Structural gates confirmed clear. Observable application states in Section 3.1 are specific enough to gate QA test authorship. Intent document and QA test file must be filed before implementation PR opens — these remain blocking conditions. Near-miss register call to PI Agent (file authority violation on user-journeys.md, PR #974) noted and accepted. Implementation may proceed once the Step 2 gate is satisfied.
+> — @PublicEnemage (2026-06-16)


### PR DESCRIPTION
## Summary

- Records EL approval of the M14 G1 sprint entry document (2026-06-16)
- Updates `docs/process/sprint-plans/m14-g1-sprint-entry.md`: frontmatter `el-approved: 2026-06-16`, status field, and EL Approval Record section filled in with EL statement
- Updates `SESSION_STATE.md`: G1 sprint entry row changed from "Awaiting EL approval" to "EL Approved 2026-06-16 (PR #996)"; Last Updated header updated

## Gate status after this PR

- G1 sprint entry: **EL Approved** ✅
- Intent document (`docs/process/intents/G1-2026-06-16-prerequisite-bugs.md`): **BLOCKING** — must file before implementation PR opens
- QA test file (`frontend/tests/g1-prerequisite-bugs.spec.ts`): **BLOCKING** — must author from intent doc before implementation begins

## Test plan

- [ ] Docs-only PR — `changes` and `branch-naming` pass; backend/frontend test checks skip
- [ ] Autonomous merge once all checks terminal (pass or skip, none failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)