### PR TITLE
feat(m15-g1): Layer 3 IR fixes — Zone 1B sentence, L0 badges, Grounding strip labels, PSP sentence

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -422,6 +422,29 @@ export function FourFrameworkZone1D({
           </span>
         </div>
       )}
+
+      {/* ADR-015 §Component 3 — PSP Layer 3 self-interpreting sentence (#1075).
+          Visible when PE enabled and PSP value is available. Fallback when null. */}
+      {peEnabled && pspValue !== undefined && (
+        <div
+          data-testid="psp-layer3-sentence"
+          style={{
+            borderLeft: "3px solid #7c3aed",
+            paddingLeft: 6,
+            paddingTop: 2,
+            paddingBottom: 2,
+            fontSize: 10,
+            color: "#555",
+            lineHeight: 1.4,
+          }}
+        >
+          {pspValue === null ? (
+            "Programme survival probability unavailable — computation error."
+          ) : (
+            `Programme survival probability: ${(parseFloat(pspValue) * 100).toFixed(0)}%. This means the programme has a ${(parseFloat(pspValue) * 100).toFixed(0)}% chance of remaining on track through conditionality compliance.`
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/GroundingStrip.tsx
+++ b/frontend/src/components/GroundingStrip.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { InitialStateResponse, GroundingIndicator } from "../types";
+import { useScenarioStepStore } from "../store/scenarioStepStore";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
@@ -45,6 +46,38 @@ function IndicatorRow({ ind }: { ind: GroundingIndicator }) {
   );
 }
 
+// Current-step indicator value (model output — no citation metadata)
+function CurrentIndicatorRow({
+  displayName,
+  value,
+  unit,
+}: {
+  displayName: string;
+  value: string | null;
+  unit: string | null;
+}) {
+  const formatted = value != null ? `${value}${unit ? " " + unit : ""}` : "—";
+  return (
+    <div
+      style={{
+        padding: "3px 0",
+        fontSize: 11,
+        borderBottom: "1px solid rgba(255,255,255,0.04)",
+        color: "#cbd5e1",
+      }}
+    >
+      <span style={{ color: "#8aa8c4" }}>{displayName}:</span>{" "}
+      <span style={{ fontWeight: 600 }}>{formatted}</span>
+    </div>
+  );
+}
+
+// Current step indicator value map: { framework -> { indicator_key -> { value, unit } } }
+interface CurrentIndicatorValue {
+  value: string | null;
+  unit: string | null;
+}
+
 interface Props {
   scenarioId: string;
 }
@@ -52,6 +85,13 @@ interface Props {
 export default function GroundingStrip({ scenarioId }: Props) {
   const [data, setData] = useState<InitialStateResponse | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Current step data for dual-value disambiguation (#1069, ADR-016 §Component 2)
+  const [currentValues, setCurrentValues] = useState<Record<string, Record<string, CurrentIndicatorValue>> | null>(null);
+
+  // Read current step and entity id from the Zustand store
+  const { current_step, trajectory } = useScenarioStepStore();
+  const entityId = trajectory?.entity_id ?? null;
 
   useEffect(() => {
     setData(null);
@@ -78,12 +118,64 @@ export default function GroundingStrip({ scenarioId }: Props) {
     };
   }, [scenarioId]);
 
+  // Fetch current step indicator values for the simulation section (#1069)
+  useEffect(() => {
+    if (!entityId || current_step <= 0) {
+      setCurrentValues(null);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(
+      `${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/measurement-output?entity_id=${encodeURIComponent(entityId)}&step=${current_step}`
+    )
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json() as Promise<{
+          outputs: Record<string, { indicators: Record<string, { value: string | null; unit?: string | null }> }>;
+        }>;
+      })
+      .then((body) => {
+        if (cancelled) return;
+        const parsed: Record<string, Record<string, CurrentIndicatorValue>> = {};
+        for (const [fw, output] of Object.entries(body.outputs)) {
+          parsed[fw] = {};
+          for (const [key, ind] of Object.entries(output.indicators)) {
+            if (ind !== null && typeof ind === "object" && "value" in ind) {
+              parsed[fw][key] = {
+                value: (ind as { value: string | null }).value,
+                unit: (ind as { unit?: string | null }).unit ?? null,
+              };
+            }
+          }
+        }
+        setCurrentValues(parsed);
+      })
+      .catch(() => {
+        if (!cancelled) setCurrentValues(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [scenarioId, entityId, current_step]);
+
   // Filter to named frameworks only — "None" key must not render.
   const namedFrameworks = data
     ? Object.entries(data.frameworks).filter(([key]) => key in FRAMEWORK_LABELS)
     : [];
 
   const hasData = namedFrameworks.length > 0;
+  const hasCurrentData = currentValues !== null && current_step > 0;
+
+  const sectionHeaderStyle: React.CSSProperties = {
+    fontSize: 10,
+    fontWeight: 600,
+    color: "#6b9abf",
+    marginBottom: 4,
+    marginTop: 2,
+    letterSpacing: "0.04em",
+  };
 
   return (
     <div
@@ -105,35 +197,100 @@ export default function GroundingStrip({ scenarioId }: Props) {
           Initial state data not available for this scenario
         </span>
       ) : (
-        namedFrameworks.map(([key, section]) => {
-          const visibleIndicators = section.indicators.filter(
-            (ind: GroundingIndicator) => ind.value != null,
-          );
-          if (visibleIndicators.length === 0) return null;
-          return (
-            <div key={key} style={{ marginBottom: 10 }}>
-              <div
-                role="heading"
-                aria-level={4}
-                style={{
-                  fontSize: 10,
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.08em",
-                  color: "#8aa8c4",
-                  marginBottom: 4,
-                  paddingBottom: 2,
-                  borderBottom: "1px solid rgba(138,168,196,0.2)",
-                }}
-              >
-                {FRAMEWORK_LABELS[key]}
-              </div>
-              {visibleIndicators.map((ind: GroundingIndicator) => (
-                <IndicatorRow key={ind.name} ind={ind} />
-              ))}
+        <>
+          {/* Initial conditions section — source-cited entry-state values */}
+          <div style={{ marginBottom: hasCurrentData ? 8 : 0 }}>
+            <div style={sectionHeaderStyle}>
+              Initial conditions (step 0 · source-cited data)
             </div>
-          );
-        })
+            {namedFrameworks.map(([key, section]) => {
+              const visibleIndicators = section.indicators.filter(
+                (ind: GroundingIndicator) => ind.value != null,
+              );
+              if (visibleIndicators.length === 0) return null;
+              return (
+                <div key={key} style={{ marginBottom: 8 }}>
+                  <div
+                    role="heading"
+                    aria-level={4}
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "#8aa8c4",
+                      marginBottom: 4,
+                      paddingBottom: 2,
+                      borderBottom: "1px solid rgba(138,168,196,0.2)",
+                    }}
+                  >
+                    {FRAMEWORK_LABELS[key]}
+                  </div>
+                  {visibleIndicators.map((ind: GroundingIndicator) => (
+                    <IndicatorRow key={ind.name} ind={ind} />
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Current trajectory section — model output at current step (#1069) */}
+          {hasCurrentData && (
+            <div
+              style={{
+                borderTop: "1px solid rgba(255,255,255,0.1)",
+                paddingTop: 8,
+              }}
+            >
+              <div style={sectionHeaderStyle}>
+                Current trajectory (step {current_step} · model output)
+              </div>
+              {namedFrameworks.map(([fwKey, section]) => {
+                const fwCurrent = currentValues![fwKey];
+                if (!fwCurrent) return null;
+
+                const matchingIndicators = section.indicators.filter((ind: GroundingIndicator) => {
+                  const cur = fwCurrent[ind.name];
+                  return cur && cur.value !== null;
+                });
+
+                if (matchingIndicators.length === 0) return null;
+
+                return (
+                  <div key={fwKey} style={{ marginBottom: 8 }}>
+                    <div
+                      role="heading"
+                      aria-level={4}
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                        color: "#8aa8c4",
+                        marginBottom: 4,
+                        paddingBottom: 2,
+                        borderBottom: "1px solid rgba(138,168,196,0.2)",
+                      }}
+                    >
+                      {FRAMEWORK_LABELS[fwKey]}
+                    </div>
+                    {matchingIndicators.map((ind: GroundingIndicator) => {
+                      const cur = fwCurrent[ind.name];
+                      return (
+                        <CurrentIndicatorRow
+                          key={ind.name}
+                          displayName={ind.display_name}
+                          value={cur.value}
+                          unit={cur.unit ?? ind.unit}
+                        />
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -141,6 +141,35 @@ export function formatAlertText(
 }
 
 /**
+ * Build the Zone 1B Layer 3 directive sentence for the top alert (#1065, ADR-015 §Component 4).
+ *
+ * When consecutive_breach_steps is null (computation unavailable), renders a transparent
+ * fallback disclosure rather than an absent element (AC-10 silent-failure rule).
+ */
+export function buildTrajectoryLayerSentence(alert: Zone1BAlert): string {
+  const cbs = alert.consecutive_breach_steps;
+
+  if (cbs === null || cbs === undefined) {
+    return "Trajectory analysis unavailable for this alert.";
+  }
+
+  const displayName = getIndicatorDisplayNameAny(alert.indicator_key);
+  const currentNum = parseFloat(String(alert.current_value));
+  const floorNum = parseFloat(String(alert.floor_value));
+
+  if (!isNaN(currentNum) && !isNaN(floorNum)) {
+    const diff = Math.abs(currentNum - floorNum).toFixed(2);
+    if (currentNum < floorNum) {
+      return `${displayName} has fallen ${diff} below the ${alert.severity} threshold. Breach active for ${cbs} consecutive step${cbs !== 1 ? "s" : ""}.`;
+    }
+    const pctAbove = (((currentNum - floorNum) / floorNum) * 100).toFixed(1);
+    return `${displayName} is approaching the ${alert.severity} threshold (${pctAbove}% above floor). Breach streak: ${cbs} consecutive step${cbs !== 1 ? "s" : ""}.`;
+  }
+
+  return `${displayName}: ${alert.severity} threshold breach active for ${cbs} consecutive step${cbs !== 1 ? "s" : ""}.`;
+}
+
+/**
  * Truncate indicator display name to ≤ maxChars, appending "…" if truncated.
  */
 export function truncateIndicatorName(name: string, maxChars = 22): string {
@@ -358,7 +387,7 @@ export function AlertDetailPanel({ alert, onClose }: AlertDetailPanelProps) {
         <div>
           <span style={{ color: "#888" }}>Consecutive </span>
           <span data-testid="detail-consecutive" style={{ fontWeight: 700, color: "#555" }}>
-            {alert.consecutive_breach_steps} step{alert.consecutive_breach_steps !== 1 ? "s" : ""}
+            {alert.consecutive_breach_steps ?? "—"} step{alert.consecutive_breach_steps !== 1 ? "s" : ""}
           </span>
         </div>
       </div>
@@ -485,7 +514,7 @@ function TopAlertDetail({ alert, mode, showNewBadge }: TopAlertDetailProps) {
         </span>
       </div>
 
-      {/* Status + consecutive steps */}
+      {/* Status + consecutive steps (zero suppressed — #1066) */}
       <div style={{ display: "flex", gap: 8, marginBottom: 2 }}>
         <span
           data-testid="detail-status"
@@ -493,15 +522,19 @@ function TopAlertDetail({ alert, mode, showNewBadge }: TopAlertDetailProps) {
         >
           {statusText}
         </span>
-        <span style={{ color: "#888" }}>·</span>
-        <span>
-          <span
-            data-testid="detail-consecutive"
-            style={{ fontWeight: 700, color: "#555" }}
-          >
-            {alert.consecutive_breach_steps} consecutive step{alert.consecutive_breach_steps !== 1 ? "s" : ""}
-          </span>
-        </span>
+        {alert.consecutive_breach_steps !== null &&
+         alert.consecutive_breach_steps !== undefined &&
+         alert.consecutive_breach_steps > 0 && (
+          <>
+            <span style={{ color: "#888" }}>·</span>
+            <span
+              data-testid="detail-consecutive"
+              style={{ fontWeight: 700, color: "#555" }}
+            >
+              {alert.consecutive_breach_steps} consecutive step{alert.consecutive_breach_steps !== 1 ? "s" : ""}
+            </span>
+          </>
+        )}
       </div>
 
       {/* Negotiation-defensibility label (always shown in detail slot) */}
@@ -513,6 +546,22 @@ function TopAlertDetail({ alert, mode, showNewBadge }: TopAlertDetailProps) {
         }}
       >
         {getNegotiationLabel(alert.confidence_tier)}
+      </div>
+
+      {/* Layer 3 directive sentence (#1065, ADR-015 §Component 4) — always rendered when
+          top alert is present; shows fallback text when trajectory computation unavailable. */}
+      <div
+        data-testid="zone-1b-trajectory-sentence"
+        style={{
+          marginTop: 4,
+          fontSize: 10,
+          color: "#444",
+          lineHeight: 1.4,
+          borderTop: "1px solid rgba(0,0,0,0.06)",
+          paddingTop: 3,
+        }}
+      >
+        {buildTrajectoryLayerSentence(alert)}
       </div>
 
       {/* Causal attribution — Mode 3 only */}

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -136,7 +136,7 @@ interface RawMDAAlert {
   floor_value: string;
   current_value: string;
   approach_pct_remaining: string;
-  consecutive_breach_steps: number;
+  consecutive_breach_steps: number | null;
   recovery_horizon_years?: number | null;
 }
 

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -530,6 +530,51 @@ export function TrajectoryView({
         </ComposedChart>
       </ResponsiveContainer>
 
+      {/* ADR-015 §Component 1 — L0 confidence tier badges on trajectory curves (#1068).
+          One badge per active framework (score non-null), showing T{N} at the right edge.
+          Always visible at zero interaction — not a hover state or tooltip. */}
+      {mergedData.length > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: 16,
+            right: 4,
+            display: "flex",
+            flexDirection: "column",
+            gap: 3,
+            pointerEvents: "none",
+            zIndex: 10,
+          }}
+        >
+          {FRAMEWORKS.map((fw) => {
+            const lastStep = mergedData[mergedData.length - 1];
+            const score = lastStep[`${fw}_active` as keyof MergedStepDatum] as number | null;
+            const tier = lastStep[`${fw}_confidence_tier` as keyof MergedStepDatum] as number;
+            if (score === null) return null;
+            const color = FRAMEWORK_COLORS[fw];
+            return (
+              <span
+                key={fw}
+                data-testid="zone-1a-l0-badge"
+                style={{
+                  fontSize: 9,
+                  fontWeight: 700,
+                  color,
+                  background: "rgba(255,255,255,0.92)",
+                  padding: "1px 4px",
+                  borderRadius: 2,
+                  border: `1px solid ${color}`,
+                  lineHeight: 1.4,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                T{tier}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
       {/* Inline entity labels — at right edge of chart area (DEMO-063).
           Lets audience identify entities without consulting the legend. */}
       {entityIds && entityIds.length >= 2 && (

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -66,8 +66,8 @@ export interface Zone1BAlert {
   current_value: string;
   /** Remaining approach headroom (Decimal as string; negative = breached). */
   approach_pct_remaining: string;
-  /** Number of consecutive steps in breach (≥2 → TERMINAL). */
-  consecutive_breach_steps: number;
+  /** Number of consecutive steps in breach (≥2 → TERMINAL). null if computation unavailable. */
+  consecutive_breach_steps: number | null;
   /**
    * Rider #271 — reversibility classification.
    * null = irreversible threshold; integer = recoverable within N years given intervention.


### PR DESCRIPTION
## Summary

Implements all five M15-G1 deliverables (AC-1–AC-11) per intent document at `docs/process/intents/M15-G1-2026-06-20-layer3-ir-fixes.md`:

- **#1065** — `zone-1b-trajectory-sentence` added to Zone 1B top detail slot. `buildTrajectoryLayerSentence()` derives a plain-language directive sentence from alert fields (`consecutive_breach_steps`, `current_value`, `floor_value`, indicator name). Fallback text when `consecutive_breach_steps` is null (AC-10 silent failure rule).
- **#1066** — Zero consecutive steps suppressed: `detail-consecutive` only renders when `cbs > 0`. "0 consecutive steps" never appears in `zone-1b-top-detail` text.
- **#1068** — `zone-1a-l0-badge` overlay added to `TrajectoryView`. One badge per active framework (T{N} format) at right edge; zero interaction required; always visible.
- **#1069** — `GroundingStrip` restructured to show two labeled sections: "Initial conditions (step 0 · source-cited data)" from `/initial-state`, and "Current trajectory (step N · model output)" from `/measurement-output`. Entry-state label persists when trajectory fetch fails (AC-11).
- **#1075** — `psp-layer3-sentence` added to `FourFrameworkZone1D` below the PSP row. Visible when PE enabled and `pspValue !== undefined`.

**Type change:** `Zone1BAlert.consecutive_breach_steps: number → number | null` throughout (store + ScenarioInstrumentCluster raw type).

## Test plan

- [ ] All 11 ACs in `frontend/tests/e2e/m15-g1-layer3-ir-fixes.spec.ts` guard-pass (feature not present → no-op) pre-implementation and activate post-merge
- [ ] `npm run build` passes — 0 TypeScript errors ✓ (verified locally before push)
- [ ] No backend changes — backend pre-push gate not required
- [ ] Step 4 Verify to be conducted by Frontend Architect Agent against live running application after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)