### PR TITLE
chore(m14): rename milestone — Trust Architecture and Instrument Credibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Detailed domain profiles: `docs/agents/domain-intelligence-council.md`
 M0–M13 complete (v0.1.0–v0.12.1+). ADRs 001–014 current.
 See GitHub Releases for full delivery history.
 
-**Milestone 14 — Methodology Publication and External Validation (Current)**
+**Milestone 14 — Trust Architecture and Instrument Credibility (Current)**
 
 *Primary objective (M14 exit gate):*
 - Methodology publication — complete documentation of every model relationship, calibration assumption, and known limitation
@@ -333,7 +333,7 @@ The full roadmap covering M14 and beyond — milestone deliverables, demo anchor
 **Milestone 13 — Political Economy and Instrument Credibility (Complete)**
 Delivered: ADR-013 (political economy module boundary), political economy module (conditionality, elite capture, political feasibility), ADR-014 (alert panel Zone 1B master-detail), instrument legibility (DEMO-059–064), mode transition UX (step preservation), Process Redesign Phases 0–D.
 
-**Milestone 14 — Methodology Publication and External Validation (Current)**
+**Milestone 14 — Trust Architecture and Instrument Credibility (Current)**
 Core deliverable: Methodology publication, external validation by domain experts, live stakeholder demo with real external participants (#843), Technical Steering Committee formation. Demo 5 at M14 close.
 
 Full roadmap: `docs/roadmap/worldsim-roadmap.md`

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
 **Last updated: 2026-06-20 (G8 honest narration revision COMPLETE — PR #1078. EL decision: accept north star FAIL, retain M15 promises explicitly in narration. North star re-evaluation: PASS (conditional). Step 9 READY — pending EL scheduling of live Demo 5.)**
-**Current milestone:** M14 — Methodology Publication and External Validation (GitHub Milestone 15)
+**Current milestone:** M14 — Trust Architecture and Instrument Credibility (GitHub Milestone 15)
 **Previous milestone:** M13 — Political Economy and Instrument Credibility (formally closed 2026-06-15; release/m13 → main merged by EL; #264 closed)
 
 ---
@@ -599,7 +599,7 @@ CI hotfix: NM-035 filed; `ci.yml` PR trigger updated to include `release/m*` (PR
 
 ---
 
-## Open Issues — M14 (Methodology Publication and External Validation)
+## Open Issues — M14 (Trust Architecture and Instrument Credibility)
 
 **GitHub Milestone:** 15 | **Created:** 2026-06-11 | **Target:** Q2 2027 | **M14 is current milestone**
 *Board trimmed 2026-06-16 — 17 issues moved to M15/M16/M17 per panel deliberation. G6b/G6c added (design-only). #988/#989 filed for G7.*

--- a/docs/process/sprint-plans/m14-sprint-plan.md
+++ b/docs/process/sprint-plans/m14-sprint-plan.md
@@ -1,7 +1,7 @@
 ---
 name: m14-sprint-plan
 type: sprint-plan
-milestone: M14 — Methodology Publication and External Validation
+milestone: M14 — Trust Architecture and Instrument Credibility
 status: EL Approved — implementation may begin (sprint entry document required per group)
 authored-by: PM Agent
 authored-date: 2026-06-16
@@ -14,7 +14,7 @@ consulted-agents:
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
-# M14 Sprint Plan — Methodology Publication and External Validation
+# M14 Sprint Plan — Trust Architecture and Instrument Credibility
 
 **Status:** EL Approved 2026-06-16 — implementation may begin; sprint entry document required per group before implementation PR opens
 **Release branch:** `release/m14` (cut from `main` 2026-06-16)

--- a/docs/roadmap/worldsim-roadmap.md
+++ b/docs/roadmap/worldsim-roadmap.md
@@ -32,7 +32,7 @@
 | M11.5 | Usability Validation and Experience Audit | Priority A usability sessions; universal finding; M12 scope filed | Complete |
 | M12 | Active Control and External Sector | Matrix engine production, ExternalSectorModule (ADR-012), Mode 3, Demo 4 | Complete |
 | M13 | Political Economy and Instrument Credibility | ADR-013, political economy integration, ADR-014 alert panel UX, instrument legibility, mode transition UX, Process Redesign Phases 0–D | Complete |
-| M14 | Methodology Publication and External Validation | Methodology publication, external validation, live demo, TSC formation | Current |
+| M14 | Trust Architecture and Instrument Credibility | ADR-016 Grounding strip (source provenance), ADR-015 Evidence thread (Zone 1B credibility), PSP in Zone 1D, methodology foundation docs, Demo 5 | Current |
 | M15 | Human Cost Architecture | Zone 1A information architecture (ADR), cohort disaggregation design, political risk surface design, approved-source query (Path 1), accessibility validation | Planned |
 | M16 | Distributional Visibility | Demo 6: cohort-level distributional output, 25-year human capital trajectory, uncertainty quantification as bands, ecological transmission, Path 2 data upload | Planned |
 | M17 | Multi-Scenario Infrastructure | Multi-scenario comparison infrastructure (>2 scenarios), dynamic relationship weights, stock vs. flow at scale, entity template library design | Planned |
@@ -245,7 +245,7 @@ surface: any milestone entry with UNTRACKED items is an open kickoff gate.
 
 ---
 
-### Milestone 14 — Methodology Publication and External Validation *(current)*
+### Milestone 14 — Trust Architecture and Instrument Credibility *(current)*
 
 **Core deliverable:** WorldSim is ready for institutional adoption. The methodology is published, externally validated, and inspectable by anyone.
 


### PR DESCRIPTION
## Summary

Renames M14 from "Methodology Publication and External Validation" to **"Trust Architecture and Instrument Credibility"** — accurately reflecting what was delivered.

## Rationale

Previous name overstated delivery: external validation was simulated (not real participants), and full methodology publication was not completed. The new name maps directly to the actual M14 deliverables and the Demo 5 thesis ("WorldSim can be trusted").

## Files updated

- `CLAUDE.md` — "What We Are Building First" and "Milestone Roadmap" sections (×2)
- `SESSION_STATE.md` — header and M14 issues section (×2)
- `docs/roadmap/worldsim-roadmap.md` — milestone table title and deliverables column (×2)
- `docs/process/sprint-plans/m14-sprint-plan.md` — frontmatter and heading (×2)
- GitHub milestone 15 — title and description updated via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)