### PR TITLE
docs(m15-g6): G6 sprint exit document

### DIFF
--- a/docs/process/sprint-plans/m15-g6-sprint-exit.md
+++ b/docs/process/sprint-plans/m15-g6-sprint-exit.md
@@ -1,0 +1,137 @@
+---
+name: m15-g6-sprint-exit
+type: sprint-exit
+milestone: M15 — Human Cost Architecture
+sprint-group: G6
+status: Confirmed
+authored-by: PM Agent
+date: 2026-06-22
+pi-confirmed: true
+release-branch: release/m15
+sop-reference: docs/process/sprint-planning-sop.md §Sprint Exit Gate
+---
+
+# Sprint Exit — M15, G6: Accessibility Validation
+
+**Status:** Confirmed — all exit conditions satisfied
+**Date produced:** 2026-06-22
+**Release branch:** `release/m15`
+**Sprint entry document:** `docs/process/sprint-plans/m15-g6-sprint-entry.md` — EL Approved 2026-06-22
+
+*Authority: `docs/process/sprint-planning-sop.md §Sprint Exit Gate` (Phase D output).
+G6 is an Infrastructure Sprint — Business PO acceptance and Customer Agent Layer 3
+assessment are waived at exit. PI Agent confirms exit conditions directly from the
+validation report and the Infrastructure Sprint Exception declaration.*
+
+---
+
+## Section 1 — Sprint Identification and Date
+
+| Field | Value |
+|---|---|
+| Milestone | M15 — Human Cost Architecture |
+| Sprint group | G6 — Accessibility Validation |
+| Release branch | `release/m15` |
+| Sprint entry document | `docs/process/sprint-plans/m15-g6-sprint-entry.md` |
+| Validation report | `docs/process/validation/m15-g6-accessibility-validation-report.md` |
+| Exit checklist issue | #984 |
+| Date validation completed | 2026-06-22 |
+| CI status on release branch | Green — PR #1128 merged 2026-06-23 (playwright-e2e PASS; pre-existing AC-4 mock bug fixed in PR #1130) |
+
+---
+
+## Section 2 — Validation Status
+
+*All four VC checks must be documented in the validation report at
+`docs/process/validation/m15-g6-accessibility-validation-report.md`.
+CONDITIONAL PASS with documented limitation is acceptable at exit; FAIL requires
+a new issue before exit.*
+
+| Check | Result | PR | Evidence |
+|---|---|---|---|
+| VC-1 — Docker stack startup + responsiveness | ✅ PASS | #1128 | `/health/` HTTP 200; GRC/JOR/EGY/ZMB in `/countries`; frontend :5173 responsive; ~440 MiB / 7.663 GiB Docker limit |
+| VC-2 — Simulation engine 8-step timing | ✅ PASS | #1128 | 0.079s wall-clock (target ≤ 60s); all 4 framework keys in trajectory |
+| VC-3 — Non-Docker Playwright path documented | ✅ CONDITIONAL PASS | #1128 | `CONTRIBUTING.md §4` lightweight local path documented; fully offline path (MSW) planned; limitation on record |
+| VC-4 — Frontend build time | ✅ PASS | #1128 | 3.4 seconds on host (target ≤ 5 min); exits 0 |
+
+**Overall: 3 PASS + 1 CONDITIONAL PASS. No FAIL findings.**
+
+---
+
+## Section 3 — Business PO Acceptance Table
+
+**Infrastructure Sprint Exception applies — BPO acceptance waived for G6.**
+
+G6 produces no user-facing deliverable. The primary output is the validation report
+(a documentation artifact). Per the sprint entry §Infrastructure Sprint Declaration:
+"Business PO acceptance and Customer Agent Layer 3 assessment are not required at exit
+for G6 deliverables."
+
+| Deliverable | Type | BPO verdict required? | Status |
+|---|---|---|---|
+| `docs/process/validation/m15-g6-accessibility-validation-report.md` | Infrastructure documentation | No — Infrastructure Sprint Exception | N/A |
+
+**BPO acceptance: WAIVED (Infrastructure Sprint Exception)**
+
+---
+
+## Section 4 — Rejection Artifacts
+
+No rejection artifacts were produced. All four VC checks passed or met the CONDITIONAL PASS
+criterion. No FAIL findings were recorded. No implementation remediation was required.
+
+| Rejection artifact | Status |
+|---|---|
+| None | N/A |
+
+---
+
+## Section 5 — Near-Miss Sweep
+
+**Near-miss sweep date:** 2026-06-22
+**Sweep period:** G6 sprint entry approval (2026-06-22) through validation completion (2026-06-22)
+
+| Finding | Category | Action |
+|---|---|---|
+| G6 validation report initially committed directly to `release/m15` (caught before push; reset and recommitted on feature branch) | Process deviation — feature branch discipline | Self-corrected before push; no NM entry required (caught at the earliest possible point — before the commit reached the remote) |
+| VC-2 sprint entry spec described `outputs.financial` in per-advance responses; actual API structure uses `frameworks` list in trajectory endpoint | Spec wording imprecision — not a process gap | Documented in validation report §Known Limitations; no NM entry required (spec wording issue, not a process failure or near-miss) |
+
+**No near-miss entries filed in this sweep period.** Both findings were self-correcting
+specification issues or caught before causing any artifact contamination.
+
+*PI Agent note: the direct-to-release-branch commit was caught before pushing to the remote.
+Per near-miss policy, a defect caught before any external visibility does not require an NM
+entry — the process worked (the pre-push review caught it). If it had been pushed to the remote,
+an NM entry would have been required.*
+
+---
+
+## Section 6 — PI Agent Exit Confirmation
+
+**PI Agent confirmation: ✅ CONFIRMED 2026-06-22**
+
+*PI Agent assessment:*
+
+1. **Validation report exists at canonical location:** `docs/process/validation/m15-g6-accessibility-validation-report.md` ✅
+2. **All four VC checks documented:** VC-1 PASS, VC-2 PASS, VC-3 CONDITIONAL PASS (limitation on record), VC-4 PASS ✅
+3. **No FAIL findings:** No new issues required ✅
+4. **Infrastructure Sprint Exception classification confirmed:** No G6 output modifies user-visible application state. The validation report is a process artifact. The sprint entry's exception declaration is correctly applied. ✅
+5. **Business PO acceptance waived per Infrastructure Sprint Exception:** Correct ✅
+6. **#990 closable:** All acceptance criteria for the accessibility validation issue satisfied ✅
+
+*PI Agent concludes: G6 exit conditions are satisfied. Sprint is closed.*
+
+---
+
+## Section 7 — North Star Test (Infrastructure Tier)
+
+G6 is an infrastructure sprint (Tier 3 classification). Per CLAUDE.md:
+> "Deliverable is reclassified as infrastructure (Tier 3, which does not require a
+> sprint-level north star test — only a forward trace to the downstream capability that
+> will eventually pass the test)."
+
+**Forward trace:** VC-1 and VC-2 confirm that a finance ministry analyst on target hardware
+(8GB/4-core) can run the full simulation stack and complete an 8-step scenario analysis.
+This forward trace connects to the north star test for Demo 6 (G8): a Zambian ministry analyst
+on target hardware runs the simulation and presents the findings to real external participants.
+The infrastructure foundation is confirmed. The north star test itself belongs to G8.


### PR DESCRIPTION
## Summary

- Files sprint exit document for M15-G6 (Accessibility Validation)
- PI Agent confirmed: all 4 VC checks documented, no FAIL findings, BPO waived per Infrastructure Sprint Exception
- Issue #990 closed
- G6 sprint is CLOSED; G8 path-dependency confirmed

**Note:** includes a CI status update noting that the pre-existing AC-4 mock null-tier bug (PR #1130) was the blocker for PR #1128, now resolved.

## Test plan

- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)