### PR TITLE
fix(m15-tests): preserve explicit null in makeTrajectoryMock financialTier (AC-4)

### DIFF
--- a/frontend/tests/e2e/m14-g5-adr015-frontend.spec.ts
+++ b/frontend/tests/e2e/m14-g5-adr015-frontend.spec.ts
@@ -144,7 +144,8 @@ function makeTrajectoryMock(
     ecologicalBreachType?: "ceiling" | "floor";
   } = {},
 ): object {
-  const financialTier = options.financialTier ?? 2;
+  // Use !== undefined so that explicit null is preserved (null ?? 2 would collapse to 2).
+  const financialTier = options.financialTier !== undefined ? options.financialTier : 2;
   const ecologicalTier = 3;
   const humanTier = 3;
   const governanceTier = 3;


### PR DESCRIPTION
## Summary

- Fixes the AC-4 test (`m14-g5-adr015-frontend.spec.ts:573`) that was failing with `expect("[T2 · pre-cal]").toContain("[—]")`
- Root cause: `options.financialTier ?? 2` treats `null` identically to `undefined` — when AC-4 passes `{ financialTier: null }`, the mock returned `confidence_tier: 2`, not null
- The bug was latent: before PR #1123 (Docker Alembic auto-migration), `createCompletedScenario` silently failed in CI `beforeAll`, setting `jorScenarioId = null` and causing all AC-1..AC-4 to soft-skip. After #1123 fixed backend startup, the scenario is created successfully and AC-4 actually runs — exposing the null-handling bug
- Fix: `options.financialTier !== undefined ? options.financialTier : 2` preserves explicit `null`; `undefined` (omitted) still defaults to `2`

## Test plan

- [ ] `playwright-e2e` CI passes on this PR
- [ ] AC-4 assertion `expect(text).toContain("[—]")` passes
- [ ] AC-1/AC-2/AC-3 still pass (default tier=2 path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)