### PR TITLE
feat(m14-g5): ADR-015 Evidence Thread Architecture — Components 1, 2, 3

### DIFF
--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -370,7 +370,16 @@ endpoints:
           timestep_label: {type: string}
           start_date: {type: "string|null"}
           initial_attributes: {type: object}
-          modules_config: {type: object}
+          fiscal_multiplier: {type: "number|null", description: "Mode 2 fiscal multiplier; 1.0 = default; null = not set"}
+          modules_config:
+            type: object
+            description: >
+              Optional module activation JSONB. DA-G5-3 confirmed paths:
+              political_economy.enabled (boolean) — whether the political economy module is active;
+              political_economy.conditionality_type (string: "standard"|"strict"|"relaxed") — conditionality type.
+            political_economy:
+              enabled: {type: "boolean|null", required: false}
+              conditionality_type: {type: "string|null", values: ["standard", "strict", "relaxed"], required: false}
         scheduled_inputs:
           type: array
           items:
@@ -683,6 +692,7 @@ endpoints:
       - "financial framework includes all untagged attributes (backward-compat rule)"
       - "composite_score is null when single_entity_warning=true for financial and human_development — percentile rank requires ≥2 entities"
       - "db_reads includes simulation_reference_constants for ecological effective-at-simulation-time boundary constant query"
+      - "DA-G5-4 (ADR-015 Component 3): political_economy framework outputs.political_economy.indicators.programme_survival_probability is a QuantitySchema entry (value: Decimal string|null, confidence_tier: 3, unit: 'probability'). Distinct from political_economy.composite_score (3-factor composite from ADR-013). Frontend fetches this via Option A: measurement-output at current step."
 
   # ---------------------------------------------------------------------------
   # Causal Graph (US-048 — X-Ray Interactive Graph)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import FidelityDashboard from "./components/FidelityDashboard";
 import GroundingStrip from "./components/GroundingStrip";
 import { ModeSelector } from "./components/ModeSelector";
 import ScenarioParameters from "./components/ScenarioParameters";
+import { AssumptionSurface } from "./components/AssumptionSurface";
 import { ScenarioIdentityHeader } from "./components/ScenarioIdentityHeader";
 import { ScenarioInstrumentCluster } from "./components/ScenarioInstrumentCluster";
 import ScenarioControls from "./components/ScenarioControls";
@@ -309,6 +310,11 @@ export default function App() {
           />
         )}
 
