### PR TITLE
fix(m14-g4): fidelity-contextualisation text — 'not input data' contiguous substring for AC-5

### DIFF
--- a/frontend/src/components/FidelityDashboard.tsx
+++ b/frontend/src/components/FidelityDashboard.tsx
@@ -401,8 +401,8 @@ export default function FidelityDashboard() {
           lineHeight: 1.5,
         }}
       >
-        This panel validates model relationships using historical cases. It does not validate
-        input data for the active scenario.
+        This panel validates model relationships using historical cases — not input data
+        for the active scenario.
       </div>
 
       {/* Framing note */}


### PR DESCRIPTION
## Summary

- AC-5 (`toContainText("not input data")`) was failing locally because the prior text read "does not validate input data" — the word "validate" between "not" and "input" breaks the contiguous substring match.
- New text: "This panel validates model relationships using historical cases — not input data for the active scenario." — "not input data" appears verbatim.
- All 9/9 G4 E2E tests pass locally after this change.

## Test plan

- [ ] `playwright-e2e` CI passes (AC-5 no longer fails)
- [ ] All 9 G4 tests in `m14-g4-adr016-frontend.spec.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)