### PR TITLE
feat(m15-g4): frontend Path 1 entity selector + fidelity contextualisation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -290,7 +290,7 @@ export default function App() {
         />
       )}
 
-      {fidelityOpen && <FidelityDashboard />}
+      {fidelityOpen && <FidelityDashboard scenarioId={selectedScenarioId} />}
 
       {groundingOpen && selectedScenarioId && (
         <GroundingStrip scenarioId={selectedScenarioId} />

--- a/frontend/src/components/DataQualityPreview.tsx
+++ b/frontend/src/components/DataQualityPreview.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import type { DataQualityResponse, DataQualityFramework } from "../types";
+import { useEffect, useState, useRef } from "react";
+import type { DataQualityResponse, DataQualityFramework, PullJobResponse, PullJobStatusResponse } from "../types";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
@@ -28,7 +28,7 @@ function TierBadge({ tier }: { tier: number }) {
   );
 }
 
-function FrameworkRow({ fw }: { fw: DataQualityFramework }) {
+function FrameworkRow({ fw, onLoad }: { fw: DataQualityFramework; onLoad?: () => void }) {
   const label = FRAMEWORK_LABELS[fw.framework] ?? fw.framework;
   const citation = [fw.source_institution, fw.data_vintage].filter(Boolean).join(" · ");
   return (
@@ -50,6 +50,14 @@ function FrameworkRow({ fw }: { fw: DataQualityFramework }) {
             <span style={{ color: "#f87171" }}>synthetic</span>
             {fw.synthetic_basis ? ` — ${fw.synthetic_basis}` : ""}
           </>
+        ) : fw.loadable ? (
+          <span
+            style={{ color: "#fbbf24", cursor: onLoad ? "pointer" : "default" }}
+            onClick={onLoad}
+            title="Click to load data for this entity"
+          >
+            {citation ? `${citation} · ` : ""}available — click to load
+          </span>
         ) : (
           citation || "—"
         )}
@@ -61,34 +69,98 @@ function FrameworkRow({ fw }: { fw: DataQualityFramework }) {
 interface Props {
   entityId: string;
   year: number;
+  onPullComplete?: () => void;
 }
 
-export default function DataQualityPreview({ entityId, year }: Props) {
+export default function DataQualityPreview({ entityId, year, onPullComplete }: Props) {
   const [data, setData] = useState<DataQualityResponse | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const [pulling, setPulling] = useState(false);
+  const [pullStatus, setPullStatus] = useState<string | null>(null);
+  const [pullError, setPullError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => {
+  const fetchData = () => {
     if (!entityId || !year) return;
     setData(null);
     setUnavailable(false);
 
-    let cancelled = false;
     fetch(`${API_BASE}/entities/${encodeURIComponent(entityId)}/data-quality?year=${year}`)
       .then((res) => {
         if (!res.ok) throw new Error(`${res.status}`);
         return res.json() as Promise<DataQualityResponse>;
       })
-      .then((body) => {
-        if (!cancelled) setData(body);
-      })
-      .catch(() => {
-        if (!cancelled) setUnavailable(true);
-      });
+      .then((body) => setData(body))
+      .catch(() => setUnavailable(true));
+  };
 
+  useEffect(() => {
+    fetchData();
+    // Cancel any active pull when entity/year changes
+    setPulling(false);
+    setPullStatus(null);
+    setPullError(null);
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, [entityId, year]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     return () => {
-      cancelled = true;
+      if (pollRef.current) clearInterval(pollRef.current);
     };
-  }, [entityId, year]);
+  }, []);
+
+  const handlePull = async () => {
+    if (pulling || !entityId || !year) return;
+    setPulling(true);
+    setPullStatus("queued");
+    setPullError(null);
+
+    try {
+      const res = await fetch(
+        `${API_BASE}/entities/${encodeURIComponent(entityId)}/pull?year=${year}`,
+        { method: "POST" }
+      );
+      if (!res.ok) throw new Error(`Pull request failed: ${res.status}`);
+      const job = await res.json() as PullJobResponse;
+      setPullStatus(job.status);
+
+      // Poll until complete or failed
+      pollRef.current = setInterval(async () => {
+        try {
+          const pollRes = await fetch(
+            `${API_BASE}/entities/${encodeURIComponent(entityId)}/pull/${encodeURIComponent(job.job_id)}`
+          );
+          if (!pollRes.ok) return;
+          const statusData = await pollRes.json() as PullJobStatusResponse;
+          setPullStatus(statusData.status);
+
+          if (statusData.status === "complete") {
+            if (pollRef.current) clearInterval(pollRef.current);
+            pollRef.current = null;
+            setPulling(false);
+            fetchData();
+            onPullComplete?.();
+          } else if (statusData.status === "failed") {
+            if (pollRef.current) clearInterval(pollRef.current);
+            pollRef.current = null;
+            setPulling(false);
+            setPullError(statusData.error ?? "Pull failed");
+          }
+        } catch {
+          // poll errors are transient — continue polling
+        }
+      }, 3000);
+    } catch (err) {
+      setPulling(false);
+      setPullStatus("failed");
+      setPullError(err instanceof Error ? err.message : "Pull failed");
+    }
+  };
+
+  const hasLoadable = data?.frameworks.some((fw) => fw.loadable) ?? false;
 
   return (
     <div
@@ -119,10 +191,75 @@ export default function DataQualityPreview({ entityId, year }: Props) {
             {data.entity_id} · {data.year}
           </div>
           {data.frameworks.map((fw) => (
-            <FrameworkRow key={fw.framework} fw={fw} />
+            <FrameworkRow
+              key={fw.framework}
+              fw={fw}
+              onLoad={fw.loadable ? () => void handlePull() : undefined}
+            />
           ))}
+
+          {hasLoadable && !pulling && pullStatus !== "complete" && (
+            <button
+              data-testid="data-pull-action"
+              onClick={() => void handlePull()}
+              style={{
+                marginTop: 6,
+                fontSize: 11,
+                background: "rgba(59,130,246,0.15)",
+                border: "1px solid rgba(59,130,246,0.4)",
+                borderRadius: 3,
+                color: "#93c5fd",
+                padding: "3px 8px",
+                cursor: "pointer",
+                width: "100%",
+              }}
+            >
+              Load data for {entityId} {year}
+            </button>
+          )}
+
+          {pulling && (
+            <div
+              data-testid="data-pull-progress"
+              style={{
+                marginTop: 6,
+                fontSize: 11,
+                color: "#fbbf24",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  border: "2px solid #fbbf24",
+                  borderTopColor: "transparent",
+                  animation: "spin 0.8s linear infinite",
+                }}
+              />
+              Pulling data{pullStatus ? ` — ${pullStatus}` : ""}…
+            </div>
+          )}
+
+          {pullError && (
+            <div style={{ marginTop: 4, fontSize: 11, color: "#f87171" }}>
+              Pull failed: {pullError}
+            </div>
+          )}
+
+          {pullStatus === "complete" && !pulling && (
+            <div style={{ marginTop: 4, fontSize: 11, color: "#6ee7b7" }}>
+              Data loaded ✓
+            </div>
+          )}
         </>
       )}
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
     </div>
   );
 }

--- a/frontend/src/components/FidelityDashboard.tsx
+++ b/frontend/src/components/FidelityDashboard.tsx
@@ -12,7 +12,15 @@
  * Data is hardcoded — this is methodology documentation alongside outputs,
  * not a live status board. Values are sourced from the backtesting_thresholds
  * table migrations (c7e2a9f4d1b8, a3d9e7c2f4b1, and related migrations).
+ *
+ * M15-G4: Added scenarioId prop; fidelity-context API fetch for dynamic
+ * contextualisation (AC-11/12/13 from the intent document).
  */
+
+import { useEffect, useState } from "react";
+import type { FidelityContextResponse, AnalogousCase } from "../types";
+
+const API_BASE = "http://localhost:8000/api/v1";
 
 interface StepResult {
   step: number;
@@ -310,13 +318,78 @@ function CaseRow({ c }: { c: CrisisCase }) {
   );
 }
 
+// ─── M15-G4: Analogous case contextualisation sub-component ──────────────────
+
+function AnalogousCaseSection({ entityId, analogousCase }: {
+  entityId: string;
+  analogousCase: AnalogousCase;
+}) {
+  const validated = analogousCase.directional_accuracy_validated;
+  const magnitudeValidated = analogousCase.magnitude_validated;
+  return (
+    <div>
+      <span style={{ color: "#93c5fd", fontWeight: 600 }}>
+        For your scenario ({entityId}):
+      </span>{" "}
+      The most analogous validation case is{" "}
+      <span style={{ color: "#e2e8f0", fontWeight: 600 }}>
+        {analogousCase.case_name}
+      </span>{" "}
+      ({analogousCase.mechanism_match}){" "}
+      {validated ? (
+        <span style={{ color: "#6ee7b7" }}>
+          Directional accuracy has been validated for this crisis mechanism type (5/5 direction checks passed).
+        </span>
+      ) : (
+        <span style={{ color: "#fbbf24" }}>
+          Directional accuracy not yet validated for this entity type.
+        </span>
+      )}{" "}
+      {magnitudeValidated ? (
+        <span>Magnitude has been validated.</span>
+      ) : (
+        <span style={{ color: "#94a3b8" }}>
+          Magnitude has not been validated at this entity type.
+        </span>
+      )}{" "}
+      <span style={{ color: "#64748b" }}>
+        Use outputs for {analogousCase.use_for}; confirm magnitude estimates with country-specific
+        analysis before citing at a negotiating table.
+      </span>
+    </div>
+  );
+}
+
 // ─── Main component ────────────────────────────────────────────────────────────
 
-export default function FidelityDashboard() {
+interface FidelityDashboardProps {
+  scenarioId: string | null;
+}
+
+export default function FidelityDashboard({ scenarioId }: FidelityDashboardProps) {
   const totalStepChecks = CASES.reduce((n, c) => n + c.steps.length, 0);
   const magnitudePasses = CASES.flatMap((c) =>
     c.steps.filter((s) => s.thresholdType === "MAGNITUDE" && s.status === "PASS"),
   ).length;
+
+  // M15-G4: Fetch scenario-specific fidelity context when a scenario is active
+  const [fidelityContext, setFidelityContext] = useState<FidelityContextResponse | null>(null);
+
+  useEffect(() => {
+    if (!scenarioId) {
+      setFidelityContext(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/fidelity-context`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json() as Promise<FidelityContextResponse>;
+      })
+      .then((data) => { if (!cancelled) setFidelityContext(data); })
+      .catch(() => { /* silent — static fallback text shows */ });
+    return () => { cancelled = true; };
+  }, [scenarioId]);
 
   return (
     <div
@@ -389,7 +462,7 @@ export default function FidelityDashboard() {
         </div>
       </div>
 
-      {/* IC-4 — static scope contextualisation header (ADR-016 §EL Decision 2) */}
+      {/* IC-4 — contextualisation header; static fallback or scenario-specific (M15-G4) */}
       <div
         data-testid="fidelity-contextualisation"
         style={{
@@ -401,8 +474,19 @@ export default function FidelityDashboard() {
           lineHeight: 1.5,
         }}
       >
-        This panel validates model relationships using historical cases — not input data
-        for the active scenario.
+        {fidelityContext === null ? (
+          // No scenario loaded or still loading — show static fallback
+          "This panel validates model relationships using historical cases — not input data for the active scenario."
+        ) : fidelityContext.analogous_case === null ? (
+          // No analogous case identified — verbatim SF-3 fallback (AC-13)
+          "No analogous validation case identified for this scenario type. Global backtesting results apply — see validation cases below."
+        ) : (
+          // Scenario-specific contextualisation (AC-11/12)
+          <AnalogousCaseSection
+            entityId={fidelityContext.entity_id}
+            analogousCase={fidelityContext.analogous_case}
+          />
+        )}
       </div>
 
       {/* Framing note */}

--- a/frontend/src/components/ScenarioPanel.tsx
+++ b/frontend/src/components/ScenarioPanel.tsx
@@ -4,6 +4,23 @@ import type { ScenarioDetailResponse, ScenarioResponse } from "../types";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
+// Entity name mapping for the searchable selector (M15-G4)
+const ENTITY_NAMES: Record<string, string> = {
+  GRC: "Greece", JOR: "Jordan", EGY: "Egypt", ZMB: "Zambia",
+  SEN: "Senegal", GHA: "Ghana", KEN: "Kenya", ETH: "Ethiopia",
+  TZA: "Tanzania", UGA: "Uganda", CMR: "Cameroon", CIV: "Côte d'Ivoire",
+  MOZ: "Mozambique", ZWE: "Zimbabwe", PAK: "Pakistan", BGD: "Bangladesh",
+  NPL: "Nepal", LKA: "Sri Lanka", MMR: "Myanmar", KHM: "Cambodia",
+  LAO: "Laos", IDN: "Indonesia", PHL: "Philippines", VNM: "Vietnam",
+  BRA: "Brazil", ARG: "Argentina", COL: "Colombia", PER: "Peru",
+  ECU: "Ecuador", BOL: "Bolivia", PRY: "Paraguay", URY: "Uruguay",
+  VEN: "Venezuela", LBN: "Lebanon", TUN: "Tunisia", MAR: "Morocco",
+  DZA: "Algeria", SDN: "Sudan", YEM: "Yemen", IRQ: "Iraq",
+  PSE: "Palestine",
+};
+
+const ALL_ENTITIES = Object.keys(ENTITY_NAMES);
+
 interface Props {
   selectedScenarioId: string | null;
   secondScenarioId: string | null;
@@ -23,6 +40,8 @@ export default function ScenarioPanel({
   const [listError, setListError] = useState<string | null>(null);
   const [createName, setCreateName] = useState("");
   const [createEntity, setCreateEntity] = useState("GRC");
+  const [entitySearch, setEntitySearch] = useState("GRC — Greece");
+  const [entityDropdownOpen, setEntityDropdownOpen] = useState(false);
   const [createStartYear, setCreateStartYear] = useState(2020);
   const [createFiscalMultiplier, setCreateFiscalMultiplier] = useState(1.0);
   const [creating, setCreating] = useState(false);
@@ -111,6 +130,11 @@ export default function ScenarioPanel({
     }
   };
 
+  const filteredEntities = ALL_ENTITIES.filter((code) => {
+    const q = entitySearch.toUpperCase();
+    return code.startsWith(q) || (ENTITY_NAMES[code] ?? "").toUpperCase().includes(q);
+  }).slice(0, 10);
+
   return (
     <div className="scenario-panel">
       <div className="scenario-panel-inner">
@@ -191,19 +215,72 @@ export default function ScenarioPanel({
               }}
               disabled={creating}
             />
-            <select
-              className="scenario-create-input scenario-create-input--entity"
-              data-testid="entity-selector"
-              value={createEntity}
-              onChange={(e) => setCreateEntity(e.target.value)}
-              disabled={creating}
-              aria-label="Entity"
-            >
-              <option value="GRC">GRC</option>
-              <option value="JOR">JOR</option>
-              <option value="EGY">EGY</option>
-              <option value="ZMB">ZMB</option>
-            </select>
+
+            {/* Searchable entity selector (M15-G4) */}
+            <div style={{ position: "relative" }}>
+              <input
+                className="scenario-create-input scenario-create-input--entity"
+                data-testid="entity-selector"
+                type="text"
+                placeholder="Entity (e.g. ZMB, SEN)"
+                value={entitySearch}
+                onChange={(e) => {
+                  setEntitySearch(e.target.value);
+                  setEntityDropdownOpen(true);
+                }}
+                onFocus={() => setEntityDropdownOpen(true)}
+                onBlur={() => setTimeout(() => setEntityDropdownOpen(false), 150)}
+                disabled={creating}
+                aria-label="Entity"
+                autoComplete="off"
+              />
+              {entityDropdownOpen && entitySearch.length > 0 && (
+                <div
+                  style={{
+                    position: "absolute",
+                    top: "100%",
+                    left: 0,
+                    right: 0,
+                    background: "#0f1f33",
+                    border: "1px solid rgba(100,148,200,0.3)",
+                    borderRadius: 4,
+                    maxHeight: 160,
+                    overflowY: "auto",
+                    zIndex: 100,
+                  }}
+                >
+                  {filteredEntities.map((code) => (
+                    <div
+                      key={code}
+                      role="option"
+                      data-testid={`entity-option-${code}`}
+                      aria-selected={createEntity === code}
+                      style={{
+                        padding: "4px 8px",
+                        fontSize: 12,
+                        cursor: "pointer",
+                        color: "#cbd5e1",
+                        background: createEntity === code ? "rgba(59,130,246,0.15)" : "transparent",
+                      }}
+                      onMouseDown={() => {
+                        setCreateEntity(code);
+                        setEntitySearch(`${code} — ${ENTITY_NAMES[code] ?? code}`);
+                        setEntityDropdownOpen(false);
+                      }}
+                    >
+                      <span style={{ fontWeight: 700 }}>{code}</span>
+                      {ENTITY_NAMES[code] ? ` — ${ENTITY_NAMES[code]}` : ""}
+                    </div>
+                  ))}
+                  {filteredEntities.length === 0 && (
+                    <div style={{ padding: "4px 8px", fontSize: 12, color: "#64748b" }}>
+                      No matching entities
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             <input
               className="scenario-create-input scenario-create-input--year"
               type="number"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -90,12 +90,45 @@ export interface DataQualityFramework {
   data_vintage: string | null;
   is_synthetic: boolean;
   synthetic_basis: string | null;
+  loadable: boolean;           // G4: true if registered but not yet pulled
+  load_action_available: boolean; // G4: true when loadable is true
 }
 
 export interface DataQualityResponse {
   entity_id: string;
   year: number;
   frameworks: DataQualityFramework[];
+}
+
+// M15-G4 Path 1 — Pull job and fidelity contextualisation types
+export interface PullJobResponse {
+  job_id: string;
+  entity_id: string;
+  year: number;
+  status: "queued" | "running" | "complete" | "failed";
+}
+
+export interface PullJobStatusResponse {
+  job_id: string;
+  status: "queued" | "running" | "complete" | "failed";
+  frameworks_loaded: string[];
+  error: string | null;
+}
+
+export interface AnalogousCase {
+  case_id: string;
+  case_name: string;
+  mechanism_type: string;
+  mechanism_match: string;
+  directional_accuracy_validated: boolean;
+  magnitude_validated: boolean;
+  use_for: string;
+}
+
+export interface FidelityContextResponse {
+  scenario_id: string;
+  entity_id: string;
+  analogous_case: AnalogousCase | null;
 }
 
 // ADR-016 Component 2 — Initial state (Grounding Strip) response

--- a/frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts
+++ b/frontend/tests/e2e/m14-g1-prerequisite-bugs.spec.ts
@@ -111,15 +111,11 @@ test("AC-1: entity-selector present with options GRC, JOR, EGY, ZMB", async ({ p
 
   await expect(entitySelector).toBeVisible();
 
-  // Assert all four required entity options are present
-  const optionValues: string[] = await entitySelector
-    .locator("option")
-    .evaluateAll((opts: HTMLOptionElement[]) => opts.map((o) => o.value));
-
-  expect(optionValues).toContain("GRC");
-  expect(optionValues).toContain("JOR");
-  expect(optionValues).toContain("EGY");
-  expect(optionValues).toContain("ZMB");
+  // With the searchable combobox, verify each standard entity option is reachable by typing
+  for (const code of ["GRC", "JOR", "EGY", "ZMB"]) {
+    await entitySelector.fill(code);
+    await expect(page.locator(`[data-testid="entity-option-${code}"]`)).toBeVisible({ timeout: 2_000 });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -142,8 +138,9 @@ test("AC-2: selecting ZMB and creating scenario stores ZMB in configuration.enti
 
   const scenarioName = `G1-AC2-ZMB-${Date.now()}`;
 
-  // Select ZMB
-  await entitySelector.selectOption("ZMB");
+  // Select ZMB via combobox
+  await entitySelector.fill("ZMB");
+  await page.locator('[data-testid="entity-option-ZMB"]').click();
   await page.locator('input[placeholder="Scenario name"]').fill(scenarioName);
   await page.locator(".scenario-btn--create").click();
 
@@ -197,8 +194,9 @@ test("AC-3: selecting JOR and creating scenario stores JOR in configuration.enti
 
   const scenarioName = `G1-AC3-JOR-${Date.now()}`;
 
-  // Select JOR
-  await entitySelector.selectOption("JOR");
+  // Select JOR via combobox
+  await entitySelector.fill("JOR");
+  await page.locator('[data-testid="entity-option-JOR"]').click();
   await page.locator('input[placeholder="Scenario name"]').fill(scenarioName);
   await page.locator(".scenario-btn--create").click();
 

--- a/frontend/tests/e2e/m14-g4-adr016-frontend.spec.ts
+++ b/frontend/tests/e2e/m14-g4-adr016-frontend.spec.ts
@@ -71,7 +71,9 @@ async function selectEntityAndYear(
   entity: string,
   year: string,
 ): Promise<void> {
-  await page.locator('[data-testid="entity-selector"]').selectOption(entity);
+  const input = page.locator('[data-testid="entity-selector"]');
+  await input.fill(entity);
+  await page.locator(`[data-testid="entity-option-${entity}"]`).click();
   const yearInput = page.locator('[aria-label="Start year"]');
   await yearInput.fill(year);
   // Tab triggers the onChange / blur event to kick off the data-quality API call


### PR DESCRIPTION
## Summary

- **`types.ts`**: Extended `DataQualityFramework` with `loadable` + `load_action_available` fields (G4); added `PullJobResponse`, `PullJobStatusResponse`, `AnalogousCase`, `FidelityContextResponse` interfaces
- **`DataQualityPreview.tsx`**: Loadable state shows "available — click to load"; "Load data" button POSTs to `/pull`, polls every 3 seconds until complete/failed, shows spinner progress, refreshes data on complete
- **`ScenarioPanel.tsx`**: Replaced static 4-option `<select>` with searchable combobox; 41-entity `ENTITY_NAMES` map including SEN, ZMB, BGD, ETH, LBN and others; filters by ISO prefix OR name substring; `data-testid="entity-selector"` on input, `data-testid="entity-option-{code}"` on each dropdown item
- **`FidelityDashboard.tsx`**: Added `scenarioId: string | null` prop; fetches `/api/v1/scenarios/{id}/fidelity-context` on scenario change; `AnalogousCaseSection` sub-component for AC-11/12; three-state display: scenario-specific / no-case fallback / static fallback (AC-13)
- **`App.tsx`**: Passes `selectedScenarioId` as `scenarioId` to `FidelityDashboard`

## Pre-push gate

`cd frontend && npm run build` — passed, 0 TypeScript errors

## Test plan

- [ ] `data-testid="entity-selector"` input present in scenario create form
- [ ] Typing "SEN" in entity selector shows Senegal option (`data-testid="entity-option-SEN"`)
- [ ] Selecting an entity updates `DataQualityPreview` entity
- [ ] When API returns `loadable: true`, row shows "available — click to load" text
- [ ] "Load data" button (`data-testid="data-pull-action"`) appears when any framework is loadable
- [ ] Clicking load button shows progress spinner (`data-testid="data-pull-progress"`)
- [ ] `data-testid="fidelity-contextualisation"` shows static text when no scenario selected
- [ ] With scenario selected, fetches `/fidelity-context` and shows scenario-specific or fallback text

🤖 Generated with [Claude Code](https://claude.com/claude-code)