### PR TITLE
process(m16): record EL approval on G1 sprint entry

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-23 (M16 G1 sprint entry filed — awaiting EL approval; intent document and QA tests must be filed before implementation PR opens)**
+**Last updated: 2026-06-23 (M16 G1 sprint entry EL-approved — intent document and QA tests are next blocking steps before implementation PR opens)**
 **Current milestone:** M16 — Distributional Visibility (GitHub Milestone 17)
 **Previous milestone:** M15 — Human Cost Architecture (FORMALLY CLOSED 2026-06-23; release/m15 → main PR #1142; v0.15.0; #984 closed; GitHub Milestone 16 closed)
 
@@ -141,7 +141,7 @@ Implementation is now unblocked. A sprint entry document must be filed and EL-ap
 - ✅ #845 milestone corrected to M16 (was M15)
 - ✅ #1147 filed (Zone 1D delta annotations — was UNTRACKED)
 - ✅ ARCH-012: not needed for G1/G2/G3 core deliverables; may be needed for #22 (G4) — confirm at G4 sprint entry
-- ⬜ G1 sprint entry filed 2026-06-23 — `docs/process/sprint-plans/m16-g1-sprint-entry.md` — **awaiting EL approval**; intent document and QA tests remain blocking before implementation PR opens
+- ✅ G1 sprint entry filed and **EL-approved 2026-06-23** — `docs/process/sprint-plans/m16-g1-sprint-entry.md`; intent document and QA tests remain blocking before implementation PR opens
 - ⬜ G2 pre-conditions: CM/DA/ARF/FA sign-off requests to be opened on #986 and #987
 
 ---

--- a/docs/process/sprint-plans/m16-g1-sprint-entry.md
+++ b/docs/process/sprint-plans/m16-g1-sprint-entry.md
@@ -3,10 +3,10 @@ name: m16-g1-sprint-entry
 type: sprint-entry
 milestone: M16 — Distributional Visibility
 sprint-group: G1
-status: Filed — awaiting EL approval before implementation begins
+status: EL Approved 2026-06-23 — intent document and QA tests must be filed before implementation PR opens
 authored-by: PM Agent
 authored-date: 2026-06-23
-el-approved: false
+el-approved: 2026-06-23
 release-branch: release/m16
 sop-reference: docs/process/sprint-planning-sop.md
 ---
@@ -214,7 +214,7 @@ condition for G8 entry.
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-23
 
-> {EL approval statement — to be filled at approval time}
-> — @PublicEnemage ({date})
+> G1 sprint entry approved. Structural gates confirmed clear. ADR prerequisites clear for both issues (ADR-017 accepted 2026-06-22; ADR-015 accepted 2026-06-16). Observable application states in Section 3.1 are specific enough to gate QA test authorship. Intent document and QA test file must be filed before implementation PR opens — these remain blocking conditions. G2 gate dependency (G2 implementation PR may not open until G1 merges) and G8 gate dependency (#843 may not open until G1 + G2 + G3 are BPO-accepted) noted and accepted. Implementation may proceed once the intent and QA gates are satisfied.
+> — @PublicEnemage (2026-06-23)


### PR DESCRIPTION
## Summary

- Records EL approval (2026-06-23) in `docs/process/sprint-plans/m16-g1-sprint-entry.md` — frontmatter `el-approved` date and EL Approval Record section
- Updates `SESSION_STATE.md` to reflect approved status

## State after merge

G1 sprint entry is fully approved. Implementation is unblocked pending two remaining gates:
1. Frontend Architect Agent authors intent document at `docs/process/intents/M16-G1-2026-06-23-zone-1a-phase4-composite.md`
2. QA Lead Agent authors `frontend/tests/e2e/m16-g1-zone-1a-phase4-composite.spec.ts` from the intent document

Neither the intent document nor the QA test file may be skipped. Implementation PR targeting `release/m16` may not open until both are on record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)