### PR TITLE
process(m16): record EL approval on G5 sprint entry (2026-06-23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ data/raw/
 .DS_Store
 Thumbs.db
 
+# Video files
+*.mov
+
 # Test coverage
 .coverage
 htmlcov/

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-23 (M16 G5 sprint entry filed — #1145/837/951/259; G1 QA tests remain the implementation blocker)**
+**Last updated: 2026-06-23 (M16 G5 sprint entry filed and EL-approved; G1 QA tests remain the implementation blocker)**
 **Current milestone:** M16 — Distributional Visibility (GitHub Milestone 17)
 **Previous milestone:** M15 — Human Cost Architecture (FORMALLY CLOSED 2026-06-23; release/m15 → main PR #1142; v0.15.0; #984 closed; GitHub Milestone 16 closed)
 
@@ -143,7 +143,7 @@ Implementation is now unblocked. A sprint entry document must be filed and EL-ap
 - ✅ ARCH-012: not needed for G1/G2/G3 core deliverables; may be needed for #22 (G4) — confirm at G4 sprint entry
 - ✅ G1 sprint entry filed and **EL-approved 2026-06-23** — `docs/process/sprint-plans/m16-g1-sprint-entry.md`; intent document and QA tests remain blocking before implementation PR opens
 - ⬜ G2 pre-conditions: CM/DA/ARF/FA sign-off requests to be opened on #986 and #987
-- ✅ G5 sprint entry filed 2026-06-23 — `docs/process/sprint-plans/m16-g5-sprint-entry.md`; #1145 (immediate) + #837/#951/#259 (near-term, capacity-allowing); awaiting EL approval
+- ✅ G5 sprint entry filed and **EL-approved 2026-06-23** — `docs/process/sprint-plans/m16-g5-sprint-entry.md`; #1145 (immediate) + #837/#951/#259 (near-term, capacity-allowing); work may begin
 - ✅ G7 sprint entry filed and **EL-approved 2026-06-23** — `docs/process/sprint-plans/m16-g7-sprint-entry.md`; #3 → #6 dependency declared; actions may begin
 
 ---

--- a/docs/process/sprint-plans/m16-g5-sprint-entry.md
+++ b/docs/process/sprint-plans/m16-g5-sprint-entry.md
@@ -3,17 +3,17 @@ name: m16-g5-sprint-entry
 type: sprint-entry
 milestone: M16 — Distributional Visibility
 sprint-group: G5
-status: Filed — awaiting EL approval before work begins
+status: EL Approved 2026-06-23 — work may begin per priority order (#1145 first; #837/#951/#259 parallel, capacity-allowing)
 authored-by: PM Agent
 authored-date: 2026-06-23
-el-approved: false
+el-approved: 2026-06-23
 release-branch: release/m16
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M16, G5: Process + Secondary Features
 
-**Status:** Filed — awaiting EL approval before work begins
+**Status:** EL Approved 2026-06-23 — work may begin per priority order (#1145 first; #837/#951/#259 parallel, capacity-allowing)
 **Date authored:** 2026-06-23
 **Release branch:** `release/m16`
 **Sprint plan:** `docs/process/sprint-plans/m16-sprint-plan.md` (EL Approved 2026-06-23)
@@ -217,7 +217,7 @@ ship in M16. Per the BPO sprint plan consultation: cut G4 before any G5 deferral
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-23
 
-> {EL approval statement — to be filled at approval time}
-> — @PublicEnemage ({date})
+> G5 sprint entry approved. Structural gates confirmed clear — release branch exists, CI trigger verified, sprint plan EL-approved. No ADR prerequisites for any G5 item; gate is clear across the board. Infrastructure sprint classification accepted: no intent document or QA test gate applies to any G5 item. Priority order accepted: #1145 (`horizon:immediate`) ships in M16 regardless of capacity; #837, #951, #259 (`horizon:near-term`) are capacity-allowing and may be deferred to M17 in order #259 → #951 → #837. Scope-cut authority noted: cut G4 before any G5 deferral. G5 is not on the G8 critical path. Work may begin.
+> — @PublicEnemage (2026-06-23)


### PR DESCRIPTION
## Summary

- Records EL approval on `docs/process/sprint-plans/m16-g5-sprint-entry.md`: frontmatter `el-approved: 2026-06-23`, status updated, approval statement filled
- Updates `SESSION_STATE.md` header and G5 entry line to reflect approved status

## Test plan

- [ ] Entry frontmatter `el-approved: 2026-06-23`
- [ ] EL Approval Record section contains dated approval statement
- [ ] SESSION_STATE.md G5 line reads "EL-approved 2026-06-23"

🤖 Generated with [Claude Code](https://claude.com/claude-code)