### PR TITLE
feat(m14-g4): ADR-016 frontend — grounding strip, data quality preview, parameter persistence, IC-4/IC-6

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,10 @@ import ChoroplethMap from "./components/ChoroplethMap";
 import DeltaChoropleth from "./components/DeltaChoropleth";
 import EntityDetailDrawer from "./components/EntityDetailDrawer";
 import FidelityDashboard from "./components/FidelityDashboard";
+import GroundingStrip from "./components/GroundingStrip";
 import { ModeSelector } from "./components/ModeSelector";
+import { ModeIndicator } from "./components/ModeIndicator";
+import ScenarioParameters from "./components/ScenarioParameters";
 import { ScenarioIdentityHeader } from "./components/ScenarioIdentityHeader";
 import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
 import ScenarioControls from "./components/ScenarioControls";
@@ -73,6 +76,9 @@ export default function App() {
   const [secondScenarioId, setSecondScenarioId] = useState<string | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
   const [fidelityOpen, setFidelityOpen] = useState(false);
+  const [groundingOpen, setGroundingOpen] = useState(false);
+  const [paramsOpen, setParamsOpen] = useState(false);
+  const [activeScenarioDetail, setActiveScenarioDetail] = useState<ScenarioDetailResponse | null>(null);
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
   // All active entities for the scenario — used by ScenarioIdentityHeader and choropleth highlight (#754)
   const [activeEntityIds, setActiveEntityIds] = useState<string[]>([]);
@@ -99,6 +105,8 @@ export default function App() {
     setActiveEntityIds([]);
     setActiveFiscalMultiplier(null);
     setMode3Active(false);
+    setActiveScenarioDetail(null);
+    setParamsOpen(false);
     writeStoredScenario({ id, name, totalSteps });
   };
 
@@ -153,6 +161,7 @@ export default function App() {
 
   // When a scenario is selected: fast-forward currentStep if already completed,
   // and extract the primary entity for the identity header + choropleth highlight (#744).
+  // Also stores the full detail for the ScenarioParameters panel (ADR-016 Component 4).
   useEffect(() => {
     if (!selectedScenarioId) return;
 
@@ -168,6 +177,8 @@ export default function App() {
         setActiveEntityIds(detail.configuration.entities ?? []);
         // Extract fiscal multiplier for Mode 2 display (Issue #746)
         setActiveFiscalMultiplier(detail.configuration.fiscal_multiplier ?? null);
+        // Store full detail for ScenarioParameters panel (ADR-016 Component 4)
+        setActiveScenarioDetail(detail);
       })
       .catch(() => {
         // Non-fatal — currentStep and activeEntityId stay at previous values
@@ -203,48 +214,77 @@ export default function App() {
         </label>
         <button
           className={`scenario-toggle-btn${panelOpen ? " scenario-toggle-btn--open" : ""}`}
-          onClick={() => { setPanelOpen((v) => !v); setFidelityOpen(false); }}
+          onClick={() => { setPanelOpen((v) => !v); setFidelityOpen(false); setGroundingOpen(false); setParamsOpen(false); }}
         >
           Scenarios {panelOpen ? "▲" : "▼"}
         </button>
         <button
           className={`scenario-toggle-btn${fidelityOpen ? " scenario-toggle-btn--open" : ""}`}
-          onClick={() => { setFidelityOpen((v) => !v); setPanelOpen(false); }}
+          onClick={() => { setFidelityOpen((v) => !v); setPanelOpen(false); setGroundingOpen(false); setParamsOpen(false); }}
           data-testid="fidelity-toggle"
         >
           Fidelity {fidelityOpen ? "▲" : "▼"}
         </button>
         {selectedScenarioId && (
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            {selectedScenarioName && (
-              <span style={{ fontSize: 13, opacity: 0.85, maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {selectedScenarioName}
-              </span>
-            )}
-            <ModeSelector />
+          <>
             <button
-              data-testid="mode3-toggle"
-              onClick={() => setMode3Active((v) => !v)}
+              data-testid="grounding-strip-toggle"
+              onClick={() => { setGroundingOpen((v) => !v); setPanelOpen(false); setFidelityOpen(false); setParamsOpen(false); }}
               style={{
-                fontSize: 11,
-                padding: "3px 8px",
-                background: mode3Active ? "#8b5cf6" : "transparent",
-                color: mode3Active ? "#fff" : "#8b5cf6",
-                border: "1px solid #8b5cf6",
+                padding: "4px 10px",
+                fontSize: 13,
+                background: groundingOpen ? "rgba(255,255,255,0.25)" : "rgba(255,255,255,0.15)",
+                color: "#fff",
+                border: "none",
                 borderRadius: 4,
                 cursor: "pointer",
-                fontWeight: 600,
+                fontWeight: groundingOpen ? 600 : 400,
               }}
             >
-              Mode 3
+              Grounding {groundingOpen ? "▲" : "▼"}
             </button>
-            <ScenarioControls
-              scenarioId={selectedScenarioId}
-              totalSteps={selectedScenarioSteps}
-              initialStep={currentStep ?? 0}
-              onStepChange={handleStepChange}
-            />
-          </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              {selectedScenarioName && (
+                <span style={{ fontSize: 13, opacity: 0.85, maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {selectedScenarioName}
+                </span>
+              )}
+              <ModeSelector />
+              {/* Clickable ModeIndicator opens parameter persistence panel (ADR-016 Component 4) */}
+              <span
+                role="button"
+                tabIndex={0}
+                style={{ cursor: "pointer" }}
+                onClick={() => { setParamsOpen((v) => !v); setGroundingOpen(false); setPanelOpen(false); setFidelityOpen(false); }}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setParamsOpen((v) => !v); }}
+                title="Show scenario parameters"
+              >
+                <ModeIndicator />
+              </span>
+              <button
+                data-testid="mode3-toggle"
+                onClick={() => setMode3Active((v) => !v)}
+                style={{
+                  fontSize: 11,
+                  padding: "3px 8px",
+                  background: mode3Active ? "#8b5cf6" : "transparent",
+                  color: mode3Active ? "#fff" : "#8b5cf6",
+                  border: "1px solid #8b5cf6",
+                  borderRadius: 4,
+                  cursor: "pointer",
+                  fontWeight: 600,
+                }}
+              >
+                Mode 3
+              </button>
+              <ScenarioControls
+                scenarioId={selectedScenarioId}
+                totalSteps={selectedScenarioSteps}
+                initialStep={currentStep ?? 0}
+                onStepChange={handleStepChange}
+              />
+            </div>
+          </>
         )}
       </header>
 
@@ -259,6 +299,12 @@ export default function App() {
       )}
 
       {fidelityOpen && <FidelityDashboard />}
+
+      {groundingOpen && selectedScenarioId && (
+        <GroundingStrip scenarioId={selectedScenarioId} />
+      )}
+
+      {paramsOpen && <ScenarioParameters detail={activeScenarioDetail} />}
 
       <main className="app-main" style={{ position: "relative" }}>
         {/* Scenario identity header — always visible when scenario active (Issue #744, GAP-02) */}
@@ -288,6 +334,7 @@ export default function App() {
         )}
 
         {/* Context layer — choropleth map (navigable context per CLAUDE.md UX commitment 2) */}
+        {/* IC-6 reference header rendered inside ChoroplethMap (ADR-016 §EL Decision 5) */}
         {showDelta ? (
           <DeltaChoropleth
             scenarioAId={selectedScenarioId}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import EntityDetailDrawer from "./components/EntityDetailDrawer";
 import FidelityDashboard from "./components/FidelityDashboard";
 import GroundingStrip from "./components/GroundingStrip";
 import { ModeSelector } from "./components/ModeSelector";
-import { ModeIndicator } from "./components/ModeIndicator";
 import ScenarioParameters from "./components/ScenarioParameters";
 import { ScenarioIdentityHeader } from "./components/ScenarioIdentityHeader";
 import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
@@ -249,18 +248,10 @@ export default function App() {
                   {selectedScenarioName}
                 </span>
               )}
-              <ModeSelector />
-              {/* Clickable ModeIndicator opens parameter persistence panel (ADR-016 Component 4) */}
-              <span
-                role="button"
-                tabIndex={0}
-                style={{ cursor: "pointer" }}
-                onClick={() => { setParamsOpen((v) => !v); setGroundingOpen(false); setPanelOpen(false); setFidelityOpen(false); }}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setParamsOpen((v) => !v); }}
-                title="Show scenario parameters"
-              >
-                <ModeIndicator />
-              </span>
+              {/* ModeSelector wrapper click opens parameter persistence panel (ADR-016 Component 4) */}
+              <ModeSelector
+                onWrapperClick={() => { setParamsOpen((v) => !v); setGroundingOpen(false); setPanelOpen(false); setFidelityOpen(false); }}
+              />
               <button
                 data-testid="mode3-toggle"
                 onClick={() => setMode3Active((v) => !v)}

--- a/frontend/src/components/ChoroplethMap.tsx
+++ b/frontend/src/components/ChoroplethMap.tsx
@@ -264,6 +264,25 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
       data-step={currentStep ?? 0}
       style={{ position: "relative", width: "100%", height: "100%" }}
     >
+      {/* IC-6 mitigation: ADR-016 §EL Decision 5 — verbatim text required, always visible */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          background: "rgba(15,31,51,0.82)",
+          color: "#8aa8c4",
+          fontSize: 11,
+          fontWeight: 600,
+          padding: "4px 12px",
+          letterSpacing: "0.04em",
+          pointerEvents: "none",
+        }}
+      >
+        Reference data — not scenario outputs
+      </div>
       <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
       {error && (
         <div

--- a/frontend/src/components/DataQualityPreview.tsx
+++ b/frontend/src/components/DataQualityPreview.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import type { DataQualityResponse, DataQualityFramework } from "../types";
+
+const API_BASE = "http://localhost:8000/api/v1";
+
+const FRAMEWORK_LABELS: Record<string, string> = {
+  financial: "Financial",
+  human_development: "Human Dev",
+  ecological: "Ecological",
+  governance: "Governance",
+  political_economy: "Pol. Economy",
+};
+
+function TierBadge({ tier }: { tier: number }) {
+  const color = tier <= 2 ? "#6ee7b7" : tier === 3 ? "#fbbf24" : "#f87171";
+  return (
+    <span
+      style={{
+        fontWeight: 700,
+        color,
+        fontSize: 11,
+        minWidth: 22,
+        display: "inline-block",
+      }}
+    >
+      T{tier}
+    </span>
+  );
+}
+
+function FrameworkRow({ fw }: { fw: DataQualityFramework }) {
+  const label = FRAMEWORK_LABELS[fw.framework] ?? fw.framework;
+  const citation = [fw.source_institution, fw.data_vintage].filter(Boolean).join(" · ");
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "90px 24px 1fr",
+        gap: "0 6px",
+        padding: "2px 0",
+        fontSize: 11,
+        alignItems: "baseline",
+      }}
+    >
+      <span style={{ color: "#94a3b8" }}>{label}</span>
+      <TierBadge tier={fw.confidence_tier} />
+      <span style={{ color: "#64748b" }}>
+        {fw.is_synthetic ? (
+          <>
+            <span style={{ color: "#f87171" }}>synthetic</span>
+            {fw.synthetic_basis ? ` — ${fw.synthetic_basis}` : ""}
+          </>
+        ) : (
+          citation || "—"
+        )}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  entityId: string;
+  year: number;
+}
+
+export default function DataQualityPreview({ entityId, year }: Props) {
+  const [data, setData] = useState<DataQualityResponse | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    if (!entityId || !year) return;
+    setData(null);
+    setUnavailable(false);
+
+    let cancelled = false;
+    fetch(`${API_BASE}/entities/${encodeURIComponent(entityId)}/data-quality?year=${year}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json() as Promise<DataQualityResponse>;
+      })
+      .then((body) => {
+        if (!cancelled) setData(body);
+      })
+      .catch(() => {
+        if (!cancelled) setUnavailable(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entityId, year]);
+
+  return (
+    <div
+      data-testid="data-quality-preview"
+      style={{
+        background: "rgba(15,31,51,0.92)",
+        border: "1px solid rgba(100,148,200,0.25)",
+        borderRadius: 4,
+        padding: "8px 10px",
+        marginTop: 8,
+        color: "#cbd5e1",
+        fontFamily: "system-ui, 'Segoe UI', sans-serif",
+      }}
+    >
+      {unavailable ? (
+        <span style={{ fontSize: 11, color: "#f87171" }}>
+          Data quality preview unavailable
+        </span>
+      ) : !data ? (
+        <span style={{ fontSize: 11, color: "#64748b" }}>Loading…</span>
+      ) : data.frameworks.length === 0 ? (
+        <span style={{ fontSize: 11, color: "#64748b" }}>
+          No coverage data for {entityId} {year}.
+        </span>
+      ) : (
+        <>
+          <div style={{ fontSize: 11, color: "#8aa8c4", marginBottom: 4, fontWeight: 600 }}>
+            {data.entity_id} · {data.year}
+          </div>
+          {data.frameworks.map((fw) => (
+            <FrameworkRow key={fw.framework} fw={fw} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/FidelityDashboard.tsx
+++ b/frontend/src/components/FidelityDashboard.tsx
@@ -389,6 +389,22 @@ export default function FidelityDashboard() {
         </div>
       </div>
 
+      {/* IC-4 — static scope contextualisation header (ADR-016 §EL Decision 2) */}
+      <div
+        data-testid="fidelity-contextualisation"
+        style={{
+          padding: "8px 16px",
+          fontSize: 12,
+          color: "#8aa8c4",
+          background: "rgba(18,42,69,0.6)",
+          borderBottom: "1px solid rgba(100,148,200,0.15)",
+          lineHeight: 1.5,
+        }}
+      >
+        This panel validates model relationships using historical cases. It does not validate
+        input data for the active scenario.
+      </div>
+
       {/* Framing note */}
       <div
         style={{

--- a/frontend/src/components/GroundingStrip.tsx
+++ b/frontend/src/components/GroundingStrip.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import type { InitialStateResponse, GroundingIndicator } from "../types";
+
+const API_BASE = "http://localhost:8000/api/v1";
+
+// Named frameworks only — "None" key must not render as a section heading.
+const FRAMEWORK_LABELS: Record<string, string> = {
+  financial: "Financial",
+  human_development: "Human Development",
+  ecological: "Ecological",
+  governance: "Governance",
+  political_economy: "Political Economy",
+};
+
+function IndicatorRow({ ind }: { ind: GroundingIndicator }) {
+  const value =
+    ind.value != null
+      ? `${ind.value}${ind.unit ? " " + ind.unit : ""}`
+      : "—";
+  const citation = [ind.source_institution, ind.data_vintage]
+    .filter(Boolean)
+    .join(" · ");
+  const tier = ind.confidence_tier != null ? ` · T${ind.confidence_tier}` : "";
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: "0 12px",
+        padding: "3px 0",
+        fontSize: 11,
+        borderBottom: "1px solid rgba(255,255,255,0.04)",
+        alignItems: "baseline",
+      }}
+    >
+      <span style={{ color: "#cbd5e1" }}>
+        <span style={{ color: "#8aa8c4" }}>{ind.display_name}:</span>{" "}
+        <span style={{ fontWeight: 600 }}>{value}</span>
+      </span>
+      <span style={{ color: "#475569", whiteSpace: "nowrap" }}>
+        {citation ? `${citation}${tier}` : tier || "—"}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  scenarioId: string;
+}
+
+export default function GroundingStrip({ scenarioId }: Props) {
+  const [data, setData] = useState<InitialStateResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setData(null);
+    setLoading(true);
+
+    let cancelled = false;
+    fetch(`${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/initial-state`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json() as Promise<InitialStateResponse>;
+      })
+      .then((body) => {
+        if (!cancelled) {
+          setData(body);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [scenarioId]);
+
+  // Filter to named frameworks only — "None" key must not render.
+  const namedFrameworks = data
+    ? Object.entries(data.frameworks).filter(([key]) => key in FRAMEWORK_LABELS)
+    : [];
+
+  const hasData = namedFrameworks.length > 0;
+
+  return (
+    <div
+      data-testid="grounding-strip"
+      style={{
+        background: "#0f1f33",
+        borderBottom: "1px solid rgba(255,255,255,0.08)",
+        color: "#cbd5e1",
+        fontFamily: "system-ui, 'Segoe UI', sans-serif",
+        maxHeight: 400,
+        overflowY: "auto",
+        padding: "8px 16px",
+      }}
+    >
+      {loading ? (
+        <span style={{ fontSize: 11, color: "#64748b" }}>Loading grounding data…</span>
+      ) : !hasData ? (
+        <span style={{ fontSize: 11, color: "#64748b" }}>
+          Initial state data not available for this scenario
+        </span>
+      ) : (
+        namedFrameworks.map(([key, section]) => {
+          const visibleIndicators = section.indicators.filter(
+            (ind: GroundingIndicator) => ind.value != null,
+          );
+          if (visibleIndicators.length === 0) return null;
+          return (
+            <div key={key} style={{ marginBottom: 10 }}>
+              <div
+                role="heading"
+                aria-level={4}
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "#8aa8c4",
+                  marginBottom: 4,
+                  paddingBottom: 2,
+                  borderBottom: "1px solid rgba(138,168,196,0.2)",
+                }}
+              >
+                {FRAMEWORK_LABELS[key]}
+              </div>
+              {visibleIndicators.map((ind: GroundingIndicator) => (
+                <IndicatorRow key={ind.name} ind={ind} />
+              ))}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ModeSelector.tsx
+++ b/frontend/src/components/ModeSelector.tsx
@@ -20,7 +20,11 @@ import { ModeTransitionModal } from "./ModeTransitionModal";
 type Mode = "MODE_1" | "MODE_2" | "MODE_3";
 const MODES: Mode[] = ["MODE_1", "MODE_2", "MODE_3"];
 
-export function ModeSelector() {
+interface ModeSelectorProps {
+  onWrapperClick?: () => void;
+}
+
+export function ModeSelector({ onWrapperClick }: ModeSelectorProps = {}) {
   const { mode, current_step, setMode } = useScenarioStepStore();
   const [pendingMode, setPendingMode] = useState<Mode | null>(null);
 
@@ -48,7 +52,8 @@ export function ModeSelector() {
     <div
       data-testid="mode-indicator"
       data-mode={mode}
-      style={{ position: "relative", display: "inline-flex", gap: 2 }}
+      onClick={onWrapperClick}
+      style={{ position: "relative", display: "inline-flex", gap: 2, cursor: onWrapperClick ? "pointer" : undefined }}
     >
       {MODES.map((m) => {
         const isActive = m === mode;

--- a/frontend/src/components/ScenarioPanel.tsx
+++ b/frontend/src/components/ScenarioPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import DataQualityPreview from "./DataQualityPreview";
 import type { ScenarioDetailResponse, ScenarioResponse } from "../types";
 
 const API_BASE = "http://localhost:8000/api/v1";
@@ -221,6 +222,7 @@ export default function ScenarioPanel({
               {creating ? "Creating…" : "Create"}
             </button>
           </form>
+          <DataQualityPreview entityId={createEntity} year={createStartYear} />
           <div className="scenario-fiscal-multiplier" style={{ marginTop: 8 }}>
             <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 8 }}>
               <span>Fiscal multiplier:</span>

--- a/frontend/src/components/ScenarioParameters.tsx
+++ b/frontend/src/components/ScenarioParameters.tsx
@@ -1,0 +1,83 @@
+import type { ScenarioDetailResponse } from "../types";
+
+const NOT_RECORDED = "(not recorded)";
+
+function ParamRow({ label, value }: { label: string; value: string }) {
+  const isAbsent = value === NOT_RECORDED;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "130px 1fr",
+        gap: "0 8px",
+        padding: "3px 0",
+        fontSize: 11,
+        borderBottom: "1px solid rgba(255,255,255,0.05)",
+        alignItems: "baseline",
+      }}
+    >
+      <span style={{ color: "#64748b" }}>{label}</span>
+      <span
+        style={{
+          color: isAbsent ? "#475569" : "#cbd5e1",
+          fontStyle: isAbsent ? "italic" : "normal",
+          fontWeight: isAbsent ? 400 : 600,
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  detail: ScenarioDetailResponse | null;
+}
+
+export default function ScenarioParameters({ detail }: Props) {
+  if (!detail) return null;
+
+  const cfg = detail.configuration;
+
+  const entity = cfg.entities[0] ?? NOT_RECORDED;
+  const nSteps = cfg.n_steps != null ? String(cfg.n_steps) : NOT_RECORDED;
+  const fiscalMultiplier =
+    cfg.fiscal_multiplier != null ? cfg.fiscal_multiplier.toFixed(2) : NOT_RECORDED;
+
+  // Base year from start_date "YYYY-MM-DD" or "(not recorded)"
+  let baseYear = NOT_RECORDED;
+  if (cfg.start_date) {
+    const year = cfg.start_date.slice(0, 4);
+    if (/^\d{4}$/.test(year)) baseYear = year;
+  }
+
+  return (
+    <div
+      data-testid="scenario-parameters"
+      style={{
+        background: "#0f1f33",
+        borderBottom: "1px solid rgba(255,255,255,0.08)",
+        color: "#cbd5e1",
+        fontFamily: "system-ui, 'Segoe UI', sans-serif",
+        padding: "10px 16px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#8aa8c4",
+          marginBottom: 6,
+        }}
+      >
+        Scenario Parameters
+      </div>
+      <ParamRow label="Entity" value={entity} />
+      <ParamRow label="Base year" value={baseYear} />
+      <ParamRow label="Steps" value={nSteps} />
+      <ParamRow label="Fiscal multiplier" value={fiscalMultiplier} />
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,6 +72,46 @@ export interface ScenarioConfigSchema {
   n_steps: number;
   timestep_label: string;
   fiscal_multiplier?: number;
+  start_date?: string;
+}
+
+// ADR-016 Component 1 — Data quality preview response
+export interface DataQualityFramework {
+  framework: string;
+  confidence_tier: number;
+  source_institution: string | null;
+  data_vintage: string | null;
+  is_synthetic: boolean;
+  synthetic_basis: string | null;
+}
+
+export interface DataQualityResponse {
+  entity_id: string;
+  year: number;
+  frameworks: DataQualityFramework[];
+}
+
+// ADR-016 Component 2 — Initial state (Grounding Strip) response
+export interface GroundingIndicator {
+  name: string;
+  display_name: string;
+  value: number | null;
+  unit: string | null;
+  source_institution: string | null;
+  data_vintage: string | null;
+  confidence_tier: number | null;
+  is_synthetic: boolean;
+}
+
+export interface GroundingFramework {
+  indicators: GroundingIndicator[];
+}
+
+export interface InitialStateResponse {
+  scenario_id: string;
+  entity_id: string;
+  step_0_year: number | null;
+  frameworks: Record<string, GroundingFramework>;
 }
 
 export interface ScenarioDetailResponse extends ScenarioResponse {


### PR DESCRIPTION
## Summary

Implements G4 — the frontend half of ADR-016 Scenario Grounding Architecture. All seven deliverables in scope:

- **DataQualityPreview** (`DataQualityPreview.tsx`): appears in scenario creation form after entity + year selection; calls `/entities/{id}/data-quality`; shows per-framework T1–T5 tier labels, source citations, and verbatim "synthetic" flag for T4 entries. `data-testid="data-quality-preview"` (AC-1, AC-2, AC-8).
- **GroundingStrip** (`GroundingStrip.tsx`): "Grounding ▼" toggle in header (only when scenario loaded); panel calls `/initial-state`; renders named frameworks only — `"None"` framework key filtered; fallback text on empty frameworks. `data-testid="grounding-strip-toggle"` + `data-testid="grounding-strip"` (AC-3, AC-7, AC-9).
- **ScenarioParameters** (`ScenarioParameters.tsx`): clicking the mode indicator chip opens the parameter persistence panel showing entity, base year, n_steps, fiscal_multiplier with `"(not recorded)"` fallback for absent values. `data-testid="scenario-parameters"` (AC-4).
- **IC-4 Fidelity header** (`FidelityDashboard.tsx`): static `data-testid="fidelity-contextualisation"` block inserted above existing case cards — "validates model relationships, not input data" (AC-5).
- **IC-6 Choropleth header** (`ChoroplethMap.tsx`): "Reference data — not scenario outputs" overlay, always visible, `pointerEvents: none`, no interaction required (AC-6).
- **Types**: `start_date` added to `ScenarioConfigSchema`; `DataQualityResponse`, `GroundingIndicator`, `GroundingFramework`, `InitialStateResponse` added to `types.ts`.

## Gates

- Sprint entry: EL-approved 2026-06-17 (PR #1014)
- Intent document: `docs/process/intents/M14-G4-2026-06-17-adr016-frontend.md` (filed before implementation)
- QA tests: `frontend/tests/e2e/m14-g4-adr016-frontend.spec.ts` AC-1–AC-9 (filed before implementation)
- G3 API gate: `/data-quality` and `/initial-state` confirmed in running application at G3 BPO Step 5
- Frontend build gate: `tsc -b && vite build` ✓ (0 TypeScript errors)

## Test plan

- [ ] Playwright E2E: `m14-g4-adr016-frontend.spec.ts` AC-1–AC-9 pass on CI
- [ ] Step 4 Verify: dev server at 1440×900 — entity selector shows data quality preview; "Grounding ▼" opens strip with JOR source citation; mode indicator click shows parameters; fidelity panel has scope header; choropleth has reference header
- [ ] Step 5 Validate: Business PO opens JOR scenario, opens Grounding strip, reads "Reserve coverage: 7.1 months · CBJ 2023-Q4 · T2" within 90 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)