### PR TITLE
process(m14-g5): record Data Architect decisions DA-G5-1 through DA-G5-5

### DIFF
--- a/docs/process/intents/M14-G5-2026-06-17-adr015-frontend.md
+++ b/docs/process/intents/M14-G5-2026-06-17-adr015-frontend.md
@@ -583,4 +583,31 @@ These decisions must be resolved before G5 implementation PR opens:
 
 ---
 
-*Intent document version: 2026-06-17. ADR-015 Accepted 2026-06-16 (PR #998). Sprint entry: `docs/process/sprint-plans/m14-g5-sprint-entry.md` (EL Approved 2026-06-17). Implementing agent: Frontend Architect Agent. Component 4 (cross-examination mode) is explicitly out of scope — M15. Full lifecycle authority: `CLAUDE.md §Agent Execution Lifecycle`. G5 delivers L0 annotations (always-visible), the assumption surface, and `programme_survival_probability` in Zone 1D. L1 basis expansion on interaction is M15.*
+## Appendix B: Data Architect Decisions — Recorded 2026-06-18
+
+*Data Architect agent consulted by EL 2026-06-18. All five decisions recorded below. Implementation and QA test authorship are now unblocked for all 14 ACs.*
+
+**DA-G5-1 — CONFIRMED:** Use `/data-quality` endpoint for Zone 1D source annotation text. Source institution is a per-entity property, not per-step; reuse of G4 data-quality pattern is appropriate. Null `source_institution` → annotation renders `[T{N} · pre-cal]` without source name (graceful degradation). `api_contracts.yml` — no change required.
+
+**DA-G5-2 — CONFIRMED with caveat:** Use `/initial-state` indicator array for count, but count only indicators where `value !== null` at step 0 (exclude null-value placeholder indicators). `api_contracts.yml` — no change required.
+
+**DA-G5-3 — CONFIRMED:** `modules_config.political_economy.enabled` (boolean) and `modules_config.political_economy.conditionality_type` (string: `"standard" | "strict" | "relaxed"`, may be absent when default) are confirmed JSONB paths. `ScenarioConfigSchema` in `frontend/src/types.ts` must be extended with:
+```typescript
+modules_config?: {
+  political_economy?: {
+    enabled?: boolean;
+    conditionality_type?: "standard" | "strict" | "relaxed";
+  };
+};
+```
+`api_contracts.yml` must document `modules_config` under `GET /scenarios/{id}` `configuration` response schema. Data Architect holds R on `api_contracts.yml` — Frontend Architect Agent must include the schema update in the G5 implementation PR for Data Architect review before merge.
+
+**DA-G5-4 — OPTION A CONFIRMED:** Use `GET /scenarios/{id}/measurement-output?entity_id={entity_id}&step={current_step}` → `outputs["political_economy"].indicators["programme_survival_probability"]` (a `QuantitySchema` entry) for the Component 3 Zone 1D Political Feasibility row. Zero backend change required. Options B and C rejected (B adds backend scope; C uses composite_score which is a different and incorrect value per G6 BPO validate 2026-06-12). `api_contracts.yml` must add explicit named-field documentation for `programme_survival_probability` as a `QuantitySchema` under `outputs.political_economy.indicators` — Frontend Architect Agent includes this in the G5 implementation PR.
+
+**DA-G5-5 — CONFIRMED:** Ecological breach type mapping: GRC and EGY → ceiling (`[↑ approaching planetary ceiling — climate]`); JOR and ZMB → floor (`[↓ approaching resource floor — freshwater]`). Direction arrow must reflect breach direction (↑ for ceiling approach, ↓ for floor approach). Static mapping in `ECOLOGICAL_BREACH_TYPES` frontend constant is acceptable for M14; M15 schema-level fix supersedes.
+
+*All five decisions recorded. QA Lead may author tests for all 14 ACs. Implementation PR may open after QA test file is filed.*
+
+---
+
+*Intent document version: 2026-06-17 (DA decisions added 2026-06-18). ADR-015 Accepted 2026-06-16 (PR #998). Sprint entry: `docs/process/sprint-plans/m14-g5-sprint-entry.md` (EL Approved 2026-06-17). Data Architect decisions: DA-G5-1 through DA-G5-5 all CONFIRMED 2026-06-18. Implementing agent: Frontend Architect Agent. Component 4 (cross-examination mode) is explicitly out of scope — M15. Full lifecycle authority: `CLAUDE.md §Agent Execution Lifecycle`. G5 delivers L0 annotations (always-visible), the assumption surface, and `programme_survival_probability` in Zone 1D. L1 basis expansion on interaction is M15.*


### PR DESCRIPTION
## Summary

- Appends Data Architect decisions for all five DA-G5 gates to `docs/process/intents/M14-G5-2026-06-17-adr015-frontend.md`
- All five decisions CONFIRMED — QA test authorship and implementation are now unblocked for all 14 ACs

## Decisions recorded

| Gate | Decision |
|---|---|
| DA-G5-1 | `/data-quality` for Zone 1D source annotation — CONFIRMED |
| DA-G5-2 | `/initial-state` indicator count (null-filtered) — CONFIRMED |
| DA-G5-3 | `modules_config` JSONB path confirmed; `ScenarioConfigSchema` extension specified |
| DA-G5-4 | Option A (`measurement-output`) for `programme_survival_probability` — CONFIRMED |
| DA-G5-5 | GRC/EGY → ceiling, JOR/ZMB → floor — CONFIRMED |

## What's unblocked

- QA Lead may now author `frontend/tests/e2e/m14-g5-adr015-frontend.spec.ts` for all 14 ACs (including AC-9/10/11 which were previously gated on DA-G5-4)
- Implementation PR may open after QA test file is filed
- `api_contracts.yml` updates for DA-G5-3 (`modules_config`) and DA-G5-4 (`programme_survival_probability`) are carried in the implementation PR (Data Architect holds R and reviews before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)