+        {/* ADR-015 §Component 2 — Assumption surface strip (between Zone 0 and Zone 1) */}
+        {selectedScenarioId && (
+          <AssumptionSurface detail={activeScenarioDetail} />
+        )}
+
         {/* Instrument cluster — primary viewport when a scenario is active (CLAUDE.md UX commitment 1) */}
         {selectedScenarioId && (
           <div style={{ overflowX: "auto", background: "#fafafa", borderBottom: "1px solid #e8e8e8" }}>
@@ -320,6 +326,7 @@ export default function App() {
               fiscalMultiplier={activeFiscalMultiplier}
               mode3Active={mode3Active}
               entityIds={activeEntityIds}
+              activeScenarioDetail={activeScenarioDetail}
             />
           </div>
         )}

--- a/frontend/src/components/AssumptionSurface.tsx
+++ b/frontend/src/components/AssumptionSurface.tsx
@@ -1,0 +1,126 @@
+/**
+ * AssumptionSurface — ADR-015 §Component 2.
+ *
+ * A single-line fixed-height strip rendered between the scenario identity header
+ * (Zone 0) and the instrument cluster (Zone 1). Shows the key assumptions that
+ * shaped the current trajectory at zero interaction.
+ *
+ * Content priority (fallback order per DA-G5-3 and intent doc §4c §Component 2):
+ *   1. Fiscal multiplier (if non-null and non-default)
+ *   2. Political economy: enabled (if PE module is enabled)
+ *   3. Conditionality type (if PE enabled and conditionality_type is present)
+ *   4. Data vintage (derived from start_date as YYYY-Q{N})
+ *
+ * Silent failure: if no content items can be derived (empty configuration),
+ * renders data-testid="assumption-surface-unavailable" instead of an empty strip.
+ *
+ * Max height: 24px at all viewport widths (AC-6 constraint).
+ * Content overflow: truncated with ellipsis — no wrapping.
+ *
+ * Implements: ADR-015 §Component 2, AC-5 through AC-8.
+ */
+import type { CSSProperties } from "react";
+import type { ScenarioDetailResponse } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a "YYYY-Q{N}" vintage label from a start_date string like "2023-01-01". */
+function deriveVintageFromStartDate(startDate: string | null | undefined): string | null {
+  if (!startDate) return null;
+  const match = /^(\d{4})-(\d{2})/.exec(startDate);
+  if (!match) return null;
+  const year = match[1];
+  const month = parseInt(match[2], 10);
+  const quarter = Math.ceil(month / 3);
+  return `${year}-Q${quarter}`;
+}
+
+// ---------------------------------------------------------------------------
+// Styles — single-line constraint: max 24px height, ellipsis overflow (AC-6)
+// ---------------------------------------------------------------------------
+
+const SURFACE_STYLE: CSSProperties = {
+  maxHeight: 24,
+  height: 24,
+  lineHeight: "24px",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+  padding: "0 10px",
+  fontSize: 10,
+  color: "#666",
+  background: "#f7f5ff",
+  borderBottom: "1px solid #e9d5ff",
+  boxSizing: "border-box",
+};
+
+const UNAVAILABLE_STYLE: CSSProperties = {
+  height: 0,
+  overflow: "hidden",
+};
+
+// ---------------------------------------------------------------------------
+// AssumptionSurface
+// ---------------------------------------------------------------------------
+
+interface AssumptionSurfaceProps {
+  detail: ScenarioDetailResponse | null;
+}
+
+export function AssumptionSurface({ detail }: AssumptionSurfaceProps) {
+  if (!detail) {
+    return (
+      <div
+        data-testid="assumption-surface-unavailable"
+        style={UNAVAILABLE_STYLE}
+      />
+    );
+  }
+
+  const { configuration } = detail;
+
+  const parts: string[] = [];
+
+  // Fiscal multiplier — only if non-default (default 1.0) and present
+  const fiscalMultiplier = configuration.fiscal_multiplier;
+  if (fiscalMultiplier !== null && fiscalMultiplier !== undefined && fiscalMultiplier !== 1.0) {
+    parts.push(`Fiscal ×${fiscalMultiplier.toFixed(2)}`);
+  }
+
+  // Political economy module status
+  const peEnabled = configuration.modules_config?.political_economy?.enabled;
+  if (peEnabled === true) {
+    parts.push("Political economy: enabled");
+    // Conditionality type — only shown when PE is enabled
+    const condType = configuration.modules_config?.political_economy?.conditionality_type;
+    if (condType) {
+      parts.push(`Conditionality: ${condType}`);
+    }
+  }
+
+  // Data vintage — derived from start_date
+  const vintage = deriveVintageFromStartDate(configuration.start_date);
+  if (vintage) {
+    parts.push(`Data: ${vintage} vintage`);
+  }
+
+  if (parts.length === 0) {
+    return (
+      <div
+        data-testid="assumption-surface-unavailable"
+        style={UNAVAILABLE_STYLE}
+      />
+    );
+  }
+
+  return (
+    <div
+      data-testid="assumption-surface"
+      style={SURFACE_STYLE}
+    >
+      {parts.join(" · ")}
+    </div>
+  );
+}

--- a/frontend/src/components/CohortIndicatorsPanel.tsx
+++ b/frontend/src/components/CohortIndicatorsPanel.tsx
@@ -20,6 +20,18 @@ import type { QuantitySchema } from "../types";
 import { getIndicatorDisplayName } from "../lib/indicatorDisplayNames";
 
 // ---------------------------------------------------------------------------
+// Tier meaning labels — ADR-015 §Component 1 §HCL
+// ---------------------------------------------------------------------------
+
+const TIER_MEANING_LABELS: Record<number, string> = {
+  1: "real observed data",
+  2: "official statistics",
+  3: "synthetic",
+  4: "model estimate",
+  5: "synthetic extrapolation",
+};
+
+// ---------------------------------------------------------------------------
 // Cohort indicator configuration
 // ---------------------------------------------------------------------------
 
@@ -174,7 +186,7 @@ export function CohortIndicatorsPanel({ indicators, prevIndicators }: Props) {
                   data-testid={`cohort-tier-${key}`}
                   style={{ fontSize: 8, color: "#aaa", flexShrink: 0 }}
                 >
-                  T{tier}
+                  {`[T${tier} · ${TIER_MEANING_LABELS[tier] ?? "unknown"}]`}
                 </span>
               )}
             </div>

