### PR TITLE
fix(m14-g1): entity selector, step counter, choropleth labels (#961 #962 #963)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -241,6 +241,7 @@ export default function App() {
             <ScenarioControls
               scenarioId={selectedScenarioId}
               totalSteps={selectedScenarioSteps}
+              initialStep={currentStep ?? 0}
               onStepChange={handleStepChange}
             />
           </div>

--- a/frontend/src/components/ScenarioControls.tsx
+++ b/frontend/src/components/ScenarioControls.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { AdvanceResponse } from "../types";
 
 const API_BASE = "http://localhost:8000/api/v1";
@@ -6,14 +6,22 @@ const API_BASE = "http://localhost:8000/api/v1";
 interface Props {
   scenarioId: string;
   totalSteps: number;
+  initialStep?: number;
   onStepChange: (step: number, isComplete: boolean) => void;
 }
 
-export default function ScenarioControls({ scenarioId, totalSteps, onStepChange }: Props) {
-  const [currentStep, setCurrentStep] = useState(0);
+export default function ScenarioControls({ scenarioId, totalSteps, initialStep = 0, onStepChange }: Props) {
+  const [currentStep, setCurrentStep] = useState(initialStep);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isComplete, setIsComplete] = useState(false);
+  const [isComplete, setIsComplete] = useState(initialStep >= totalSteps && totalSteps > 0);
+
+  // Sync internal step when scenario changes or when parent detects a completed
+  // scenario after async fetch (e.g., URL-loaded completed scenario).
+  useEffect(() => {
+    setCurrentStep(initialStep);
+    setIsComplete(initialStep >= totalSteps && totalSteps > 0);
+  }, [scenarioId, initialStep, totalSteps]);
 
   const advance = async () => {
     if (isComplete || loading) return;

--- a/frontend/src/components/ScenarioPanel.tsx
+++ b/frontend/src/components/ScenarioPanel.tsx
@@ -21,6 +21,7 @@ export default function ScenarioPanel({
   const [scenarios, setScenarios] = useState<ScenarioResponse[]>([]);
   const [listError, setListError] = useState<string | null>(null);
   const [createName, setCreateName] = useState("");
+  const [createEntity, setCreateEntity] = useState("GRC");
   const [createStartYear, setCreateStartYear] = useState(2020);
   const [createFiscalMultiplier, setCreateFiscalMultiplier] = useState(1.0);
   const [creating, setCreating] = useState(false);
@@ -81,7 +82,7 @@ export default function ScenarioPanel({
           name,
           description: null,
           configuration: {
-            entities: ["GRC"],
+            entities: [createEntity],
             n_steps: 3,
             timestep_label: "annual",
             start_date: startDate,
@@ -142,6 +143,7 @@ export default function ScenarioPanel({
                   <div
                     key={s.scenario_id}
                     className={`scenario-row${isPrimary ? " scenario-row--primary" : ""}${isSecond ? " scenario-row--second" : ""}`}
+                    data-scenario-id={s.scenario_id}
                   >
                     <div className="scenario-row-info">
                       <span className="scenario-row-name">{s.name}</span>
@@ -188,6 +190,19 @@ export default function ScenarioPanel({
               }}
               disabled={creating}
             />
+            <select
+              className="scenario-create-input scenario-create-input--entity"
+              data-testid="entity-selector"
+              value={createEntity}
+              onChange={(e) => setCreateEntity(e.target.value)}
+              disabled={creating}
+              aria-label="Entity"
+            >
+              <option value="GRC">GRC</option>
+              <option value="JOR">JOR</option>
+              <option value="EGY">EGY</option>
+              <option value="ZMB">ZMB</option>
+            </select>
             <input
               className="scenario-create-input scenario-create-input--year"
               type="number"
@@ -245,7 +260,7 @@ export default function ScenarioPanel({
             <div className="scenario-panel-error">{createError}</div>
           )}
           <div className="scenario-create-hint">
-            Creates a GRC scenario with 3 annual steps starting at the given year. Fiscal
+            Creates a scenario with 3 annual steps starting at the given year. Fiscal
             multiplier 1.0 = standard; &gt;1.0 = expansionary amplification; &lt;1.0 = contractionary.
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **#961 — Entity selector:** Adds `data-testid="entity-selector"` `<select>` to the New Scenario form with GRC/JOR/EGY/ZMB options (ADR-016 entity scope). Wires selected entity into the create payload. Adds `data-scenario-id` attribute to scenario rows for E2E test verification. Removes hardcoded `entities: ["GRC"]` from the create request.
- **#962 — Step counter:** `ScenarioControls` now accepts `initialStep` prop and uses a `useEffect([scenarioId, initialStep, totalSteps])` to sync internal step state. `App.tsx` passes `currentStep ?? 0` as `initialStep`. This fixes the "Step 0 / N" display when loading a completed scenario via `?scenario=<id>` URL param.
- **#963 — Choropleth labels:** No code change required. `getIndicatorDisplayNameAny` is already called in `AttributeSelector.tsx`; AC-6/AC-7 assertions activate once the `entity-selector` guard passes (the tests are no-ops pre-implementation per QA Lead authorship notes).

## Intent document

`docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md`

## Test plan

- AC-1: `entity-selector` present with GRC/JOR/EGY/ZMB options in New Scenario panel
- AC-2: Selecting ZMB → created scenario has `configuration.entities[0] === "ZMB"`
- AC-3: Selecting JOR → created scenario has `configuration.entities[0] === "JOR"`
- AC-4: `?scenario=<completed-id>` shows `Step N / N` (not `Step 0 / N`) within 3s of load
- AC-5: Step display stays at N (not 0) 1s after load (SF-2 stability guard)
- AC-6: No option label in `AttributeSelector` contains `_` (label portion before `(`)
- AC-7: `reserve_coverage_months` option shows label containing "Reserve" without `_`

All tests in `frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts` (filed PR #1001, Step 2 complete).

## Files changed

- `frontend/src/components/ScenarioPanel.tsx` — entity selector, data-scenario-id
- `frontend/src/components/ScenarioControls.tsx` — initialStep prop + useEffect sync
- `frontend/src/App.tsx` — pass initialStep to ScenarioControls

🤖 Generated with [Claude Code](https://claude.com/claude-code)