### PR TITLE
fix(m15-g1): guard getIndicatorDisplayNameAny against undefined indicator_key (NM-046)

### DIFF
--- a/frontend/src/lib/indicatorDisplayNames.ts
+++ b/frontend/src/lib/indicatorDisplayNames.ts
@@ -84,6 +84,7 @@ export function getIndicatorDisplayName(framework: string, key: string): string 
  *  framework blocks, falling back to title-cased key. Used by surfaces that have
  *  the attribute key but not the framework (e.g. AttributeSelector). */
 export function getIndicatorDisplayNameAny(key: string): string {
+  if (!key) return "Indicator"; // defensive: guard against null/undefined (NM-046)
   for (const block of Object.values(INDICATOR_DISPLAY_NAMES)) {
     if (key in block) return block[key];
   }


### PR DESCRIPTION
## Summary

- Adds a one-line null guard at the entry point of `getIndicatorDisplayNameAny` in `indicatorDisplayNames.ts`
- Real API always provides `indicator_key` (required field in `RawMDAAlert`), so production code is unaffected
- The guard prevents a crash when QA test mocks use `alert_id`/`indicator_id` field names (matching the test's `MDAAlert` interface) rather than `mda_id`/`indicator_key` (matching `RawMDAAlert`)
- Without this guard, `formatFallback(undefined)` → `TypeError: Cannot read properties of undefined (reading 'replace')` → React tree unmount → AC-7 toggle button detaches → 30s Playwright timeout
- Protects all three Zone 1B call sites (AlertDetailPanel, TopAlertDetail, buildTrajectoryLayerSentence) at a single point

## Root cause (NM-046)

The AC-7 QA test's mock factory `makeReserveAlert` uses `alert_id`/`indicator_id` field names matching the test file's own `MDAAlert` interface. `parseMdaAlerts` reads `alert.indicator_key` (undefined) and `alert.mda_id` (undefined). All three render paths in Zone 1B then called `getIndicatorDisplayNameAny(undefined)` → crash → app unmount.

## Test plan

- `npx playwright test tests/e2e/m15-g1-layer3-ir-fixes.spec.ts` — 11/11 passing (was 10/11 before this fix)
- `npm run build` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)