### PR TITLE
process(intent-template): add §4b Visual Spec (before/after) section (#1004)

### DIFF
--- a/docs/insights-log.md
+++ b/docs/insights-log.md
@@ -54,3 +54,18 @@ Each entry has four fields:
 **Source:** NM-042 deliberation
 **Finding:** The agent sign-off mechanism has no structural independence guarantee in a single-session single-principal context — same-session sign-offs are self-reported.
 **Status:** promoted → NM-042 process amendment PR #930
+
+---
+
+**Date:** 2026-06-16
+**Source:** EL review of CLAUDE.md structure
+**Finding:** CLAUDE.md is 1,080 lines / ~9,000 words and mixes constitutional principles with detailed operational procedures; three sections (Agent Execution Lifecycle ~200 lines, Domain Intelligence Council table ~25 lines, Milestone Exit Ceremony + Retrospective ~65 lines) are candidates for extraction into child docs to reduce the file by ~25% without information loss.
+**Status:** open — deferred to M14 sprint close to avoid mid-sprint section citation breaks; planned child docs: `docs/process/agent-execution-lifecycle.md`, `docs/process/milestone-exit-sop.md`
+
+---
+
+**Date:** 2026-06-17
+**Source:** QA Lead + Frontend Architect deliberation during M14-G1 test authorship (PR #1001)
+**Finding:** The intent document template has no Visual Spec section; AC-6 (#963 label scope) required the QA Lead to read `AttributeSelector.tsx` source to resolve a prose ambiguity about whether "no underscore in option text" applied to the full string or only the label portion — a before/after annotated screenshot would have made scope self-answering without any code read.
+**Detail:** The specific failure mode: intent document §3.2 described the correct observable state in prose ("Reserve Coverage (months)") without capturing what the current broken state looked like in the running app. QA Lead had to make a judgment call (label portion vs. full text content including unit metadata), which caused a two-commit fix sequence. A "Visual Spec (before/after)" section in `docs/process/intent-template.md` — optional for backend/infrastructure ACs, encouraged for any AC involving text display, label format, or layout — would eliminate this class of scope ambiguity at authorship time. The ADR is not the right home for this material; the intent document is, because that is where QA-testable observable states are specified.
+**Status:** promoted → #1004

--- a/docs/process/intent-template.md
+++ b/docs/process/intent-template.md
@@ -134,6 +134,46 @@ observable characteristic.]
 
 ---
 
+## 4b. Visual Spec (before/after)
+
+> *Required when: any AC in Section 4 involves text display, label format, layout, or visual
+> hierarchy — i.e., when the observable state is a string value, element appearance, or
+> spatial arrangement that a QA reviewer must match exactly.*
+>
+> *Optional when: all ACs are backend-only (API responses, database state, computation outputs)
+> with no text-display component.*
+>
+> *What to provide:* For each display-format AC, show:
+> - **Before** — the current broken or absent state (screenshot, annotated text block, or
+>   wireframe excerpt). Label what is wrong: which string is raw, which element is absent,
+>   which layout is violated.
+> - **After** — the intended fixed state. Label what "done" looks like: the exact string
+>   the option must display, the exact zone the element must occupy, the exact label format.
+>
+> *Why this exists:* Prose descriptions of text display states have an inherent scope ambiguity —
+> "no underscore in option text" does not distinguish label portion from unit metadata. A
+> before/after visual eliminates that ambiguity without requiring the QA Lead to read source
+> code. Authority: insights log entry 2026-06-17; M14-G1 AC-6 incident; #1004.
+>
+> *Format:* Inline fenced text blocks are sufficient when screenshots are unavailable. Mark
+> the bug location explicitly (e.g., `^^^^ THIS IS THE BUG`). A marked-up text block is
+> better than prose; a screenshot is better than a text block.
+
+**AC-N (before):**
+```
+[Paste current broken output here. Annotate the specific wrong string or missing element.]
+```
+
+**AC-N (after):**
+```
+[Paste intended fixed output here. Annotate the specific correct string or present element.]
+```
+
+[Repeat for each display-format AC. Leave this section blank with "N/A — backend only" if
+no AC involves text display, label format, or layout.]
+
+---
+
 ## 5. Kryptonite Constraint Check
 
 > *Authority: CLAUDE.md §Agent Execution Lifecycle — Kryptonite Design Constraint (FD-3).
@@ -176,7 +216,8 @@ Backend pytest: `backend/tests/test_m{N}_g{N}_{short_name}.py`]
 
 ---
 
-*Template version: 2026-06-12. Phase A encoded. Authoring authority: `docs/process/agents.md
-§Architect Agent`. The intent document is the contract; the implementation is the execution.
-A discrepancy between them is a Verify-step failure — not a document-update opportunity.
-For the full lifecycle this template feeds into, see `CLAUDE.md §Agent Execution Lifecycle`.*
+*Template version: 2026-06-17. Phase A encoded; §4b Visual Spec added (#1004). Authoring
+authority: `docs/process/agents.md §Architect Agent`. The intent document is the contract;
+the implementation is the execution. A discrepancy between them is a Verify-step failure —
+not a document-update opportunity. For the full lifecycle this template feeds into, see
+`CLAUDE.md §Agent Execution Lifecycle`.*


### PR DESCRIPTION
## Summary

- Adds `§4b Visual Spec (before/after)` to `docs/process/intent-template.md`
- Promotes insights-log entry 2026-06-17 to `promoted → #1004`
- Infrastructure change — no sprint entry required (internal process tooling, no user-facing output)

## What changed

New section in the intent template between §4 (Acceptance Criteria) and §5 (Kryptonite Constraint Check):

**Required when:** any AC involves text display, label format, layout, or visual hierarchy.
**Optional when:** all ACs are backend-only.

Content: before/after annotated text blocks, wireframes, or screenshots showing exactly which string is the bug and which string is the fix. Inline fenced text blocks are sufficient when screenshots are unavailable.

## Why

M14-G1 AC-6 (choropleth attribute selector, #963) required a two-commit fix sequence because the QA Lead could not determine from prose alone whether "no underscore in option text" applied to the full option string or only the label portion. Reading `AttributeSelector.tsx` source was required to resolve it.

A before/after block at authorship time makes that scope self-answering. The QA Lead writes tests from the intent document — if the document is ambiguous, the tests are ambiguous.

## Closes

#1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)