### PR TITLE
fix(m15-g5): grounding-strip date format + recompute-badge timing (#1083, #1007)

### DIFF
--- a/frontend/src/components/GroundingStrip.tsx
+++ b/frontend/src/components/GroundingStrip.tsx
@@ -13,12 +13,51 @@ const FRAMEWORK_LABELS: Record<string, string> = {
   political_economy: "Political Economy",
 };
 
+// Month abbreviations for Q1–Q4 (start-of-quarter convention).
+const QUARTER_MONTHS = ["Jan", "Apr", "Jul", "Oct"];
+
+/**
+ * Format a vintage date string for human-readable display.
+ *
+ * "YYYY-QN" → "Mmm YYYY" (e.g., "2024-Q1" → "Jan 2024").
+ * "YYYY-MM-DD" → "Mmm YYYY" via Date parsing.
+ * Anything else is returned unchanged.
+ */
+function formatVintageDate(vintage: string): string {
+  const quarterMatch = vintage.match(/^(\d{4})-Q([1-4])$/i);
+  if (quarterMatch) {
+    const year = quarterMatch[1];
+    const quarter = parseInt(quarterMatch[2], 10);
+    return `${QUARTER_MONTHS[quarter - 1]} ${year}`;
+  }
+  const isoMatch = vintage.match(/^(\d{4})-(\d{2})-\d{2}$/);
+  if (isoMatch) {
+    const d = new Date(`${vintage}T00:00:00Z`);
+    return d.toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+  }
+  return vintage;
+}
+
+/**
+ * Extract the first non-null vintage date across all frameworks and format it.
+ * Returns null if no vintage is available.
+ */
+function extractReferenceDate(frameworks: InitialStateResponse["frameworks"]): string | null {
+  for (const section of Object.values(frameworks)) {
+    for (const ind of section.indicators) {
+      if (ind.vintage) return formatVintageDate(ind.vintage);
+    }
+  }
+  return null;
+}
+
 function IndicatorRow({ ind }: { ind: GroundingIndicator }) {
   const value =
     ind.value != null
       ? `${ind.value}${ind.unit ? " " + ind.unit : ""}`
       : "—";
-  const citation = [ind.source, ind.vintage]
+  const formattedVintage = ind.vintage ? formatVintageDate(ind.vintage) : null;
+  const citation = [ind.source, formattedVintage]
     .filter(Boolean)
     .join(" · ");
   const tier = ind.confidence_tier != null ? ` · T${ind.confidence_tier}` : "";
@@ -167,6 +206,7 @@ export default function GroundingStrip({ scenarioId }: Props) {
 
   const hasData = namedFrameworks.length > 0;
   const hasCurrentData = currentValues !== null && current_step > 0;
+  const referenceDate = data ? extractReferenceDate(data.frameworks) : null;
 
   const sectionHeaderStyle: React.CSSProperties = {
     fontSize: 10,
@@ -202,6 +242,14 @@ export default function GroundingStrip({ scenarioId }: Props) {
           <div style={{ marginBottom: hasCurrentData ? 8 : 0 }}>
             <div style={sectionHeaderStyle}>
               Initial conditions (step 0 · source-cited data)
+              {referenceDate && (
+                <span
+                  data-testid="grounding-strip-date"
+                  style={{ marginLeft: 8, fontWeight: 400, color: "#64748b" }}
+                >
+                  · {referenceDate}
+                </span>
+              )}
             </div>
             {namedFrameworks.map(([key, section]) => {
               const visibleIndicators = section.indicators.filter(

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -463,6 +463,10 @@ export function ScenarioInstrumentCluster({
     const abortController = new AbortController();
     branchAbortRef.current = abortController;
 
+    // Signal pending immediately so the badge appears within the 2-second AC-4 ceiling,
+    // before the branch POST returns (which may take several seconds on slow connections).
+    useScenarioStepStore.setState({ recomputeStatus: "pending" });
+
     const { branchScenarioId } = store;
 
     try {
@@ -617,14 +621,20 @@ export function ScenarioInstrumentCluster({
                   animation: "pulse 1.2s infinite",
                 }}
               />
-              <span>Recomputing…</span>
-              {totalBranchSteps > 0 && (
-                <span
-                  data-testid="recompute-step-progress"
-                  style={{ fontWeight: 400, color: "#9d78ef" }}
-                >
-                  Computing step {branchStepsComputed + 1} of {totalBranchSteps}
-                </span>
+              {recomputeStatus === "pending" ? (
+                <span>Recompute pending — advance step to see updated trajectory</span>
+              ) : (
+                <>
+                  <span>Recomputing…</span>
+                  {totalBranchSteps > 0 && (
+                    <span
+                      data-testid="recompute-step-progress"
+                      style={{ fontWeight: 400, color: "#9d78ef" }}
+                    >
+                      Computing step {branchStepsComputed + 1} of {totalBranchSteps}
+                    </span>
+                  )}
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
## Summary

- **#1083** — `GroundingStrip.tsx`: add `formatVintageDate()` to convert `YYYY-QN` → `Mmm YYYY` (e.g., `2024-Q1` → `Jan 2024`). Add `data-testid="grounding-strip-date"` element in the initial conditions section header. `IndicatorRow` citations also format vintage so indicator rows no longer show raw quarter notation.
- **#1007** — `ScenarioInstrumentCluster.tsx`: set `recomputeStatus` to `"pending"` immediately at the start of `handleApplyControlChange`, before the branch POST fetch. This makes `data-testid="recompute-badge"` visible within the AC-4 2-second ceiling regardless of network latency. Pending-state badge text updated to `"Recompute pending — advance step to see updated trajectory"` (kryptonite-compliant self-interpreting text).

## Test plan

- [ ] AC-1: `grounding-strip-date` does not contain `YYYY-QN` notation
- [ ] AC-2: `grounding-strip-date` matches `[A-Z][a-z]{2} \d{4}` (e.g., `Jan 2024`)
- [ ] AC-3: `recompute-badge` not visible before Apply
- [ ] AC-4: `recompute-badge` visible within 2s after Apply (contains explanatory text)
- [ ] AC-5: `recompute-badge` clears after step advance
- [ ] Frontend build gate: `npm run build` — 0 TypeScript errors ✓

**Sprint:** M15-G5 | **Intent doc:** `docs/process/intents/M15-G5-2026-06-22-process-fixes.md` | **Tier 1 gate:** #1083 gates G8

🤖 Generated with [Claude Code](https://claude.com/claude-code)