### PR TITLE
process(m14-g1): Step 4 Verify PASS — all 7 ACs pass; #1007 filed

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-17 (PR #1001 merged — G1 QA tests authored and filed (Step 2 complete); AC-1–AC-7 in frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts; entity-selector guard pattern applied to all ACs; QA Lead acknowledgment recorded in intent doc. G1 implementation PR may now open.)**
+**Last updated: 2026-06-17 (PR #1006 merged — G1 implementation COMPLETE (Steps 3 + 4 done); all 7 ACs pass; entity selector #961, step counter #962, label display #963; Step 4 Verify PASS; pre-existing E2E bug #1007 filed (recompute-badge). Awaiting BPO Step 5 Validate.)**
 **Current milestone:** M14 — Methodology Publication and External Validation (GitHub Milestone 15)
 **Previous milestone:** M13 — Political Economy and Instrument Credibility (formally closed 2026-06-15; release/m13 → main merged by EL; #264 closed)
 
@@ -93,9 +93,10 @@
 
 | Item | Status | Next action |
 |---|---|---|
-| Bug #961 — GRC hardcoded in creation form | Filed 2026-06-15 | G1 — QA tests (Step 2) blocking before implementation PR opens |
-| Bug #962 — step counter 'Step 0 / 8' | Filed 2026-06-15 | G1 — QA tests (Step 2) blocking before implementation PR opens |
-| Bug #963 — choropleth raw DB field names | Filed 2026-06-15 | G1 — QA tests (Step 2) blocking before implementation PR opens |
+| Bug #961 — GRC hardcoded in creation form | ✅ FIXED 2026-06-17 (PR #1006) | BPO Step 5 Validate pending |
+| Bug #962 — step counter 'Step 0 / 8' | ✅ FIXED 2026-06-17 (PR #1006) | BPO Step 5 Validate pending |
+| Bug #963 — choropleth raw DB field names | ✅ FIXED 2026-06-17 (PR #1006) | BPO Step 5 Validate pending |
+| Bug #1007 — recompute-badge not visible after apply-control-change | Filed 2026-06-17 | Pre-existing; discovered during G1 Step 4 Verify; to be addressed in G2 or follow-on |
 | ARCH-010 / ADR-016 — Scenario Grounding | ✅ ACCEPTED 2026-06-16 (PR #967) | G3/G4 implementation gated on sprint entry |
 | ADR-016 entity scope | GRC, JOR, EGY, ZMB (EL decision 2026-06-16) | — |
 | ADR-016 Component 3 | Deferred to M15 (EL decision 2026-06-16) | — |
@@ -104,8 +105,11 @@
 | M14 sprint plan | ✅ **EL APPROVED 2026-06-16** — `docs/process/sprint-plans/m14-sprint-plan.md` | Sprint entry document required per group before implementation PR opens |
 | release/m14 branch | ✅ Cut 2026-06-16 from main | Ready for feature PRs — sprint entry document required first |
 | G1 sprint entry document | ✅ Filed 2026-06-16 — `docs/process/sprint-plans/m14-g1-sprint-entry.md` (PR #993) | **EL Approved 2026-06-16** (PR #996); intent doc ✅ filed (PR #999); QA tests ✅ filed (PR #1001) |
-| G1 intent document | ✅ Filed 2026-06-16 — `docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md` (PR #999) | QA Lead acknowledgment ✅ 2026-06-17 — `frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts` (AC-1–AC-7); **G1 implementation PR may now open** |
-| G1 QA tests (Step 2) | ✅ Filed 2026-06-17 — `frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts` (PR #1001) | All 7 ACs covered; entity-selector guard pattern; AC-4/AC-5 API fixture; AC-6 label-scope; **Step 2 COMPLETE — implementation PR unblocked** |
+| G1 intent document | ✅ Filed 2026-06-16 — `docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md` (PR #999) | Step 4 Verify PASS 2026-06-17 — all 7 ACs pass; Step 4 verdict recorded in §8 of intent doc |
+| G1 QA tests (Step 2) | ✅ Filed 2026-06-17 — `frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts` (PR #1001) | All 7 ACs covered; entity-selector guard pattern; AC-4/AC-5 API fixture; AC-6 label-scope |
+| G1 implementation (Step 3) | ✅ MERGED 2026-06-17 — PR #1006 → release/m14 | ScenarioPanel entity selector; ScenarioControls initialStep; App.tsx initialStep prop |
+| G1 Step 4 Verify | ✅ PASS 2026-06-17 | 7/7 ACs pass; 4 probes pass; pre-existing #1007 discovered and filed; verdict in intent doc §8 |
+| G1 Step 5 Validate | ⬜ PENDING | **BPO required action** — open live app, confirm Persona 2 observable states per intent doc §3 |
 | Intent/test naming convention | ✅ Enforced 2026-06-16 (PR #999) | M{N}-G{N} prefix on intent docs and E2E tests — CLAUDE.md, intent-template.md, sprint-planning-sop.md, sprint-entry-template.md all updated |
 | M14 Exit Checklist | ✅ Filed 2026-06-16 — **#968** (closure gate: #843) | Tracks all M14 deliverables |
 | CI merge gate enforcement (#970) | ✅ CLOSED 2026-06-16 | `release-branch-ci-gate` Ruleset (ID 17751852) live — 6 required checks: `changes`, `lint`, `test-backend`, `playwright-e2e`, `compliance-scan`, `branch-naming`; `--admin` removed from SESSION_STATE merge rule |

--- a/docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md
+++ b/docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md
@@ -299,6 +299,44 @@ The QA Lead should use approach (1) for independence from seed state.
 
 ---
 
+## 8. Step 4 — Verify (2026-06-17)
+
+**Implementing agent:** Frontend Architect Agent
+**Date:** 2026-06-17
+**PR merged:** #1006 → `release/m14`
+
+**Method:** `npx playwright test tests/e2e/m14-g1-prerequisite-bugs.spec.ts` against live
+app (backend :8000 `db:connected`; frontend dev server :5173). Followed by 4 manual
+probing steps via a temporary Playwright spec.
+
+**AC results:**
+
+| AC | Description | Result |
+|---|---|---|
+| AC-1 | entity-selector present with GRC/JOR/EGY/ZMB | ✅ PASS (1.2s) |
+| AC-2 | ZMB selection → API stores `entities[0]==="ZMB"` | ✅ PASS (1.0s) |
+| AC-3 | JOR selection → API stores `entities[0]==="JOR"` | ✅ PASS (693ms) |
+| AC-4 | URL-loaded completed scenario shows Step 3 (not 0) within 3s | ✅ PASS (786ms) |
+| AC-5 | Step display stays at 3 after 1s stability wait (SF-2) | ✅ PASS (808ms) |
+| AC-6 | No underscore in attribute selector option labels | ✅ PASS (3.5s) |
+| AC-7 | reserve_coverage_months option shows "Reserve" without `_` | ✅ PASS (3.6s) |
+
+**Probes beyond the spec:**
+- PROBE 1: Default entity selector value = "GRC" ✅ (preserves prior default)
+- PROBE 2: SF-1 guard — ZMB stored in DB not just UI; `data-scenario-id` on row
+  confirmed; API returns `entities[0]==="ZMB"` with no "GRC" ✅
+- PROBE 3: Switching scenarios resets step counter to 0 ✅ (`useEffect` sync works for
+  manual panel select; advanced A to Step 1, switched to B → "Step 0 / 3")
+- PROBE 4: Entity selector not disabled at rest ✅
+
+**Full suite regression:** 105 pass, 1 fail —
+`demo-trajectory-mode3.spec.ts G2/AC-1` (`recompute-badge` never visible).
+Confirmed pre-existing (predates G1). Bug issue filed: #1007.
+
+**Step 4 verdict: PASS**
+
+---
+
 *Intent document version: 2026-06-16. Sprint entry EL-approved 2026-06-16. No ADR
 required — bug fixes only; ADR-016 entity scope (GRC/JOR/EGY/ZMB) provides context
 for #961 entity list. Implementing agent: Frontend Architect Agent. Kryptonite


### PR DESCRIPTION
## Summary

- Records Step 4 (Verify) verdict in `docs/process/intents/M14-G1-2026-06-16-prerequisite-bugs.md §8`
- All 7 ACs pass in running app (PR #1006 merged); 4 manual probes pass
- Pre-existing E2E failure discovered during verification: `recompute-badge` never appears after `apply-control-change` — filed as **#1007**
- `SESSION_STATE.md` updated: G1 Steps 3 + 4 marked complete; Step 5 BPO Validate flagged as next required action

## Step 4 verdict: PASS

| AC | Result |
|---|---|
| AC-1: entity-selector with GRC/JOR/EGY/ZMB | ✅ |
| AC-2: ZMB stored in configuration.entities | ✅ |
| AC-3: JOR stored in configuration.entities | ✅ |
| AC-4: URL-loaded completed scenario shows Step 3 | ✅ |
| AC-5: Step display stable 1s after load | ✅ |
| AC-6: no underscore in attribute selector labels | ✅ |
| AC-7: reserve_coverage_months shows "Reserve" | ✅ |

## Next action

**BPO Step 5 Validate** — open live app, confirm Persona 2 can select ZMB, create scenario, observe ZMB-calibrated step counter and choropleth labels per intent doc §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)