### PR TITLE
feat(m16-g2): cohort disaggregation + political risk summary on primary surface (#986, #987, #1163)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -113,7 +113,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -427,7 +426,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -474,9 +472,45 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1352,7 +1386,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1477,7 +1512,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1488,7 +1522,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1499,7 +1532,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1564,7 +1596,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -1966,7 +1997,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2006,6 +2036,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2038,6 +2069,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2121,7 +2153,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2448,6 +2479,7 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2466,7 +2498,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/earcut": {
       "version": "3.0.2",
@@ -2539,7 +2572,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3472,6 +3504,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3736,7 +3769,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3840,6 +3872,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3854,6 +3887,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3865,7 +3899,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
@@ -3893,7 +3928,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3903,7 +3937,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3923,7 +3956,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3976,8 +4008,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4363,7 +4394,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4490,7 +4520,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4781,7 +4810,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -17,7 +17,7 @@
  *
  * Implements: US-021, US-022, ADR-008 Decision 7, DD-011, ADR-015 Components 1+3
  */
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
 import { FRAMEWORK_COLORS } from "../constants/frameworkColors";
 import { sortAlerts } from "./MDAAlertPanelZone1B";
@@ -129,6 +129,53 @@ export function formatReversibilityLabel(
 // FourFrameworkZone1D
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// PSP severity classification (M16-G2 #987, #1163)
+// ---------------------------------------------------------------------------
+
+export type PspSeverity = "CRITICAL" | "WARNING" | "WATCH" | "STABLE";
+
+/** Classify PSP value into severity tier per CM-calibrated thresholds (2026-06-23). */
+export function getPspSeverity(pspValue: string): PspSeverity {
+  const v = parseFloat(pspValue);
+  if (v < 0.40) return "CRITICAL";
+  if (v < 0.55) return "WARNING";
+  if (v < 0.70) return "WATCH";
+  return "STABLE";
+}
+
+const PSP_SEVERITY_COLOR: Record<PspSeverity, string> = {
+  CRITICAL: "#cc0000",
+  WARNING: "#a06000",
+  WATCH: "#0070a0",
+  STABLE: "#059669",
+};
+
+/** Historical analogue sentence per PSP severity (CM sign-off 2026-06-23). */
+function getPspHistoricalAnalogue(severity: PspSeverity): string | null {
+  if (severity === "CRITICAL") return "At this level, historical ECF programmes show abandonment within 3 steps.";
+  if (severity === "WARNING") return "At this level, historical ECF programmes show abandonment within 6 steps.";
+  if (severity === "WATCH") return "At this level, historical ECF programmes show elevated discontinuation risk.";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Legitimacy floor proximity label
+// ---------------------------------------------------------------------------
+
+function getFloorProximityLabel(value: string, floor: string): string {
+  const v = parseFloat(value);
+  const f = parseFloat(floor);
+  const diff = Math.abs(v - f);
+  if (Math.abs(v - f) < 0.001) return "AT fragility threshold";
+  if (v > f) return `${diff.toFixed(2)} above fragility threshold`;
+  return `${diff.toFixed(2)} below fragility threshold`;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
 interface FourFrameworkZone1DProps {
   "data-testid"?: string;
   /** True while the trajectory fetch is in flight (IR-006). */
@@ -141,17 +188,27 @@ interface FourFrameworkZone1DProps {
   entityIds?: string[];
   /** ADR-015 §Component 1: data-quality per framework (DA-G5-1). */
   dataQuality?: Record<string, FrameworkDataQuality> | null;
-  /** ADR-015 §Component 3: whether political economy module is enabled (DA-G5-3). */
+  /** Whether political economy module is enabled (DA-G5-3). */
   peEnabled?: boolean;
   /**
-   * ADR-015 §Component 3: programme_survival_probability value as Decimal string.
-   * undefined = not fetched / PE disabled (row absent).
-   * null = PE enabled but computation returned null (show error row).
-   * string = valid value (show percentage).
+   * M16-G2 (#987): programme_survival_probability value as Decimal string.
+   * undefined = not fetched / PE disabled (section absent).
+   * null = PE enabled but computation returned null.
+   * string = valid value.
    */
   pspValue?: string | null;
-  /** ADR-015 §Component 3: confidence tier of the PSP indicator. */
+  /** Confidence tier of the PSP indicator. */
   pspTier?: number | null;
+  /** M16-G2 (#987): legitimacy_index value as Decimal string (null = unavailable). */
+  legitimacyValue?: string | null;
+  /** M16-G2 (#987): legitimacy_index floor value as Decimal string. */
+  legitimacyFloor?: string | null;
+  /** M16-G2 (#987): legitimacy_index direction ("declining" | "stable" | "improving"). */
+  legitimacyDirection?: string | null;
+  /** M16-G2 (#987): elite_capture_divergence direction ("widening" | "stable" | "narrowing"). */
+  eliteCaptureDirection?: string | null;
+  /** M16-G2 (#987): elite_capture_divergence qualifier text (e.g. "fiscal benefits concentrating"). */
+  eliteCaptureQualifier?: string | null;
 }
 
 const CONTAINER_STYLE: React.CSSProperties = {
@@ -172,24 +229,14 @@ export function FourFrameworkZone1D({
   dataQuality,
   peEnabled,
   pspValue,
-  pspTier,
+  pspTier: _pspTier,
+  legitimacyValue,
+  legitimacyFloor,
+  legitimacyDirection,
+  eliteCaptureDirection,
+  eliteCaptureQualifier,
 }: FourFrameworkZone1DProps) {
   const { trajectory, current_step, mda_alerts, mode } = useScenarioStepStore();
-
-  // ADR-017 §Zone 1D Integration — step-over-step PSP delta tracking.
-  // prevPspRef holds the PSP value from the previous render cycle.
-  // Read synchronously during render; updated in useEffect (after paint) so
-  // next render sees the previous value as "prev".
-  const prevPspRef = useRef<string | null | undefined>(undefined);
-  const pspDeltaPercent: number | null =
-    pspValue != null && prevPspRef.current != null
-      ? Math.round((parseFloat(pspValue) - parseFloat(prevPspRef.current)) * 100)
-      : null;
-  useEffect(() => {
-    if (pspValue !== undefined) {
-      prevPspRef.current = pspValue;
-    }
-  }, [pspValue]);
 
   // Top alert per framework for the "see alerts →" navigation link (#745)
   const topAlertByFramework: Record<string, string> = {};
@@ -401,105 +448,123 @@ export function FourFrameworkZone1D({
         );
       })}
 
-      {/* ADR-015 §Component 3 — Political Feasibility row (programme_survival_probability).
-          ADR-017 §Zone 1D Integration — PSP delta shown inline when prev PSP is known (step ≥ 1).
-          Visible only when PE module is enabled. Absent entirely when PE is disabled. */}
-      {peEnabled && (
-        <div
-          data-testid="zone-1d-political-feasibility"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            borderLeft: "3px solid #7c3aed",
-            paddingLeft: 6,
-            paddingTop: 2,
-            paddingBottom: 2,
-          }}
-        >
-          <span style={{ fontSize: 11, color: "#555", fontWeight: 500 }}>
-            Political Feasibility
-          </span>
-          <span
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 4,
-              fontSize: 12,
-              fontWeight: 700,
-              color: "#7c3aed",
-              fontVariantNumeric: "tabular-nums",
-            }}
-          >
-            {pspValue === undefined ? (
-              "—"
-            ) : pspValue === null ? (
-              <span style={{ color: "#cc0000", fontSize: 10 }}>— [computation error]</span>
-            ) : (
-              `${(parseFloat(pspValue) * 100).toFixed(0)}% [T${pspTier ?? 3} · political economy module]`
-            )}
-            {/* ADR-017 §Zone 1D Integration — step-over-step delta annotation */}
-            {pspDeltaPercent !== null && (
+      {/* M16-G2 #987 — Political Risk sub-section (replaces G1 political economy elements).
+          Visible when PE enabled; shows structured severity-labeled summary for Persona 3.
+          Empty state shown when PE is disabled. G1 testids fully retired (DD-016). */}
+      {peEnabled ? (
+        pspValue !== undefined ? (
+          <div data-testid="zone-1d-political-risk">
+            {/* Section divider + header */}
+            <div
+              style={{
+                borderTop: "1px solid #e0e0e0",
+                paddingTop: 4,
+                marginTop: 2,
+              }}
+            >
               <span
-                data-testid="psp-delta"
+                data-testid="zone-1d-political-risk-header"
+                style={{ fontSize: 9, fontWeight: 600, color: "#555", letterSpacing: 0.3 }}
+              >
+                POLITICAL RISK
+              </span>
+            </div>
+
+            {/* PSP severity row */}
+            {pspValue !== null ? (() => {
+              const severity = getPspSeverity(pspValue);
+              const pspPct = Math.round(parseFloat(pspValue) * 100);
+              const severityColor = PSP_SEVERITY_COLOR[severity];
+              const analogue = getPspHistoricalAnalogue(severity);
+              return (
+                <>
+                  <div
+                    data-testid="psp-severity-row"
+                    style={{ paddingTop: 2, fontSize: 11, color: "#333" }}
+                  >
+                    {"Programme survival: "}
+                    <span
+                      data-testid="psp-severity-badge"
+                      style={{ fontWeight: 700, color: severityColor }}
+                    >
+                      {severity}
+                    </span>
+                    {` (${pspPct}%) — `}
+                    <span style={{ color: "#555" }}>
+                      {legitimacyDirection === "declining" || eliteCaptureDirection === "widening"
+                        ? "DECLINING"
+                        : "STABLE"}
+                    </span>
+                  </div>
+                  {analogue && (
+                    <div
+                      data-testid="psp-historical-analogue"
+                      style={{ paddingTop: 1, paddingBottom: 1, fontSize: 10, color: "#555", lineHeight: 1.3 }}
+                    >
+                      {analogue}
+                    </div>
+                  )}
+                </>
+              );
+            })() : (
+              <div
+                data-testid="psp-severity-row"
+                style={{ paddingTop: 2, fontSize: 10, color: "#aaa", fontStyle: "italic" }}
+              >
+                Programme survival: unavailable
+              </div>
+            )}
+
+            {/* Legitimacy index row */}
+            {legitimacyValue != null && (
+              <>
+                <div
+                  data-testid="legitimacy-index-row"
+                  style={{ paddingTop: 1, fontSize: 10, color: "#333" }}
+                >
+                  {`Legitimacy index: ${parseFloat(legitimacyValue).toFixed(2)} — `}
+                  <span style={{ color: "#555" }}>{legitimacyDirection ?? "unknown"}</span>
+                  {legitimacyFloor != null && (
+                    <span style={{ color: "#888" }}>{` (floor: ${parseFloat(legitimacyFloor).toFixed(2)})`}</span>
+                  )}
+                </div>
+                {legitimacyFloor != null && (
+                  <div
+                    data-testid="legitimacy-floor-proximity"
+                    style={{ fontSize: 9, color: "#777", paddingBottom: 1 }}
+                  >
+                    {getFloorProximityLabel(legitimacyValue, legitimacyFloor)}
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Elite capture row */}
+            {eliteCaptureDirection != null && (
+              <div
+                data-testid="elite-capture-row"
                 style={{
+                  paddingTop: 1,
+                  paddingBottom: 1,
                   fontSize: 10,
-                  fontWeight: 700,
-                  color: pspDeltaPercent < 0 ? "#dc2626" : "#059669",
+                  color: "#333",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
                 }}
               >
-                {pspDeltaPercent < 0
-                  ? `↓${Math.abs(pspDeltaPercent)}pp`
-                  : `↑${pspDeltaPercent}pp`}
-              </span>
+                {`Elite capture divergence: ${eliteCaptureDirection}`}
+                {eliteCaptureQualifier != null && ` — ${eliteCaptureQualifier}`}
+              </div>
             )}
-          </span>
-        </div>
-      )}
-
-      {/* ADR-015 §Component 3 — PSP Layer 3 self-interpreting sentence (#1075).
-          Visible when PE enabled and PSP value is available. Fallback when null. */}
-      {peEnabled && pspValue !== undefined && (
+          </div>
+        ) : null
+      ) : (
         <div
-          data-testid="psp-layer3-sentence"
-          style={{
-            borderLeft: "3px solid #7c3aed",
-            paddingLeft: 6,
-            paddingTop: 2,
-            paddingBottom: 2,
-            fontSize: 10,
-            color: "#555",
-            lineHeight: 1.4,
-          }}
+          data-testid="political-risk-empty"
+          style={{ paddingTop: 4, fontSize: 10, color: "#aaa", fontStyle: "italic" }}
         >
-          {pspValue === null ? (
-            "Programme survival probability unavailable — computation error."
-          ) : (
-            `Programme survival probability: ${(parseFloat(pspValue) * 100).toFixed(0)}%. This means the programme has a ${(parseFloat(pspValue) * 100).toFixed(0)}% chance of remaining on track through conditionality compliance.`
-          )}
-        </div>
-      )}
-
-      {/* ADR-017 §Zone 1D Integration — PSP delta Layer 3 sentence (#1147).
-          Visible at step ≥ 1 when previous PSP is known. Absent at step 0 or when
-          delta cannot be computed (prev PSP unavailable). */}
-      {peEnabled && pspValue != null && pspDeltaPercent !== null && (
-        <div
-          data-testid="psp-delta-sentence"
-          style={{
-            borderLeft: "3px solid #7c3aed",
-            paddingLeft: 6,
-            paddingTop: 2,
-            paddingBottom: 2,
-            fontSize: 10,
-            color: pspDeltaPercent < 0 ? "#dc2626" : "#059669",
-            lineHeight: 1.4,
-            fontWeight: 500,
-          }}
-        >
-          {pspDeltaPercent === 0
-            ? "programme survival unchanged this step"
-            : `programme survival ${pspDeltaPercent < 0 ? "dropped" : "improved"} ${Math.abs(pspDeltaPercent)} percentage point${Math.abs(pspDeltaPercent) !== 1 ? "s" : ""} this step`}
+          Political risk: not modelled in this fixture.
         </div>
       )}
     </div>

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -19,6 +19,15 @@ export const LAYOUT = {
   1440: { trajectory: 680, coPrimary: 400, controlPlane: 280, chartHeight: 380 },
 } as const;
 
+// DD-016 (M16-G2): viewport-responsive Zone 1B/1C/1D flex proportions.
+// Previous values (M9/DD-015): 45/25/30. New values support the political risk
+// sub-section in Zone 1D without overflow at 1280×800.
+export const ZONE_PROPORTIONS = {
+  1024: { zone1b: "50%", zone1c: "10%", zone1d: "40%" },
+  1280: { zone1b: "35%", zone1c: "15%", zone1d: "50%" },
+  1440: { zone1b: "40%", zone1c: "15%", zone1d: "45%" },
+} as const;
+
 export function useViewportBreakpoint(): 1024 | 1280 | 1440 {
   const [bp, setBp] = useState<1024 | 1280 | 1440>(
     window.innerWidth >= 1440 ? 1440 : window.innerWidth >= 1280 ? 1280 : 1024,
@@ -40,6 +49,9 @@ interface InstrumentClusterProps {
   fourFramework?: React.ReactNode;
   /** Human cost ledger strip rendered below Zone 1A trajectory chart (Issue #747). */
   cohortPanel?: React.ReactNode;
+  /** M16-G2 (#986) — Cohort Impact sub-section rendered below MDA panel in zone-1b.
+   *  Rendered as a flex sibling (not inside mdaPanel) so it has guaranteed visible space. */
+  zone1bCohortSection?: React.ReactNode;
   /** Entity ISO codes for multi-case Mode 1 tick format (UD-R2). */
   entityIds?: string[];
   /** Override chart height (px) — defaults to LAYOUT[bp].chartHeight. */
@@ -55,6 +67,7 @@ export function InstrumentCluster({
   pmmWidget,
   fourFramework,
   cohortPanel,
+  zone1bCohortSection,
   entityIds,
   chartHeight: chartHeightProp,
   entityTrajectories,
@@ -63,6 +76,7 @@ export function InstrumentCluster({
   const { mode } = useScenarioStepStore();
   const bp = useViewportBreakpoint();
   const layout = LAYOUT[bp];
+  const zoneProportions = ZONE_PROPORTIONS[bp];
   const chartHeight = chartHeightProp ?? layout.chartHeight;
 
   const isMode3 = mode === "MODE_3";
@@ -103,20 +117,31 @@ export function InstrumentCluster({
           minWidth: layout.coPrimary,
         }}
       >
-        {/* Zone 1B — MDA Alert Panel (~45% of column height) */}
-        {/* data-testid lives on MDAAlertPanelZone1B root — not duplicated here */}
-        {/* overflow:auto (not hidden) so MDAAlertPanelZone1B scroll is not clipped (DEMO-060) */}
-        <div style={{ flex: "0 0 45%", overflow: "auto" }}>
-          {mdaPanel ?? (
-            <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
-              MDA Alert Panel (Zone 1B)
-            </div>
-          )}
+        {/* Zone 1B — MDA Alert Panel + Cohort Impact sub-section (DD-016, M16-G2 #986) */}
+        {/* Flex column: mdaPanel gets flex:1 1 0 (fills remaining space after cohort section);
+            zone1bCohortSection gets flex:0 0 auto (natural height, always visible). */}
+        <div
+          data-testid="zone-1b"
+          style={{
+            flex: `0 0 ${zoneProportions.zone1b}`,
+            overflow: "auto",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <div style={{ flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>
+            {mdaPanel ?? (
+              <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
+                MDA Alert Panel (Zone 1B)
+              </div>
+            )}
+          </div>
+          {zone1bCohortSection}
         </div>
 
-        {/* Zone 1C — PMM Widget (~25% of column height) */}
+        {/* Zone 1C — PMM Widget (DD-016: 15% at 1280/1440, 10% at 1024) */}
         {/* data-testid lives on PMMWidgetZone1C root — not duplicated here */}
-        <div style={{ flex: "0 0 25%", overflow: "hidden" }}>
+        <div style={{ flex: `0 0 ${zoneProportions.zone1c}`, overflow: "hidden" }}>
           {pmmWidget ?? (
             <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
               PMM Widget (Zone 1C)
@@ -124,9 +149,10 @@ export function InstrumentCluster({
           )}
         </div>
 
-        {/* Zone 1D — Four-Framework Current Position (~30% of column height) */}
+        {/* Zone 1D — Four-Framework + Political Risk sub-section (DD-016: 50% at 1280) */}
         {/* data-testid lives on FourFrameworkZone1D root — not duplicated here */}
-        <div style={{ flex: "0 0 30%", overflow: "hidden" }}>
+        {/* overflow-y:auto per DD-016 — prevents clipping at 1024; no-op at 1280/1440 */}
+        <div style={{ flex: `0 0 ${zoneProportions.zone1d}`, overflowY: "auto" }}>
           {fourFramework ?? (
             <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
               Four-Framework Current Position (Zone 1D)

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -669,13 +669,12 @@ const COHORT_SEVERITY_COLOR: Record<CohortThresholdCrossing["severity"], string>
   WATCH: "#0070a0",
 };
 
-export function CohortImpactSection() {
-  const { cohort_threshold_crossings: crossings, mode } = useScenarioStepStore();
-  const headerLabel = mode === "MODE_1" ? "COHORT IMPACT (HISTORICAL)" : "COHORT IMPACT";
-  const emptyText =
-    mode === "MODE_1"
-      ? "No cohort threshold crossings at or before this step."
-      : "No cohort threshold crossings projected on current path.";
+export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boolean }) {
+  const { cohort_threshold_crossings: crossings } = useScenarioStepStore();
+  const headerLabel = isCompleted ? "COHORT IMPACT (HISTORICAL)" : "COHORT IMPACT";
+  const emptyText = isCompleted
+    ? "No cohort threshold crossings at or before this step."
+    : "No cohort threshold crossings projected on current path.";
 
   return (
     <div

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -19,7 +19,7 @@
  * AlertDetailPanel is exported for future EntityDetailDrawer use (ADR-014).
  */
 import { useEffect, useRef, useState } from "react";
-import { useScenarioStepStore, type Zone1BAlert } from "../store/scenarioStepStore";
+import { useScenarioStepStore, type Zone1BAlert, type CohortThresholdCrossing } from "../store/scenarioStepStore";
 import { getIndicatorDisplayNameAny, getIndicatorAbbreviation } from "../lib/indicatorDisplayNames";
 
 // ---------------------------------------------------------------------------
@@ -651,6 +651,92 @@ function CompactAlertList({ alerts, onClearNewBadge }: CompactAlertListProps) {
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CohortImpactSection — Zone 1B Cohort Impact sub-section (M16-G2 #986)
+//
+// Standalone store-connected component. Rendered as a sibling of MDAAlertPanelZone1B
+// inside the zone-1b flex wrapper (not nested inside MDAAlertPanelZone1B) so that
+// it occupies a guaranteed visible slot in zone-1b regardless of MDA panel content height.
+// ---------------------------------------------------------------------------
+
+const COHORT_SEVERITY_COLOR: Record<CohortThresholdCrossing["severity"], string> = {
+  CRITICAL: "#cc0000",
+  WARNING: "#a06000",
+  WATCH: "#0070a0",
+};
+
+export function CohortImpactSection() {
+  const { cohort_threshold_crossings: crossings, mode } = useScenarioStepStore();
+  const headerLabel = mode === "MODE_1" ? "COHORT IMPACT (HISTORICAL)" : "COHORT IMPACT";
+  const emptyText =
+    mode === "MODE_1"
+      ? "No cohort threshold crossings at or before this step."
+      : "No cohort threshold crossings projected on current path.";
+
+  return (
+    <div
+      data-testid="zone-1b-cohort-impact"
+      style={{ borderTop: "1px solid #e0e0e0", paddingTop: 2, flexShrink: 0, background: "#fff" }}
+    >
+      <div
+        data-testid="cohort-section-header"
+        style={{
+          fontSize: 9,
+          fontWeight: 600,
+          color: "#555",
+          letterSpacing: 0.3,
+          paddingBottom: 2,
+          paddingLeft: 4,
+        }}
+      >
+        {headerLabel}
+      </div>
+      {crossings.length === 0 ? (
+        <div
+          data-testid="cohort-empty-state"
+          style={{ fontSize: 10, color: "#aaa", fontStyle: "italic", paddingLeft: 4 }}
+        >
+          {emptyText}
+        </div>
+      ) : (
+        crossings.map((crossing, idx) => {
+          const color = COHORT_SEVERITY_COLOR[crossing.severity];
+          return (
+            <div
+              key={`${crossing.quintile_key}-${crossing.indicator_key}`}
+              data-testid={`cohort-row-${idx}`}
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 4,
+                borderLeft: `2px solid ${color}`,
+                paddingLeft: 6,
+                paddingTop: 2,
+                paddingBottom: 2,
+                marginBottom: 2,
+                fontSize: 10,
+              }}
+            >
+              <span style={{ color, fontWeight: 700, flexShrink: 0, fontSize: 9 }}>
+                {crossing.severity}
+              </span>
+              <span style={{ color: "#333", lineHeight: 1.3 }}>
+                <span style={{ fontWeight: 600 }}>
+                  {crossing.cohort_label} — {crossing.indicator_label}
+                </span>
+                <br />
+                <span style={{ color: "#666" }}>
+                  {`Threshold crossed at step ${crossing.step_crossed} · was ${crossing.above_floor_pct}% above floor · T${crossing.tier} · ${crossing.source}`}
+                </span>
+              </span>
+            </div>
+          );
+        })
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -30,13 +30,13 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { InstrumentCluster, LAYOUT, useViewportBreakpoint } from "./InstrumentCluster";
-import { MDAAlertPanelZone1B } from "./MDAAlertPanelZone1B";
+import { MDAAlertPanelZone1B, CohortImpactSection } from "./MDAAlertPanelZone1B";
 import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
 import { FourFrameworkZone1D } from "./FourFrameworkZone1D";
 import { CohortIndicatorsPanel } from "./CohortIndicatorsPanel";
 import { ControlPlane, type Mode3Params } from "./ControlPlane";
 import { useScenarioStepStore } from "../store/scenarioStepStore";
-import type { TrajectoryResponse, TrajectoryFrameworkPoint, Zone1BAlert } from "../store/scenarioStepStore";
+import type { TrajectoryResponse, TrajectoryFrameworkPoint, Zone1BAlert, CohortThresholdCrossing } from "../store/scenarioStepStore";
 import type { QuantitySchema, ScenarioDetailResponse } from "../types";
 import type { FrameworkDataQuality } from "./FourFrameworkZone1D";
 
@@ -140,9 +140,22 @@ interface RawMDAAlert {
   recovery_horizon_years?: number | null;
 }
 
+interface RawCohortThresholdCrossing {
+  quintile_key: string;
+  cohort_label: string;
+  indicator_key: string;
+  indicator_label: string;
+  severity: "CRITICAL" | "WARNING" | "WATCH";
+  step_crossed: number;
+  above_floor_pct: string;
+  tier: number;
+  source: string;
+}
+
 interface RawFrameworkOutputForAlerts {
   mda_alerts: RawMDAAlert[];
   indicators: Record<string, unknown>;
+  cohort_threshold_crossings?: RawCohortThresholdCrossing[];
 }
 
 interface RawMultiFrameworkOutput {
@@ -242,6 +255,13 @@ export function ScenarioInstrumentCluster({
   // undefined = not yet fetched or PE not active; null = PE active but computation failed; string = value.
   const [pspValue, setPspValue] = useState<string | null | undefined>(undefined);
   const [pspTier, setPspTier] = useState<number | null>(null);
+
+  // M16-G2 (#987) — political economy indicators for Zone 1D political risk sub-section.
+  const [legitimacyValue, setLegitimacyValue] = useState<string | null | undefined>(undefined);
+  const [legitimacyFloor, setLegitimacyFloor] = useState<string | null>(null);
+  const [legitimacyDirection, setLegitimacyDirection] = useState<string | null>(null);
+  const [eliteCaptureDirection, setEliteCaptureDirection] = useState<string | null>(null);
+  const [eliteCaptureQualifier, setEliteCaptureQualifier] = useState<string | null>(null);
 
   // ADR-017 Phase 4 — per-entity trajectory maps for composite encoding.
   const [entityTrajectories, setEntityTrajectories] = useState<Record<string, TrajectoryResponse>>({});
@@ -494,7 +514,23 @@ export function ScenarioInstrumentCluster({
           setHdState((s) => ({ prev: s.current, current: flat }));
         }
 
+        // M16-G2 (#986) — extract cohort threshold crossings from human_development output.
+        const hdCrossings = (hdOutput?.cohort_threshold_crossings ?? []) as RawCohortThresholdCrossing[];
+        const parsedCrossings: CohortThresholdCrossing[] = hdCrossings.map((c) => ({
+          quintile_key: c.quintile_key,
+          cohort_label: c.cohort_label,
+          indicator_key: c.indicator_key,
+          indicator_label: c.indicator_label,
+          severity: c.severity,
+          step_crossed: c.step_crossed,
+          above_floor_pct: c.above_floor_pct,
+          tier: c.tier,
+          source: c.source,
+        }));
+        store.setCohortThresholdCrossings(parsedCrossings);
+
         // ADR-015 §Component 3 — extract programme_survival_probability (DA-G5-4 Option A).
+        // M16-G2 (#987) — also extract legitimacy_index and elite_capture_divergence.
         const peOutput = raw.outputs["political_economy"];
         const peEnabled = activeScenarioDetail?.configuration?.modules_config?.political_economy?.enabled;
         if (peOutput && peEnabled) {
@@ -511,14 +547,42 @@ export function ScenarioInstrumentCluster({
               typeof entry.confidence_tier === "number" ? entry.confidence_tier : null,
             );
           } else {
-            // PE enabled but PSP indicator absent from output — treat as computation error
             setPspValue(null);
             setPspTier(null);
           }
+
+          // M16-G2 (#987) — legitimacy_index
+          const legEntry = peOutput.indicators["legitimacy_index"];
+          if (legEntry !== null && legEntry !== undefined && typeof legEntry === "object") {
+            const leg = legEntry as { value?: string | null; floor?: string | null; direction?: string | null };
+            setLegitimacyValue(leg.value ?? null);
+            setLegitimacyFloor(leg.floor ?? null);
+            setLegitimacyDirection(leg.direction ?? null);
+          } else {
+            setLegitimacyValue(null);
+            setLegitimacyFloor(null);
+            setLegitimacyDirection(null);
+          }
+
+          // M16-G2 (#987) — elite_capture_divergence
+          const ecEntry = peOutput.indicators["elite_capture_divergence"];
+          if (ecEntry !== null && ecEntry !== undefined && typeof ecEntry === "object") {
+            const ec = ecEntry as { direction?: string | null; qualifier?: string | null };
+            setEliteCaptureDirection(ec.direction ?? null);
+            setEliteCaptureQualifier(ec.qualifier ?? null);
+          } else {
+            setEliteCaptureDirection(null);
+            setEliteCaptureQualifier(null);
+          }
         } else if (!peEnabled) {
-          // PE not enabled — reset PSP state so row is absent
+          // PE not enabled — reset all PE state
           setPspValue(undefined);
           setPspTier(null);
+          setLegitimacyValue(undefined);
+          setLegitimacyFloor(null);
+          setLegitimacyDirection(null);
+          setEliteCaptureDirection(null);
+          setEliteCaptureQualifier(null);
         }
       })
       .catch(() => {
@@ -779,6 +843,7 @@ export function ScenarioInstrumentCluster({
             columnWidth={coPrimaryWidth}
           />
         }
+        zone1bCohortSection={<CohortImpactSection />}
         pmmWidget={<PMMWidgetZone1C />}
         fourFramework={
           <FourFrameworkZone1D
@@ -789,6 +854,11 @@ export function ScenarioInstrumentCluster({
             peEnabled={activeScenarioDetail?.configuration?.modules_config?.political_economy?.enabled ?? false}
             pspValue={pspValue}
             pspTier={pspTier}
+            legitimacyValue={legitimacyValue}
+            legitimacyFloor={legitimacyFloor}
+            legitimacyDirection={legitimacyDirection}
+            eliteCaptureDirection={eliteCaptureDirection}
+            eliteCaptureQualifier={eliteCaptureQualifier}
           />
         }
         cohortPanel={

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -843,7 +843,7 @@ export function ScenarioInstrumentCluster({
             columnWidth={coPrimaryWidth}
           />
         }
-        zone1bCohortSection={<CohortImpactSection />}
+        zone1bCohortSection={<CohortImpactSection isCompleted={activeScenarioDetail?.status === "completed"} />}
         pmmWidget={<PMMWidgetZone1C />}
         fourFramework={
           <FourFrameworkZone1D

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -76,6 +76,23 @@ export interface Zone1BAlert {
   recovery_horizon_years: number | null;
 }
 
+/**
+ * Cohort threshold crossing — from outputs.human_development.cohort_threshold_crossings.
+ * M16-G2 (#986): income quintile cohort disaggregation on primary surface (Zone 1B).
+ * Scope: poverty_headcount_ratio Q1/Q2 only (DA sign-off 2026-06-23).
+ */
+export interface CohortThresholdCrossing {
+  quintile_key: string;
+  cohort_label: string;
+  indicator_key: string;
+  indicator_label: string;
+  severity: "CRITICAL" | "WARNING" | "WATCH";
+  step_crossed: number;
+  above_floor_pct: string;
+  tier: number;
+  source: string;
+}
+
 interface ScenarioStepState {
   scenario_id: string;
   current_step: number;
@@ -85,6 +102,8 @@ interface ScenarioStepState {
   computation_state: "idle" | "computing" | "complete";
   mode: "MODE_1" | "MODE_2" | "MODE_3";
   mda_alerts: Zone1BAlert[];
+  /** M16-G2 (#986) — cohort threshold crossings at the current step (Zone 1B Cohort Impact sub-section). */
+  cohort_threshold_crossings: CohortThresholdCrossing[];
   /** Zone 1C — Policy Maneuver Margin value at current step. */
   pmm_value: number | null;
   /** Zone 1C — Direction indicator: margin growing, shrinking, or flat since last step. */
@@ -114,6 +133,7 @@ interface ScenarioStepState {
   /** Jump to a specific step — used by scenario re-selection to land on the final step. */
   setCurrentStep: (step: number) => void;
   setMdaAlerts: (alerts: Zone1BAlert[]) => void;
+  setCohortThresholdCrossings: (crossings: CohortThresholdCrossing[]) => void;
   /** Set PMM state in a single set() call (DD-012 atomicity). */
   setPmmState: (value: number | null, direction: "up" | "down" | "flat" | null) => void;
   advanceStep: () => void;
@@ -142,6 +162,7 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
   computation_state: "idle",
   mode: "MODE_1",
   mda_alerts: [],
+  cohort_threshold_crossings: [],
   pmm_value: null,
   pmm_direction: null,
   baselineScenarioId: null,
@@ -160,6 +181,7 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
       baseline_trajectory: null,
       computation_state: "idle",
       mda_alerts: [],
+      cohort_threshold_crossings: [],
       pmm_value: null,
       pmm_direction: null,
     }),
@@ -173,6 +195,8 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
   setCurrentStep: (step) => set({ current_step: step }),
 
   setMdaAlerts: (alerts) => set({ mda_alerts: alerts }),
+
+  setCohortThresholdCrossings: (crossings) => set({ cohort_threshold_crossings: crossings }),
 
   setPmmState: (value, direction) => set({ pmm_value: value, pmm_direction: direction }),
 
@@ -234,6 +258,7 @@ export const useScenarioStepStore = create<ScenarioStepState>((set, get) => ({
       computation_state: "idle",
       mode: "MODE_1",
       mda_alerts: [],
+      cohort_threshold_crossings: [],
       pmm_value: null,
       pmm_direction: null,
       baselineScenarioId: null,


### PR DESCRIPTION
## Summary

- **#986 — Zone 1B cohort disaggregation**: `CohortImpactSection` renders below MDA alert panel as a flex sibling (not nested), guaranteeing visible space at 1280×800 where MDAAlertPanelZone1B's TopAlertDetail alone approaches zone-1b's 112px height. Severity-coloured rows (CRITICAL/WARNING/WATCH) show quintile cohort, indicator, step crossed, and above-floor pct.
- **#987 — Zone 1D political risk summary**: PSP severity badge (CRITICAL < 0.40 / WARNING 0.40–0.55 / WATCH 0.55–0.70 / STABLE > 0.70) with historical-analogue sentence, legitimacy index floor-proximity row, and elite capture divergence row. G1 political-feasibility elements (zone-1d-political-feasibility, psp-delta, psp-layer3-sentence, psp-delta-sentence) removed per AC-14.
- **#1163 — PSP threshold legibility** (closed by #987): severity-labeled display makes absolute PSP values self-interpreting without additional annotation.
- **DD-016 flex proportions**: Zone 1B/1C/1D at 35%/15%/50% (1280), 40%/15%/45% (1440), 50%/10%/40% (1024). Zone 1D overflow-y:auto prevents clipping at 1024.
- **Store**: `CohortThresholdCrossing` type + `cohort_threshold_crossings` field + `setCohortThresholdCrossings` action added; reset on `setScenario` and `reset`.

## Pre-push gates

- `cd frontend && npm run build` — ✅ exit 0, zero TS errors
- Backend Python files unchanged — lint gate not applicable

## Test plan

- QA tests pre-merged in PR #1170 (`feat/m16-g2-qa-tests` → `release/m16`)
- AC-1 through AC-14 in `frontend/tests/e2e/m16-g2-distributional-surface.spec.ts`
- Guards in AC-12/AC-13 height tests prevent false failure pre-implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)