--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -12,12 +12,66 @@
  * Derives current step scores from trajectory + current_step in the Zustand atom.
  * Atomicity guaranteed by single-store subscription (DD-012, US-023).
  *
- * Implements: US-021, US-022, ADR-008 Decision 7, DD-011
+ * ADR-015 §Component 1: L0 basis annotations on each framework row.
+ * ADR-015 §Component 3: Political Feasibility (programme_survival_probability) row.
+ *
+ * Implements: US-021, US-022, ADR-008 Decision 7, DD-011, ADR-015 Components 1+3
  */
 import React from "react";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 import { FRAMEWORK_COLORS } from "../constants/frameworkColors";
 import { sortAlerts } from "./MDAAlertPanelZone1B";
+
+// ---------------------------------------------------------------------------
+// ADR-015 §Component 1 — L0 annotation constants and helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Static ecological breach-type mapping for the four M14 entities.
+ * DA-G5-5: GRC/EGY → ceiling; JOR/ZMB → floor.
+ * M15 schema-level fix will supersede this static mapping.
+ */
+const ECOLOGICAL_BREACH_TYPES: Record<string, { label: string; arrow: string }> = {
+  GRC: { label: "approaching planetary ceiling — climate", arrow: "↑" },
+  EGY: { label: "approaching planetary ceiling — climate", arrow: "↑" },
+  JOR: { label: "approaching resource floor — freshwater", arrow: "↓" },
+  ZMB: { label: "approaching resource floor — freshwater", arrow: "↓" },
+};
+
+/** Data quality info per framework from GET /entities/{id}/data-quality (DA-G5-1). */
+export interface FrameworkDataQuality {
+  source_institution: string | null;
+  data_vintage: string | null;
+  confidence_tier?: number | null;
+}
+
+/**
+ * Build the L0 basis annotation string for a framework row.
+ * Format: [T{N} · {source} · pre-cal] — always shows pre-cal in M14 (ia1_disclosure always set).
+ * Null tier → [—] (ADR-015 §Silent Failure Mode Component 1).
+ * Ecological framework uses the breach-type label from ECOLOGICAL_BREACH_TYPES.
+ */
+export function buildFrameworkAnnotation(
+  fw: string,
+  tier: number | null | undefined,
+  sourceInstitution: string | null,
+  entityId?: string | null,
+): string {
+  if (tier === null || tier === undefined) return "[—]";
+
+  if (fw === "ecological") {
+    const breachInfo = entityId ? (ECOLOGICAL_BREACH_TYPES[entityId] ?? null) : null;
+    if (breachInfo) {
+      return `[T${tier} · ${breachInfo.arrow} ${breachInfo.label} · pre-cal]`;
+    }
+    return `[T${tier} · pre-cal]`;
+  }
+
+  if (sourceInstitution) {
+    return `[T${tier} · ${sourceInstitution} · pre-cal]`;
+  }
+  return `[T${tier} · pre-cal]`;
+}
 
 // ---------------------------------------------------------------------------
 // Exported constants and pure functions (tested by FourFrameworkZone1D.test.ts)
