### PR TITLE
feat(m15-g5): Alembic auto-migration at Docker API container startup (#1048)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Apply Alembic migrations before starting the application server.
+# Resolves NM-049: Docker API container did not run migrations at startup,
+# causing 500 errors on first request after a clean docker compose up.
+set -e
+alembic upgrade head
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,11 @@
 #
 # Quickstart:
 #   1. docker compose up
-#   2. docker compose exec api alembic upgrade head
-#   3. docker compose exec api python -m app.db.seed.natural_earth_loader
-#   4. open http://localhost:5173
+#   2. docker compose exec api python -m app.db.seed.natural_earth_loader
+#   3. open http://localhost:5173
+#
+# Alembic migrations run automatically at API container startup (entrypoint.sh).
+# No manual migration step required.
 
 services:
   db:


### PR DESCRIPTION
## Summary

- `backend/entrypoint.sh`: 8-line shell script — runs `alembic upgrade head` then `exec "$@"` to start the server
- `backend/Dockerfile`: switched from `CMD` to `ENTRYPOINT` + `CMD` pattern; `chmod +x` the entrypoint
- `docker-compose.yml`: updated Quickstart comment to remove the manual migration step; added note that migrations are now automatic

Resolves NM-049: after a clean `docker compose up`, the first API request no longer returns 500 due to unapplied migrations.

The compose `command: uvicorn ... --reload` becomes `$@` in the entrypoint, so both dev (--reload) and production workflows apply migrations before the server starts.

## Closes

- #1048 (Alembic migrations auto-apply at Docker container startup)

## Test plan

- [ ] `docker compose up` → `docker compose exec api python -m app.db.seed.natural_earth_loader` → `GET /api/v1/entities` returns ≥1 entity without `docker compose exec api alembic upgrade head` step (AC-11a, AC-11b)
- [ ] `docker compose logs api` shows `alembic upgrade head` output before uvicorn startup line

🤖 Generated with [Claude Code](https://claude.com/claude-code)