### PR TITLE
process(m15): record EL approval of M15 sprint plan

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-20 (HORIZON sweep complete — M15 sprint plan filed; release/m15 cut; ARCH-011/ADR-017 entered in backlog; four M15 issues filed (#1088–#1091); insights log entry 6 promoted. HARD STOP: EL approval of m15-sprint-plan.md required before any G-group sprint entry document can be filed.)**
+**Last updated: 2026-06-20 (M15 kickoff COMPLETE — release/m15 live; sprint plan EL-approved; KI-005 permanent fix applied (do_not_enforce_on_create: true); #984 renamed to 'M15 Exit Checklist'; implementation unblocked pending G-group sprint entry documents)**
 **Current milestone:** M15 — Human Cost Architecture (GitHub Milestone 16)
 **Previous milestone:** M14 — Trust Architecture and Instrument Credibility (FORMALLY CLOSED 2026-06-20; release/m14 → main PR #1086; v0.14.0 at https://github.com/PublicEnemage/worldsim/releases/tag/v0.14.0; #968 closed; GitHub Milestone 15 closed)
 
@@ -20,11 +20,12 @@
 |---|---|---|
 | 1. PM Agent cuts `release/m15` from `main` | ✅ DONE 2026-06-20 | `release/m15` at 500e50d |
 | 2. PM Agent authors `m15-sprint-plan.md` | ✅ DONE 2026-06-20 | Filed in PR opening; EL approval pending |
-| 3. EL approves sprint plan | ⬜ **NEXT REQUIRED ACTION** | Hard stop — no sprint entry docs until approved |
+| 3. EL approves sprint plan | ✅ **EL APPROVED 2026-06-20** | `docs/process/sprint-plans/m15-sprint-plan.md` |
 | 4. PM Agent marks ARCH-011 ASSIGNED in backlog | ⬜ At ADR-017 claim time | Added as PENDING_NUMBER; Architect claims when drafting begins |
-| 5. M15 exit checklist issue #984 confirmed | ⬜ EL to confirm | Note: title reads "Milestone 16 Exit Checklist" (GitHub milestone numbering); content is correct |
+| 5. M15 exit checklist issue #984 renamed | ✅ DONE 2026-06-20 | Renamed to "M15 Exit Checklist — blocks milestone closure" |
+| 6. KI-005 permanent fix applied | ✅ DONE 2026-06-20 | `do_not_enforce_on_create: true` on Ruleset 17751852; future release branches need no Ruleset workaround |
 
-**HARD STOP:** No implementation PR may open against `release/m15` until the EL has approved the sprint plan.
+Implementation is now unblocked. A sprint entry document must be filed and EL-approved before any G-group implementation PR opens.
 
 ---
 

--- a/docs/process/sprint-plans/m15-sprint-plan.md
+++ b/docs/process/sprint-plans/m15-sprint-plan.md
@@ -2,10 +2,10 @@
 name: m15-sprint-plan
 type: sprint-plan
 milestone: M15 — Human Cost Architecture
-status: Proposed — awaiting EL approval
+status: EL Approved — implementation may begin (sprint entry document required per group)
 authored-by: PM Agent
 authored-date: 2026-06-20
-el-approved: pending
+el-approved: 2026-06-20
 consulted-agents:
   - Business Product Owner (value prioritization and Demo 6 scope)
   - Frontend Architect (component grouping and ADR-015 Component 4 assessment)
@@ -16,7 +16,7 @@ sop-reference: docs/process/sprint-planning-sop.md
 
 # M15 Sprint Plan — Human Cost Architecture
 
-**Status:** Proposed — awaiting EL approval; HARD STOP on implementation until approved
+**Status:** EL Approved 2026-06-20 — implementation may begin; sprint entry document required per group before implementation PR opens
 **Release branch:** `release/m15` (cut from `main` 2026-06-20 at commit 500e50d)
 **Exit checklist issue:** #984 (note: title reads "Milestone 16 Exit Checklist" — follows GitHub milestone numbering; content is correct for M15)
 **Primary objective:** Zone 1A information architecture ADR + Layer 3 self-interpreting outputs (Zone 1B + Zone 1D) + live stakeholder demo with real external participants (#843) as M15 exit gate.
@@ -180,11 +180,11 @@ CI green and issue closure are necessary but not sufficient. #843 is the primary
 
 1. ✅ PM Agent cuts `release/m15` from `main` — DONE 2026-06-20
 2. ✅ PM Agent authors this sprint plan — DONE 2026-06-20
-3. ⬜ **EL approves sprint plan** — NEXT REQUIRED ACTION before any implementation sprint entry document can be filed
-4. ⬜ PM Agent marks ARCH-011 ASSIGNED in `docs/architecture/backlog.md`; derives panel composition
-5. ⬜ M15 Exit Checklist issue #984 confirmed as M15 gate (note: title says "Milestone 16 Exit Checklist" — EL to confirm this is acceptable or request rename)
+3. ✅ EL approves sprint plan — DONE 2026-06-20
+4. ⬜ PM Agent marks ARCH-011 ASSIGNED in `docs/architecture/backlog.md`; derives panel composition — at ADR-017 authorship time
+5. ✅ M15 Exit Checklist issue #984 renamed to "M15 Exit Checklist — blocks milestone closure" — DONE 2026-06-20
 
-**HARD STOP:** No implementation PR may open against `release/m15` until the EL has approved this sprint plan and a sprint entry document is filed for the relevant group.
+**EL approved 2026-06-20.** No implementation PR may open against `release/m15` until a sprint entry document is filed and EL-approved for the relevant group.
 
 ---
 


### PR DESCRIPTION
## Summary

- M15 sprint plan status updated to EL Approved (2026-06-20)
- Kickoff checklist items 3 and 5 marked complete (EL approval, #984 renamed)
- SESSION_STATE.md header updated: HARD STOP → implementation unblocked
- Kickoff prerequisites table updated with all completed EL actions

## EL actions recorded

- ✅ Sprint plan EL-approved (`docs/process/sprint-plans/m15-sprint-plan.md`)
- ✅ KI-005 permanent fix applied (`do_not_enforce_on_create: true` on Ruleset 17751852)
- ✅ Issue #984 renamed to "M15 Exit Checklist — blocks milestone closure"

M15 kickoff sequence is complete. G-group sprint entry documents may now be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)