@@ -85,6 +139,19 @@ interface FourFrameworkZone1DProps {
   onSelectFrameworkAlert?: (mdaId: string) => void;
   /** Entity ISO codes — when two provided, shows entity context label (DEMO-062). */
   entityIds?: string[];
+  /** ADR-015 §Component 1: data-quality per framework (DA-G5-1). */
+  dataQuality?: Record<string, FrameworkDataQuality> | null;
+  /** ADR-015 §Component 3: whether political economy module is enabled (DA-G5-3). */
+  peEnabled?: boolean;
+  /**
+   * ADR-015 §Component 3: programme_survival_probability value as Decimal string.
+   * undefined = not fetched / PE disabled (row absent).
+   * null = PE enabled but computation returned null (show error row).
+   * string = valid value (show percentage).
+   */
+  pspValue?: string | null;
+  /** ADR-015 §Component 3: confidence tier of the PSP indicator. */
+  pspTier?: number | null;
 }
 
 const CONTAINER_STYLE: React.CSSProperties = {
@@ -102,6 +169,10 @@ export function FourFrameworkZone1D({
   isError = false,
   onSelectFrameworkAlert,
   entityIds,
+  dataQuality,
+  peEnabled,
+  pspValue,
+  pspTier,
 }: FourFrameworkZone1DProps) {
   const { trajectory, current_step, mda_alerts, mode } = useScenarioStepStore();
 
@@ -169,6 +240,9 @@ export function FourFrameworkZone1D({
     );
   }
 
+  // Primary entity ID for ecological breach type mapping (DA-G5-5).
+  const primaryEntityId = trajectory?.entity_id ?? entityIds?.[0] ?? null;
+
   // Normal render — framework rows always present in DOM regardless of error
   // state (IR-006). Error indicator is inline above the rows so existing
   // testids remain discoverable. When isError=true, trajectory is null so
@@ -205,6 +279,16 @@ export function FourFrameworkZone1D({
         const color = FRAMEWORK_COLORS[key as keyof typeof FRAMEWORK_COLORS] ?? "#888";
         const isNull = score === null;
 
+        // ADR-015 §Component 1 — L0 annotation from trajectory confidence_tier + data-quality source
+        const trajectoryTier = point?.confidence_tier ?? null;
+        const dqFramework = dataQuality?.[key] ?? null;
+        const annotationText = buildFrameworkAnnotation(
+          key,
+          trajectoryTier,
+          dqFramework?.source_institution ?? null,
+          primaryEntityId,
+        );
+
         return (
           <div
             key={key}
@@ -215,13 +299,13 @@ export function FourFrameworkZone1D({
               justifyContent: "space-between",
               borderLeft: `3px solid ${color}`,
               paddingLeft: 6,
-              paddingTop: 3,
-              paddingBottom: 3,
+              paddingTop: 2,
+              paddingBottom: 2,
               borderLeftStyle: isNull ? "dashed" : "solid",
               opacity: isNull ? 0.6 : 1,
             }}
           >
-            <span style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            <span style={{ display: "flex", flexDirection: "column", gap: 0 }}>
               <span
                 data-testid={`framework-label-${key}`}
                 style={{
@@ -239,6 +323,13 @@ export function FourFrameworkZone1D({
                     1.0 = boundary
                   </span>
                 )}
+              </span>
+              {/* ADR-015 §Component 1 — L0 basis annotation (always visible at zero interaction) */}
+              <span
+                data-testid={`framework-annotation-${key}`}
+                style={{ fontSize: 8, color: "#aaa", lineHeight: 1.2 }}
+              >
+                {annotationText}
               </span>
               {/* "Primary dimension — see alerts →" navigation link (#745) */}
               {topAlertByFramework[key] && onSelectFrameworkAlert && (
@@ -294,6 +385,43 @@ export function FourFrameworkZone1D({
           </div>
         );
       })}
+
+      {/* ADR-015 §Component 3 — Political Feasibility row (programme_survival_probability).
+          Visible only when PE module is enabled. Absent entirely when PE is disabled. */}
+      {peEnabled && (
+        <div
+          data-testid="zone-1d-political-feasibility"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderLeft: "3px solid #7c3aed",
+            paddingLeft: 6,
+            paddingTop: 2,
+            paddingBottom: 2,
+          }}
+        >
+          <span style={{ fontSize: 11, color: "#555", fontWeight: 500 }}>
+            Political Feasibility
+          </span>
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: "#7c3aed",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {pspValue === undefined ? (
+              "—"
+            ) : pspValue === null ? (
+              <span style={{ color: "#cc0000", fontSize: 10 }}>— [computation error]</span>
+            ) : (
+              `${(parseFloat(pspValue) * 100).toFixed(0)}% [T${pspTier ?? 3} · political economy module]`
+            )}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -20,7 +20,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { useScenarioStepStore, type Zone1BAlert } from "../store/scenarioStepStore";
-import { getIndicatorDisplayNameAny } from "../lib/indicatorDisplayNames";
+import { getIndicatorDisplayNameAny, getIndicatorAbbreviation } from "../lib/indicatorDisplayNames";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -562,10 +562,7 @@ function CompactAlertList({ alerts, onClearNewBadge }: CompactAlertListProps) {
         const color = SEVERITY_COLOR[alert.severity];
         const sevAbbrev = SEVERITY_ABBREV[alert.severity];
         const fwAbbrev = FRAMEWORK_ABBREV[alert.framework] ?? alert.framework.toUpperCase().slice(0, 3);
-        const indicatorDisplay = truncateIndicatorName(
-          getIndicatorDisplayNameAny(alert.indicator_key),
-          18,
-        );
+        const indicatorDisplay = getIndicatorAbbreviation(alert.indicator_key, 24);
 
         return (
           <div

--- a/frontend/src/components/PMMWidgetZone1C.tsx
+++ b/frontend/src/components/PMMWidgetZone1C.tsx
@@ -147,6 +147,14 @@ export function PMMWidgetZone1C({
         </span>
       </div>
 
+      {/* Pre-calibration annotation — ADR-015 §Component 1 §Zone 1C (Decision 3 placeholder) */}
+      <div
+        data-testid="pmm-annotation"
+        style={{ fontSize: 9, color: "#aaa", marginTop: 2, lineHeight: 1.3 }}
+      >
+        [T3 composite · pre-cal]
+      </div>
+
       {/* Scale reference — lower value = more constrained policy space (DEMO-059) */}
       <div
         data-testid="pmm-scale-note"

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -37,7 +37,8 @@ import { CohortIndicatorsPanel } from "./CohortIndicatorsPanel";
 import { ControlPlane, type Mode3Params } from "./ControlPlane";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 import type { TrajectoryResponse, TrajectoryFrameworkPoint, Zone1BAlert } from "../store/scenarioStepStore";
-import type { QuantitySchema } from "../types";
+import type { QuantitySchema, ScenarioDetailResponse } from "../types";
+import type { FrameworkDataQuality } from "./FourFrameworkZone1D";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
@@ -203,6 +204,8 @@ interface ScenarioInstrumentClusterProps {
   fiscalMultiplier?: number | null;
   /** Mode 3 Active Control — when true, ControlPlane is rendered and branching is enabled. */
   mode3Active?: boolean;
+  /** ADR-015 §Component 2+3: scenario detail for AssumptionSurface and PE status. */
+  activeScenarioDetail?: ScenarioDetailResponse | null;
 }
 
 export function ScenarioInstrumentCluster({
@@ -213,6 +216,7 @@ export function ScenarioInstrumentCluster({
   comparisonScenarioId,
   fiscalMultiplier,
   mode3Active = false,
+  activeScenarioDetail,
 }: ScenarioInstrumentClusterProps) {
   const store = useScenarioStepStore();
   const bp = useViewportBreakpoint();
@@ -230,6 +234,14 @@ export function ScenarioInstrumentCluster({
     current: Record<string, QuantitySchema> | null;
     prev: Record<string, QuantitySchema> | null;
   }>({ current: null, prev: null });
+
+  // ADR-015 §Component 1 — data-quality per framework for Zone 1D L0 annotations (DA-G5-1).
+  const [dataQuality, setDataQuality] = useState<Record<string, FrameworkDataQuality> | null>(null);
+
+  // ADR-015 §Component 3 — programme_survival_probability from measurement-output (DA-G5-4 Option A).
+  // undefined = not yet fetched or PE not active; null = PE active but computation failed; string = value.
+  const [pspValue, setPspValue] = useState<string | null | undefined>(undefined);
+  const [pspTier, setPspTier] = useState<number | null>(null);
 
   // Mode 3 branch advance loop — abortController cancels in-flight advances on cleanup.
   const branchAbortRef = useRef<AbortController | null>(null);
@@ -333,6 +345,41 @@ export function ScenarioInstrumentCluster({
     return () => { cancelled = true; };
   }, [comparisonScenarioId]);
 
+  // ADR-015 §Component 1 — fetch data-quality for Zone 1D L0 source annotations (DA-G5-1).
+  // Triggered when entity_id becomes available from the trajectory response.
+  // Source institution is per-entity (not per-step), so one fetch per entity suffices.
+  useEffect(() => {
+    const entityId = store.trajectory?.entity_id;
+    const startYear = activeScenarioDetail?.configuration?.start_date
+      ? parseInt(activeScenarioDetail.configuration.start_date.slice(0, 4), 10)
+      : null;
+    if (!entityId || !startYear) return;
+    let cancelled = false;
+
+    fetch(
+      `${API_BASE}/entities/${encodeURIComponent(entityId)}/data-quality?year=${startYear}`
+    )
+      .then((res) => (res.ok ? (res.json() as Promise<{ frameworks: Array<{ framework: string; source_institution: string | null; data_vintage: string | null; confidence_tier?: number | null }> }>) : null))
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        const byFramework: Record<string, FrameworkDataQuality> = {};
+        for (const fw of raw.frameworks) {
+          byFramework[fw.framework] = {
+            source_institution: fw.source_institution,
+            data_vintage: fw.data_vintage,
+            confidence_tier: fw.confidence_tier ?? null,
+          };
+        }
+        setDataQuality(byFramework);
+      })
+      .catch(() => {
+        // Non-fatal — annotations degrade gracefully (no source name shown)
+      });
+
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
+  }, [store.trajectory?.entity_id, activeScenarioDetail?.configuration?.start_date]);
+
   // Fetch MDA alerts from measurement-output after each step advance (IR-001).
   // Entity ID comes from the trajectory response already fetched above.
   // Skipped at step 0 — no simulation output exists before the first advance.
@@ -368,6 +415,33 @@ export function ScenarioInstrumentCluster({
           // Atomic current→prev swap via functional updater — avoids stale closure
           setHdState((s) => ({ prev: s.current, current: flat }));
         }
+
+        // ADR-015 §Component 3 — extract programme_survival_probability (DA-G5-4 Option A).
+        const peOutput = raw.outputs["political_economy"];
+        const peEnabled = activeScenarioDetail?.configuration?.modules_config?.political_economy?.enabled;
+        if (peOutput && peEnabled) {
+          const pspEntry = peOutput.indicators["programme_survival_probability"];
+          if (
+            pspEntry !== null &&
+            pspEntry !== undefined &&
+            typeof pspEntry === "object" &&
+            "value" in pspEntry
+          ) {
+            const entry = pspEntry as { value: string | null; confidence_tier?: number | null };
+            setPspValue(entry.value);
+            setPspTier(
+              typeof entry.confidence_tier === "number" ? entry.confidence_tier : null,
+            );
+          } else {
+            // PE enabled but PSP indicator absent from output — treat as computation error
+            setPspValue(null);
+            setPspTier(null);
+          }
+        } else if (!peEnabled) {
+          // PE not enabled — reset PSP state so row is absent
+          setPspValue(undefined);
+          setPspTier(null);
+        }
       })
       .catch(() => {
         // Non-fatal — Zone 1B and cohort panel remain in previous state
@@ -377,7 +451,7 @@ export function ScenarioInstrumentCluster({
       cancelled = true;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
-  }, [scenarioId, currentStep, store.trajectory?.entity_id]);
+  }, [scenarioId, currentStep, store.trajectory?.entity_id, activeScenarioDetail?.configuration?.modules_config?.political_economy?.enabled]);
 
   // ---------------------------------------------------------------------------
   // Mode 3 — branch-and-recompute advance loop (G6b, Issue #753)
@@ -621,6 +695,10 @@ export function ScenarioInstrumentCluster({
             isLoading={trajectoryLoading}
             isError={trajectoryError}
             entityIds={entityIds}
+            dataQuality={dataQuality}
+            peEnabled={activeScenarioDetail?.configuration?.modules_config?.political_economy?.enabled ?? false}
+            pspValue={pspValue}
+            pspTier={pspTier}
           />
         }
         cohortPanel={

--- a/frontend/src/lib/indicatorDisplayNames.ts
+++ b/frontend/src/lib/indicatorDisplayNames.ts
@@ -89,3 +89,36 @@ export function getIndicatorDisplayNameAny(key: string): string {
   }
   return formatFallback(key);
 }
+
+/**
+ * 24-character abbreviation set for compact Zone 1B alert rows (ADR-015 §Component 1).
+ * Names that already fit within 24 chars use their full display name.
+ * Keys not present fall back to truncateIndicatorName(getIndicatorDisplayNameAny(key), 24).
+ */
+const INDICATOR_ABBREV_24: Record<string, string> = {
+  reserve_coverage_months:              "Reserve Coverage",
+  debt_gdp_ratio:                       "Debt-to-GDP Ratio",
+  poverty_headcount_ratio:              "Poverty Headcount Ratio",
+  food_insecurity_rate:                 "Food Insecurity Rate",
+  health_index:                         "Health Index",
+  planetary_boundary_co2_proximity:     "CO₂ Boundary Proximity",
+  planetary_boundary_land_use_proximity:"Land Use Boundary Prox.",
+  programme_survival_probability:       "Prog. Survival Prob.",
+  unemployment_rate:                    "Unemployment Rate",
+  bottom_quintile_consumption_capacity: "Bottom Quintile Consump.",
+  fiscal_balance_pct_gdp:               "Fiscal Balance % GDP",
+  inflation_rate:                       "Inflation Rate",
+  current_account_balance:              "Current Account Balance",
+  gdp_growth:                           "GDP Growth",
+};
+
+/**
+ * Returns the 24-char compact abbreviation for Zone 1B rows.
+ * Prefers the INDICATOR_ABBREV_24 registry; falls back to a standard truncation.
+ */
+export function getIndicatorAbbreviation(key: string, maxChars = 24): string {
+  if (key in INDICATOR_ABBREV_24) return INDICATOR_ABBREV_24[key];
+  const full = getIndicatorDisplayNameAny(key);
+  if (full.length <= maxChars) return full;
+  return full.slice(0, maxChars - 1) + "…";
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -73,6 +73,13 @@ export interface ScenarioConfigSchema {
   timestep_label: string;
   fiscal_multiplier?: number;
   start_date?: string;
+  // DA-G5-3: confirmed JSONB paths for political economy module configuration
+  modules_config?: {
+    political_economy?: {
+      enabled?: boolean;
+      conditionality_type?: "standard" | "strict" | "relaxed";
+    };
+  };
 }
 
 // ADR-016 Component 1 — Data quality preview response


### PR DESCRIPTION
## Summary

- **Zone 1D L0 annotations** (`framework-annotation-{fw}` testids): each of the four framework rows in Zone 1D now shows `[T{N} · {source} · pre-cal]` at zero interaction, using confidence tier from the trajectory response and source institution from the `/data-quality` endpoint. Ecological rows use a static breach-type mapping (DA-G5-5: JOR/ZMB→floor, GRC/EGY→ceiling). Null tier renders `[—]` (silent failure, AC-4).
- **Assumption surface strip** (`AssumptionSurface.tsx`): new single-line component rendered between `ScenarioIdentityHeader` (Zone 0) and the instrument cluster (Zone 1). Shows fiscal multiplier (when ≠1.0), PE enabled status, conditionality type, and data vintage derived from `start_date`. Renders `assumption-surface-unavailable` testid when configuration is empty (AC-8).
- **PMM annotation** (`pmm-annotation` testid): `[T3 composite · pre-cal]` placeholder added to Zone 1C (AC-13, Decision 3 placeholder until G6 Chief Methodologist anchor is filed).
- **HCL tier expansion** (`cohort-tier-{key}` testids): labels now render `[T{N} · {meaning}]` (e.g., `[T4 · model estimate]`) instead of raw `T4` (AC-14).
- **Zone 1B 24-char abbreviation** (`compact-alert-row`): compact rows now use `getIndicatorAbbreviation(key, 24)` from a registered abbreviation set instead of 18-char mid-word truncation (AC-12). `Reserve Coverage (months)` → `Reserve Coverage`.
- **Political Feasibility row** (`zone-1d-political-feasibility` testid): conditional fifth row in Zone 1D showing `programme_survival_probability` as a percentage from the measurement-output endpoint (DA-G5-4 Option A). Absent entirely when PE disabled; shows `[computation error]` when PE enabled but PSP returns null (AC-9/10/11).

## Scope reference

Intent document: `docs/process/intents/M14-G5-2026-06-17-adr015-frontend.md`
Sprint entry: `docs/process/sprint-plans/m14-g5-sprint-entry.md` (EL approved 2026-06-17)
QA tests (authored before implementation): `frontend/tests/e2e/m14-g5-adr015-frontend.spec.ts` (AC-1–AC-14)
Data Architect decisions: DA-G5-1 through DA-G5-5 (all confirmed 2026-06-18, `api_contracts.yml` updated)

## Test plan

- [ ] Frontend build: `cd frontend && npm run build` — clean (0 TS errors) ✅
- [ ] Unit tests: `npm test -- --run` — 264/264 pass ✅
- [ ] Playwright E2E: CI runs `m14-g5-adr015-frontend.spec.ts` (all 14 ACs; guard pattern — tests skip gracefully when testids are absent in unimplemented state)
- [ ] Step 4 Verify: dev server at 1280×900 — confirm all `framework-annotation-*` testids visible, `assumption-surface` present, `pmm-annotation` present, `cohort-tier-*` labels expanded, compact rows show full names
- [ ] AC-10: load a scenario without PE enabled — confirm `zone-1d-political-feasibility` is absent from DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)