### PR TITLE
feat(m16-g1): Zone 1A Phase 4 composite encoding + Zone 1D PSP delta (#845 #1147)

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -17,7 +17,7 @@
  *
  * Implements: US-021, US-022, ADR-008 Decision 7, DD-011, ADR-015 Components 1+3
  */
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 import { FRAMEWORK_COLORS } from "../constants/frameworkColors";
 import { sortAlerts } from "./MDAAlertPanelZone1B";
@@ -175,6 +175,21 @@ export function FourFrameworkZone1D({
   pspTier,
 }: FourFrameworkZone1DProps) {
   const { trajectory, current_step, mda_alerts, mode } = useScenarioStepStore();
+
+  // ADR-017 §Zone 1D Integration — step-over-step PSP delta tracking.
+  // prevPspRef holds the PSP value from the previous render cycle.
+  // Read synchronously during render; updated in useEffect (after paint) so
+  // next render sees the previous value as "prev".
+  const prevPspRef = useRef<string | null | undefined>(undefined);
+  const pspDeltaPercent: number | null =
+    pspValue != null && prevPspRef.current != null
+      ? Math.round((parseFloat(pspValue) - parseFloat(prevPspRef.current)) * 100)
+      : null;
+  useEffect(() => {
+    if (pspValue !== undefined) {
+      prevPspRef.current = pspValue;
+    }
+  }, [pspValue]);
 
   // Top alert per framework for the "see alerts →" navigation link (#745)
   const topAlertByFramework: Record<string, string> = {};
@@ -387,6 +402,7 @@ export function FourFrameworkZone1D({
       })}
 
       {/* ADR-015 §Component 3 — Political Feasibility row (programme_survival_probability).
+          ADR-017 §Zone 1D Integration — PSP delta shown inline when prev PSP is known (step ≥ 1).
           Visible only when PE module is enabled. Absent entirely when PE is disabled. */}
       {peEnabled && (
         <div
@@ -406,6 +422,9 @@ export function FourFrameworkZone1D({
           </span>
           <span
             style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
               fontSize: 12,
               fontWeight: 700,
               color: "#7c3aed",
@@ -418,6 +437,21 @@ export function FourFrameworkZone1D({
               <span style={{ color: "#cc0000", fontSize: 10 }}>— [computation error]</span>
             ) : (
               `${(parseFloat(pspValue) * 100).toFixed(0)}% [T${pspTier ?? 3} · political economy module]`
+            )}
+            {/* ADR-017 §Zone 1D Integration — step-over-step delta annotation */}
+            {pspDeltaPercent !== null && (
+              <span
+                data-testid="psp-delta"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  color: pspDeltaPercent < 0 ? "#dc2626" : "#059669",
+                }}
+              >
+                {pspDeltaPercent < 0
+                  ? `↓${Math.abs(pspDeltaPercent)}pp`
+                  : `↑${pspDeltaPercent}pp`}
+              </span>
             )}
           </span>
         </div>
@@ -443,6 +477,29 @@ export function FourFrameworkZone1D({
           ) : (
             `Programme survival probability: ${(parseFloat(pspValue) * 100).toFixed(0)}%. This means the programme has a ${(parseFloat(pspValue) * 100).toFixed(0)}% chance of remaining on track through conditionality compliance.`
           )}
+        </div>
+      )}
+
+      {/* ADR-017 §Zone 1D Integration — PSP delta Layer 3 sentence (#1147).
+          Visible at step ≥ 1 when previous PSP is known. Absent at step 0 or when
+          delta cannot be computed (prev PSP unavailable). */}
+      {peEnabled && pspValue != null && pspDeltaPercent !== null && (
+        <div
+          data-testid="psp-delta-sentence"
+          style={{
+            borderLeft: "3px solid #7c3aed",
+            paddingLeft: 6,
+            paddingTop: 2,
+            paddingBottom: 2,
+            fontSize: 10,
+            color: pspDeltaPercent < 0 ? "#dc2626" : "#059669",
+            lineHeight: 1.4,
+            fontWeight: 500,
+          }}
+        >
+          {pspDeltaPercent === 0
+            ? "programme survival unchanged this step"
+            : `programme survival ${pspDeltaPercent < 0 ? "dropped" : "improved"} ${Math.abs(pspDeltaPercent)} percentage point${Math.abs(pspDeltaPercent) !== 1 ? "s" : ""} this step`}
         </div>
       )}
     </div>

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -11,7 +11,7 @@
  */
 import React, { useEffect, useState } from "react";
 import { TrajectoryView } from "./TrajectoryView";
-import { useScenarioStepStore } from "../store/scenarioStepStore";
+import { useScenarioStepStore, type TrajectoryResponse } from "../store/scenarioStepStore";
 
 export const LAYOUT = {
   1024: { trajectory: 480, coPrimary: 240, controlPlane: 280, chartHeight: 300 },
@@ -44,6 +44,10 @@ interface InstrumentClusterProps {
   entityIds?: string[];
   /** Override chart height (px) — defaults to LAYOUT[bp].chartHeight. */
   chartHeight?: number;
+  /** Phase 4 (ADR-017): per-entity trajectory responses for composite encoding. */
+  entityTrajectories?: Record<string, TrajectoryResponse> | null;
+  /** Phase 4 (ADR-017): per-entity baseline trajectories for Mode 3 ghost paths. */
+  entityBaselineTrajectories?: Record<string, TrajectoryResponse> | null;
 }
 
 export function InstrumentCluster({
@@ -53,6 +57,8 @@ export function InstrumentCluster({
   cohortPanel,
   entityIds,
   chartHeight: chartHeightProp,
+  entityTrajectories,
+  entityBaselineTrajectories,
 }: InstrumentClusterProps) {
   const { mode } = useScenarioStepStore();
   const bp = useViewportBreakpoint();
@@ -80,6 +86,8 @@ export function InstrumentCluster({
           width={layout.trajectory}
           height={chartHeight}
           entityIds={entityIds}
+          entityTrajectories={entityTrajectories}
+          entityBaselineTrajectories={entityBaselineTrajectories}
           data-testid="zone-1a-trajectory"
         />
         {cohortPanel}

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -243,11 +243,21 @@ export function ScenarioInstrumentCluster({
   const [pspValue, setPspValue] = useState<string | null | undefined>(undefined);
   const [pspTier, setPspTier] = useState<number | null>(null);
 
+  // ADR-017 Phase 4 — per-entity trajectory maps for composite encoding.
+  const [entityTrajectories, setEntityTrajectories] = useState<Record<string, TrajectoryResponse>>({});
+  const [entityBaselineTrajectories, setEntityBaselineTrajectories] = useState<Record<string, TrajectoryResponse>>({});
+
   // Mode 3 branch advance loop — abortController cancels in-flight advances on cleanup.
   const branchAbortRef = useRef<AbortController | null>(null);
 
   // Track previous scenarioId to distinguish scenario change (full reset) from mode-only change.
   const prevScenarioIdRef = useRef<string>("");
+
+  // Track Mode 3 activation to auto-save entity baselines when entering Mode 3.
+  const prevMode3ActiveRef = useRef(false);
+  // Deferred baseline save: when Mode 3 activates before entity trajectories are loaded,
+  // save them on the next entityTrajectories update.
+  const saveBaselineOnNextUpdateRef = useRef(false);
 
   // Initialise store when scenario changes (full reset) or update mode without resetting.
   // setScenario resets trajectory and current_step — calling it on mode changes would drop
@@ -306,6 +316,74 @@ export function ScenarioInstrumentCluster({
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
   }, [scenarioId, currentStep]);
+
+  // ADR-017 Phase 4 — per-entity trajectory fetch for composite encoding (N > 1).
+  // Fetches trajectory for each entity using ?entity_id= query param.
+  // Skipped at step 0 (no snapshots yet) and when only one entity is loaded.
+  useEffect(() => {
+    const ids = entityIds ?? [];
+    if (!scenarioId || currentStep === 0 || ids.length <= 1) return;
+    let cancelled = false;
+
+    Promise.all(
+      ids.map((entityId) =>
+        fetch(
+          `${API_BASE}/scenarios/${encodeURIComponent(scenarioId)}/trajectory?entity_id=${encodeURIComponent(entityId)}`
+        )
+          .then((res) => (res.ok ? (res.json() as Promise<RawTrajectoryResponse>) : null))
+          .then((raw) => (raw ? parseTrajectoryResponse(raw) : null))
+          .catch(() => null)
+      )
+    ).then((trajectories) => {
+      if (cancelled) return;
+      const map: Record<string, TrajectoryResponse> = {};
+      ids.forEach((entityId, i) => {
+        const traj = trajectories[i];
+        if (traj) map[entityId] = traj;
+      });
+      setEntityTrajectories(map);
+    });
+
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
+  }, [scenarioId, currentStep, entityIds]);
+
+  // ADR-017 Phase 4 — deferred baseline save when entity trajectories arrive after Mode 3 activation.
+  useEffect(() => {
+    if (!saveBaselineOnNextUpdateRef.current) return;
+    if (Object.keys(entityTrajectories).length === 0) return;
+    setEntityBaselineTrajectories({ ...entityTrajectories });
+    saveBaselineOnNextUpdateRef.current = false;
+  }, [entityTrajectories]);
+
+  // ADR-017 Phase 4 — Mode 3 auto-baseline for multi-entity composite encoding.
+  // When entering Mode 3 with N > 1, lock current entity trajectories as baseline
+  // so CompositeChartSVG can render ghost (baseline) + active paths.
+  // N=1 Mode 3: Zustand store's baseline_trajectory handles ghost (set by applyControlInput).
+  useEffect(() => {
+    const ids = entityIds ?? [];
+    if (mode3Active && !prevMode3ActiveRef.current && ids.length > 1) {
+      if (Object.keys(entityTrajectories).length > 0) {
+        setEntityBaselineTrajectories({ ...entityTrajectories });
+      } else {
+        // Entity trajectories not yet loaded — save on next update
+        saveBaselineOnNextUpdateRef.current = true;
+      }
+    }
+    if (!mode3Active) {
+      setEntityBaselineTrajectories({});
+      saveBaselineOnNextUpdateRef.current = false;
+    }
+    prevMode3ActiveRef.current = mode3Active;
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- entityTrajectories dep handled by the deferred-save effect
+  }, [mode3Active, entityIds]);
+
+  // Reset per-entity trajectory state on scenario change.
+  useEffect(() => {
+    setEntityTrajectories({});
+    setEntityBaselineTrajectories({});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scenarioId]);
 
   // Sync PMM from trajectory step data when current step changes (Issue #496).
   // PMM is pre-computed per step by the backend; no additional fetch needed.
@@ -694,6 +772,8 @@ export function ScenarioInstrumentCluster({
       <InstrumentCluster
         entityIds={entityIds}
         chartHeight={chartHeight}
+        entityTrajectories={entityTrajectories}
+        entityBaselineTrajectories={entityBaselineTrajectories}
         mdaPanel={
           <MDAAlertPanelZone1B
             columnWidth={coPrimaryWidth}

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -24,6 +24,7 @@ import {
   useScenarioStepStore,
   type TrajectoryStep,
   type TrajectoryResponse,
+  type MDAFloor,
 } from "../store/scenarioStepStore";
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,41 @@ export function computeDivergenceFill(
  */
 export function getConfidenceBadgeVisible(confidenceTier: number): boolean {
   return confidenceTier >= 4;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4 — composite encoding constants and helpers (ADR-017 §Decision table)
+// ---------------------------------------------------------------------------
+
+/** Entity color palette indexed by position in entityIds (max 4 entities per ADR-017). */
+const ENTITY_PALETTE: readonly string[] = [
+  FRAMEWORK_COLORS.financial,          // #2271B3 — entity 0
+  FRAMEWORK_COLORS.ecological,         // #1A8FA0 — entity 1
+  FRAMEWORK_COLORS.human_development,  // #D4841A — entity 2
+  FRAMEWORK_COLORS.governance,         // #7B50A8 — entity 3
+] as const;
+
+/** Mean of non-null framework composite_scores at a step. */
+function computeEntityCompositeScore(step: TrajectoryStep): number | null {
+  const scores = Object.values(step.frameworks)
+    .map((fw) => fw.composite_score)
+    .filter((s): s is number => s !== null);
+  if (scores.length === 0) return null;
+  return scores.reduce((a, b) => a + b, 0) / scores.length;
+}
+
+/** Worst (highest-number) confidence tier across all frameworks at a step. */
+function getEntityWorstTier(step: TrajectoryStep): number {
+  const tiers = Object.values(step.frameworks).map((fw) => fw.confidence_tier);
+  if (tiers.length === 0) return 3;
+  return Math.max(...tiers);
+}
+
+/** Lowest non-trivial MDA floor value (0 < value < 1) across all frameworks. */
+function getEntityMdaFloor(mda_floors: MDAFloor[]): number | null {
+  const floors = mda_floors.map((f) => f.floor_value).filter((v) => v > 0 && v < 1.0);
+  if (floors.length === 0) return null;
+  return Math.min(...floors);
 }
 
 // ---------------------------------------------------------------------------
@@ -242,6 +278,240 @@ function legendFormatter(
 }
 
 // ---------------------------------------------------------------------------
+// Phase 4 — composite SVG chart (ADR-017 §Decision table rows N≤4)
+// ---------------------------------------------------------------------------
+
+interface CompositeChartSVGProps {
+  entityCodes: string[];
+  activeTrajectories: Record<string, TrajectoryResponse>;
+  baselineTrajectories: Record<string, TrajectoryResponse>;
+  mode: "MODE_1" | "MODE_2" | "MODE_3";
+  width: number;
+  height: number;
+}
+
+function CompositeChartSVG({
+  entityCodes,
+  activeTrajectories,
+  baselineTrajectories,
+  mode,
+  width,
+  height,
+}: CompositeChartSVGProps) {
+  const MARGIN = { top: 16, right: 60, bottom: 48, left: 44 };
+  const chartW = width - MARGIN.left - MARGIN.right;
+  const chartH = height - MARGIN.top - MARGIN.bottom;
+
+  const refCode = entityCodes.find((c) => activeTrajectories[c]);
+  const refSteps = refCode ? activeTrajectories[refCode].steps : [];
+  const stepIndices = refSteps.map((s) => s.step_index);
+
+  const xScale = (idx: number): number => {
+    if (stepIndices.length <= 1) return MARGIN.left + chartW / 2;
+    const i = stepIndices.indexOf(idx);
+    if (i < 0) return MARGIN.left;
+    return MARGIN.left + (i / (stepIndices.length - 1)) * chartW;
+  };
+
+  const yScale = (score: number): number =>
+    MARGIN.top + (1 - Math.min(1, Math.max(0, score))) * chartH;
+
+  const buildPathD = (steps: TrajectoryStep[]): string => {
+    const pts: string[] = [];
+    for (const step of steps) {
+      const score = computeEntityCompositeScore(step);
+      if (score === null) continue;
+      pts.push(`${xScale(step.step_index).toFixed(1)},${yScale(score).toFixed(1)}`);
+    }
+    return pts.length >= 2 ? "M " + pts.join(" L ") : "";
+  };
+
+  const showBaseline =
+    (mode === "MODE_2" || mode === "MODE_3") &&
+    Object.keys(baselineTrajectories).length > 0;
+
+  // Only render divergence fill when trajectories actually diverge (> 0.001 delta).
+  // This prevents a zero-area fill element that would break bounding-box assertions.
+  const hasDivergence =
+    showBaseline &&
+    entityCodes.some((code) => {
+      const active = activeTrajectories[code];
+      const baseline = baselineTrajectories[code];
+      if (!active || !baseline) return false;
+      const baselineByStep = new Map(baseline.steps.map((s) => [s.step_index, s]));
+      return active.steps.some((step) => {
+        const aScore = computeEntityCompositeScore(step);
+        const bStep = baselineByStep.get(step.step_index);
+        const bScore = bStep ? computeEntityCompositeScore(bStep) : null;
+        return aScore !== null && bScore !== null && Math.abs(aScore - bScore) > 0.001;
+      });
+    });
+
+  const yGridValues = [0, 0.25, 0.5, 0.75, 1.0];
+
+  return (
+    <svg width={width} height={height} style={{ display: "block", overflow: "visible" }}>
+      {/* Y-axis grid and labels */}
+      {yGridValues.map((val) => (
+        <g key={val}>
+          <line
+            x1={MARGIN.left}
+            y1={yScale(val)}
+            x2={MARGIN.left + chartW}
+            y2={yScale(val)}
+            stroke="#f0f0f0"
+            strokeWidth={1}
+          />
+          <text
+            x={MARGIN.left - 4}
+            y={yScale(val)}
+            textAnchor="end"
+            fontSize={9}
+            fill="#888"
+            dy={3}
+          >
+            {val.toFixed(2)}
+          </text>
+        </g>
+      ))}
+
+      {/* X-axis step ticks */}
+      {stepIndices.map((idx) => (
+        <g key={idx} transform={`translate(${xScale(idx)},${MARGIN.top + chartH})`}>
+          <line y1={0} y2={4} stroke="#ccc" strokeWidth={1} />
+          <text y={14} textAnchor="middle" fontSize={9} fill="#888">
+            {`Step ${idx}`}
+          </text>
+        </g>
+      ))}
+
+      {/* Divergence fills — only rendered when hasDivergence */}
+      {hasDivergence &&
+        entityCodes.map((code, i) => {
+          const active = activeTrajectories[code];
+          const baseline = baselineTrajectories[code];
+          if (!active || !baseline) return null;
+          const baselineByStep = new Map(baseline.steps.map((s) => [s.step_index, s]));
+          const fwdPts: string[] = [];
+          const revPts: string[] = [];
+          for (const step of active.steps) {
+            const aScore = computeEntityCompositeScore(step);
+            const bStep = baselineByStep.get(step.step_index);
+            const bScore = bStep ? computeEntityCompositeScore(bStep) : null;
+            if (aScore === null || bScore === null) continue;
+            const x = xScale(step.step_index);
+            fwdPts.push(`${x.toFixed(1)},${yScale(aScore).toFixed(1)}`);
+            revPts.unshift(`${x.toFixed(1)},${yScale(bScore).toFixed(1)}`);
+          }
+          if (fwdPts.length < 2) return null;
+          const fillD = "M " + fwdPts.join(" L ") + " L " + revPts.join(" L ") + " Z";
+          const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
+          return (
+            <path
+              key={`fill-${code}`}
+              data-testid="zone-1a-divergence-fill"
+              d={fillD}
+              fill={color}
+              opacity={0.08}
+              stroke="none"
+            />
+          );
+        })}
+
+      {/* MDA floor lines — one per entity (lowest non-trivial floor) */}
+      {entityCodes.map((code, i) => {
+        const active = activeTrajectories[code];
+        if (!active) return null;
+        const floor = getEntityMdaFloor(active.mda_floors);
+        if (floor === null) return null;
+        const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
+        return (
+          <line
+            key={`mda-${code}`}
+            data-testid={`zone-1a-mda-floor-${code}`}
+            x1={MARGIN.left}
+            y1={yScale(floor)}
+            x2={MARGIN.left + chartW}
+            y2={yScale(floor)}
+            stroke={color}
+            strokeWidth={1}
+            strokeDasharray="6 3"
+            strokeOpacity={0.6}
+          />
+        );
+      })}
+
+      {/* Baseline ghost paths — Mode 2/3, opacity=0.5 + dasharray (ADR-017) */}
+      {showBaseline &&
+        entityCodes.map((code, i) => {
+          const baseline = baselineTrajectories[code];
+          if (!baseline) return null;
+          const pathD = buildPathD(baseline.steps);
+          if (!pathD) return null;
+          const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
+          return (
+            <path
+              key={`ghost-${code}`}
+              d={pathD}
+              stroke={color}
+              strokeWidth={1}
+              opacity={0.5}
+              strokeDasharray="4 2"
+              fill="none"
+            />
+          );
+        })}
+
+      {/* Active composite paths — solid, full opacity */}
+      {entityCodes.map((code, i) => {
+        const active = activeTrajectories[code];
+        if (!active) return null;
+        const pathD = buildPathD(active.steps);
+        if (!pathD) return null;
+        const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
+        return (
+          <path
+            key={`active-${code}`}
+            d={pathD}
+            stroke={color}
+            strokeWidth={2}
+            opacity={1}
+            fill="none"
+          />
+        );
+      })}
+
+      {/* Tier badges at right edge of each entity's active curve endpoint */}
+      {entityCodes.map((code, i) => {
+        const active = activeTrajectories[code];
+        if (!active || active.steps.length === 0) return null;
+        const lastStep = active.steps[active.steps.length - 1];
+        const lastScore = computeEntityCompositeScore(lastStep);
+        if (lastScore === null) return null;
+        const tier = getEntityWorstTier(lastStep);
+        const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
+        const x = MARGIN.left + chartW + 4;
+        const y = yScale(lastScore);
+        return (
+          <text
+            key={`tier-${code}`}
+            data-testid={`zone-1a-tier-badge-${code}`}
+            x={x}
+            y={y}
+            fontSize={9}
+            fontWeight="bold"
+            fill={color}
+            dominantBaseline="middle"
+          >
+            T{tier}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // TrajectoryView props
 // ---------------------------------------------------------------------------
 
@@ -252,6 +522,16 @@ interface TrajectoryViewProps {
   height?: number;
   /** Entity ISO 3166-1 alpha-3 codes — provide two for multi-case Mode 1. */
   entityIds?: string[];
+  /**
+   * Phase 4 (ADR-017): per-entity trajectory responses keyed by ISO entity code.
+   * When provided for N>1 entities, composite encoding is used instead of recharts.
+   */
+  entityTrajectories?: Record<string, TrajectoryResponse> | null;
+  /**
+   * Phase 4 (ADR-017): per-entity baseline trajectories for Mode 3 ghost paths.
+   * Keyed by ISO entity code. Empty object or null = no baseline overlay.
+   */
+  entityBaselineTrajectories?: Record<string, TrajectoryResponse> | null;
   /** test-id for AC-006 DOM assertions. */
   "data-testid"?: string;
 }
@@ -264,6 +544,8 @@ export function TrajectoryView({
   width,
   height = 300,
   entityIds,
+  entityTrajectories,
+  entityBaselineTrajectories,
   "data-testid": dataTestId = "zone-1a-trajectory",
 }: TrajectoryViewProps) {
   const { trajectory, baseline_trajectory, current_step, mode } =
@@ -276,9 +558,7 @@ export function TrajectoryView({
 
   const showBaseline = (mode === "MODE_2" || mode === "MODE_3") && baseline_trajectory !== null;
 
-  // Performance mark for AC-007 / MV-002. Fires once when trajectory data first
-  // arrives: measures from post-DOM-update to post-paint via requestAnimationFrame.
-  // Name starts with "trajectory-render" to match the AC-007 assertion.
+  // Performance mark for AC-007 / MV-002.
   const perfMarkFired = useRef(false);
   useLayoutEffect(() => {
     if (mergedData.length === 0 || perfMarkFired.current) return;
@@ -290,12 +570,106 @@ export function TrajectoryView({
     return () => cancelAnimationFrame(raf);
   }, [mergedData.length]);
 
-  // Determine if single-entity scenario (Path A: normalized_absolute scoring)
   const isSingleEntity = mergedData.some(
     (d) => d.financial_scoring_basis === "normalized_absolute",
   );
 
-  if (!trajectory) {
+  // ---------------------------------------------------------------------------
+  // Phase 4 — composite encoding data (ADR-017 §Decision table)
+  // ---------------------------------------------------------------------------
+  const primaryEntityId = entityIds?.[0] ?? null;
+
+  const effectiveActiveTrajectories = useMemo<Record<string, TrajectoryResponse>>(() => {
+    if (entityTrajectories && Object.keys(entityTrajectories).length > 0) return entityTrajectories;
+    if (trajectory && primaryEntityId) return { [primaryEntityId]: trajectory };
+    return {};
+  }, [entityTrajectories, trajectory, primaryEntityId]);
+
+  const effectiveBaselineTrajectories = useMemo<Record<string, TrajectoryResponse>>(() => {
+    if (entityBaselineTrajectories && Object.keys(entityBaselineTrajectories).length > 0) return entityBaselineTrajectories;
+    if (baseline_trajectory && primaryEntityId) return { [primaryEntityId]: baseline_trajectory };
+    return {};
+  }, [entityBaselineTrajectories, baseline_trajectory, primaryEntityId]);
+
+  const entityCount = entityIds?.length ?? 1;
+  const isLegibilityLimit = entityCount > 4;
+  // Composite path: N>1 entities, or N=1 in Mode 3 (ghost+active from store).
+  const useComposite = !isLegibilityLimit && !(entityCount <= 1 && mode !== "MODE_3");
+  const hasCompositeData = Object.keys(effectiveActiveTrajectories).length > 0;
+
+  // Shared entity-labels-overlay — rendered in every path (DEMO-063).
+  // Dynamic: N labels for N entities, indexed by position in entityIds.
+  const entityLabelsOverlay =
+    entityIds && entityIds.length >= 2 ? (
+      <div
+        data-testid="entity-labels-overlay"
+        style={{
+          position: "absolute",
+          top: 4,
+          right: 28,
+          display: "flex",
+          flexDirection: "column",
+          gap: 3,
+          pointerEvents: "none",
+        }}
+      >
+        {entityIds.map((entityId, i) => (
+          <span
+            key={entityId}
+            data-testid={`entity-label-${i}`}
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              color: ENTITY_PALETTE[i % ENTITY_PALETTE.length],
+              background: "rgba(255,255,255,0.85)",
+              padding: "1px 3px",
+            }}
+          >
+            {entityId}
+          </span>
+        ))}
+      </div>
+    ) : null;
+
+  // ---------------------------------------------------------------------------
+  // Legibility-limit notice (N > 4)
+  // ---------------------------------------------------------------------------
+  if (isLegibilityLimit) {
+    return (
+      <div
+        data-testid={dataTestId}
+        data-current-step={current_step}
+        style={{ width: width ?? 480, position: "relative" }}
+      >
+        <div
+          data-testid="zone-1a-legibility-limit"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#555",
+            fontSize: 12,
+            fontFamily: "monospace",
+            height,
+            padding: "16px 24px",
+            lineHeight: 1.5,
+            textAlign: "center",
+            borderLeft: "3px solid #ddd",
+          }}
+        >
+          Zone 1A shows individual entity trajectories for up to 4 entities. This scenario
+          has {entityCount} entities. Reduce the entity selection to 4 or fewer to see
+          trajectory curves.
+        </div>
+        {entityLabelsOverlay}
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // No data placeholder
+  // ---------------------------------------------------------------------------
+  if (!trajectory && !hasCompositeData) {
     return (
       <div
         data-testid={dataTestId}
@@ -316,50 +690,38 @@ export function TrajectoryView({
         >
           No trajectory data
         </div>
-        {/* Entity labels shown even at step 0 — audience sees which entities are loaded (DEMO-063). */}
-        {entityIds && entityIds.length >= 2 && (
-          <div
-            data-testid="entity-labels-overlay"
-            style={{
-              position: "absolute",
-              top: 4,
-              right: 28,
-              display: "flex",
-              flexDirection: "column",
-              gap: 3,
-              pointerEvents: "none",
-            }}
-          >
-            <span
-              data-testid="entity-label-0"
-              style={{
-                fontSize: 9,
-                fontWeight: 700,
-                color: FRAMEWORK_COLORS.financial,
-                background: "rgba(255,255,255,0.85)",
-                padding: "1px 3px",
-              }}
-            >
-              {entityIds[0]}
-            </span>
-            <span
-              data-testid="entity-label-1"
-              style={{
-                fontSize: 9,
-                fontWeight: 700,
-                color: FRAMEWORK_COLORS.ecological,
-                background: "rgba(255,255,255,0.85)",
-                padding: "1px 3px",
-              }}
-            >
-              {entityIds[1]}
-            </span>
-          </div>
-        )}
+        {entityLabelsOverlay}
       </div>
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // Phase 4 composite SVG (N>1 entities, or N=1 in Mode 3)
+  // ---------------------------------------------------------------------------
+  if (useComposite && hasCompositeData) {
+    const entityCodes = entityIds ?? Object.keys(effectiveActiveTrajectories);
+    return (
+      <div
+        data-testid={dataTestId}
+        data-current-step={current_step}
+        style={{ width: width ?? 480, position: "relative" }}
+      >
+        <CompositeChartSVG
+          entityCodes={entityCodes}
+          activeTrajectories={effectiveActiveTrajectories}
+          baselineTrajectories={effectiveBaselineTrajectories}
+          mode={mode}
+          width={width ?? 480}
+          height={height}
+        />
+        {entityLabelsOverlay}
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Existing recharts rendering (N=1, Mode 1/2 — unchanged path)
+  // ---------------------------------------------------------------------------
   return (
     <div
       data-testid={dataTestId}
@@ -407,7 +769,7 @@ export function TrajectoryView({
             formatter={(value) => value}
           />
 
-          {/* Uncertainty band Areas (ADR-007-gated: renders nothing until ci_lower is non-null) */}
+          {/* Uncertainty band Areas (ADR-007-gated) */}
           {FRAMEWORKS.map((fw) => (
             <Area
               key={`${fw}-band`}
@@ -422,7 +784,7 @@ export function TrajectoryView({
             />
           ))}
 
-          {/* Divergence fill Areas (Mode 3 only — always mounted, fillOpacity controls visibility) */}
+          {/* Divergence fill Areas (Mode 3 only) */}
           {FRAMEWORKS.map((fw) => (
             <Area
               key={`${fw}-divergence`}
@@ -437,8 +799,8 @@ export function TrajectoryView({
             />
           ))}
 
-          {/* Ecological WARNING floor at y=1.0 (EL Decision A — only defensible M9 floor) */}
-          {trajectory.mda_floors
+          {/* Ecological WARNING floor */}
+          {trajectory && trajectory.mda_floors
             .filter((f) => f.framework === "ecological" && f.severity === "WARNING")
             .map((floor) => (
               <ReferenceLine
@@ -451,11 +813,8 @@ export function TrajectoryView({
               />
             ))}
 
-          {/* Rider #97 — threshold-crossing markers in Mode 3 comparison.
-              Vertical lines at steps where the active trajectory crosses an MDA floor
-              that the baseline did not cross (or vice versa). Only ecological floor
-              is defined in composite score space (1.0 boundary). */}
-          {showBaseline &&
+          {/* Rider #97 — threshold-crossing markers in Mode 3 */}
+          {showBaseline && trajectory &&
             trajectory.mda_floors
               .filter((f) => f.framework === "ecological")
               .flatMap((floor) =>
@@ -464,9 +823,7 @@ export function TrajectoryView({
                     const active = d.ecological_active;
                     const baseline = d.ecological_baseline;
                     if (active === null || baseline === null) return false;
-                    const activeBreached = active >= floor.floor_value;
-                    const baselineBreached = baseline >= floor.floor_value;
-                    return activeBreached !== baselineBreached;
+                    return (active >= floor.floor_value) !== (baseline >= floor.floor_value);
                   })
                   .map((d) => (
                     <ReferenceLine
@@ -530,9 +887,7 @@ export function TrajectoryView({
         </ComposedChart>
       </ResponsiveContainer>
 
-      {/* ADR-015 §Component 1 — L0 confidence tier badges on trajectory curves (#1068).
-          One badge per active framework (score non-null), showing T{N} at the right edge.
-          Always visible at zero interaction — not a hover state or tooltip. */}
+      {/* ADR-015 §Component 1 — L0 confidence tier badges */}
       {mergedData.length > 0 && (
         <div
           style={{
@@ -575,49 +930,10 @@ export function TrajectoryView({
         </div>
       )}
 
-      {/* Inline entity labels — at right edge of chart area (DEMO-063).
-          Lets audience identify entities without consulting the legend. */}
-      {entityIds && entityIds.length >= 2 && (
-        <div
-          data-testid="entity-labels-overlay"
-          style={{
-            position: "absolute",
-            top: 20,
-            right: 28,
-            display: "flex",
-            flexDirection: "column",
-            gap: 3,
-            pointerEvents: "none",
-          }}
-        >
-          <span
-            data-testid="entity-label-0"
-            style={{
-              fontSize: 9,
-              fontWeight: 700,
-              color: FRAMEWORK_COLORS.financial,
-              background: "rgba(255,255,255,0.85)",
-              padding: "1px 3px",
-            }}
-          >
-            {entityIds[0]}
-          </span>
-          <span
-            data-testid="entity-label-1"
-            style={{
-              fontSize: 9,
-              fontWeight: 700,
-              color: FRAMEWORK_COLORS.ecological,
-              background: "rgba(255,255,255,0.85)",
-              padding: "1px 3px",
-            }}
-          >
-            {entityIds[1]}
-          </span>
-        </div>
-      )}
+      {/* Entity labels overlay — N-entity dynamic (DEMO-063) */}
+      {entityLabelsOverlay}
 
-      {/* Multi-entity composite note — shown when two entities present */}
+      {/* Multi-entity composite note */}
       {!isSingleEntity && entityIds && entityIds.length === 2 && (
         <div
           style={{


### PR DESCRIPTION
## Summary

- **Zone 1A (Issue #845)**: Phase 4 composite encoding per ADR-017 §Decision table. Replaces recharts for multi-entity scenarios with a custom SVG chart (`CompositeChartSVG`). Implements the full N-dependent routing: N>4 legibility-limit notice; N≤4 Mode 1/2 per-entity composite lines with MDA floors and tier badges; N≤4 Mode 3 baseline ghost paths + active solid paths with divergence fill when |active−baseline|>0.001; N=1 Mode 3 using Zustand store single-entity trajectories. `ScenarioInstrumentCluster` fetches per-entity trajectories in parallel and captures Mode 3 baselines with a deferred-save fallback to handle the trajectory-load/mode-toggle race condition.
- **Zone 1D (Issue #1147)**: PSP step-over-step delta annotations per ADR-015 §Component 3. `prevPspRef` (useRef) captures the previous PSP value; delta computed synchronously during render; `psp-delta` element (↓Npp/↑Npp, red/green) and `psp-delta-sentence` Layer 3 output sentence rendered at step ≥1, both absent at step 0.

## Files changed

- `frontend/src/components/TrajectoryView.tsx` — CompositeChartSVG + routing logic + entityLabelsOverlay
- `frontend/src/components/ScenarioInstrumentCluster.tsx` — multi-entity fetch + Mode 3 auto-baseline
- `frontend/src/components/InstrumentCluster.tsx` — prop passthrough for entityTrajectories/entityBaselineTrajectories
- `frontend/src/components/FourFrameworkZone1D.tsx` — prevPspRef + psp-delta + psp-delta-sentence

## Pre-push gates

- `cd frontend && npm run build` — exits 0, 0 TypeScript errors (chunk size warning only, pre-existing)
- No backend files modified — backend lint gate not applicable

## QA

QA tests for all acceptance criteria (AC-1 through AC-12) were authored and merged separately in PR #1152 (branch `test/m16-g5-process-fixes`). Tests authored before implementation per agent execution lifecycle §Step 2.

## ADRs

ADR-017 (Zone 1A Information Architecture), ADR-015 (Model Legibility Architecture)

## Test plan

- [ ] CI passes (frontend build + existing E2E suite)
- [ ] AC-1: `zone-1a-legibility-limit` present when `entityIds.length > 4`
- [ ] AC-2: Entity-count composite lines rendered for N=2..4
- [ ] AC-3: Mode 3 ghost (opacity≤0.55, dashed) + active (opacity≥0.99) paths per entity
- [ ] AC-4: Divergence fill present/absent per hasDivergence condition
- [ ] AC-5: MDA floor line per entity
- [ ] AC-6: Tier badge per entity
- [ ] AC-7/8: psp-delta absent at step 0, present at step ≥1
- [ ] AC-9: psp-delta-sentence Layer 3 sentence present when delta available
- [ ] AC-10/11/12: entity-labels-overlay N=1/2/N>4 logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)