### PR TITLE
chore(m16-g4): EE VALIDATE — AC-EE-2 SATISFIED; AC-EE-1 blocked on engine wiring

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -5,7 +5,7 @@
 > Engineering Lead decisions and context are recorded here for session
 > continuity. For permanent rules and architecture, see CLAUDE.md.
 
-**Last updated: 2026-06-24 (M16 G4 Step 5 Validate COMPLETE — BPO CONDITIONAL ACCEPT; 20 ACs PASS; #22+#102 CLOSED; #275 EE-PENDING; sprint exit BLOCKED pending EE review on #275; #1184 filed — SAD badge tooltip pre-Demo 6)**
+**Last updated: 2026-06-24 (M16 G4 EE VALIDATE COMPLETE — AC-EE-2 SATISFIED (EE review on #275); AC-EE-1 BLOCKED pending engine wiring in ExternalSectorModule; calibration params confirmed: coefficient=0.35, ±30%, step 4, Zimbabwe 2000 anchor)**
 **Current milestone:** M16 — Distributional Visibility (GitHub Milestone 17)
 **Previous milestone:** M15 — Human Cost Architecture (FORMALLY CLOSED 2026-06-23; release/m15 → main PR #1142; v0.15.0; #984 closed; GitHub Milestone 16 closed)
 
@@ -120,7 +120,7 @@ Implementation is now unblocked. A sprint entry document must be filed and EL-ap
 | #1147 ✅ | feat(ux): Zone 1D delta annotations — companion to Zone 1A Phase 4 | G1 | ✅ BPO ACCEPT 2026-06-23 — PR #1160; Step 5 Validate COMPLETE (co-accepted with #845) |
 | #1162 | ux(zone-1a): entity attribution in-fill anchor — direct visual link between divergence fill and entity label | G1 follow-up | Filed 2026-06-23 — Customer Agent Layer 3 C1; pre-demo (#843) fix required |
 | #274 ✅ | feat(simulation): 25-year human capital depletion trajectory | G3 | ✅ BPO ACCEPT 2026-06-24 — PR #1172 merged; 19 ACs PASS; Step 5 Validate COMPLETE; G8 gate open |
-| #275 | feat(simulation): calibrated ecological-to-financial transmission | G4 | `ecological_shock_coefficient` implemented (PR #1182); AC-7/8/9 BPO ACCEPT 2026-06-24; **EE-PENDING: AC-EE-1 (Zimbabwe 2005 calibration) + AC-EE-2 (EE DIC review)** — sprint exit BLOCKED; issue OPEN until EE files review on #275 |
+| #275 | feat(simulation): calibrated ecological-to-financial transmission | G4 | `ecological_shock_coefficient` schema field (PR #1182); AC-7/8/9 BPO ACCEPT; **AC-EE-2 ✅ SATISFIED 2026-06-24** (EE review on #275 — pathway confirmed, Zimbabwe 2000 anchor corrected from "2005", params: coeff=0.35 ±30% step-4); **AC-EE-1 BLOCKED** — engine wiring not yet implemented (coefficient schema-only; ExternalSectorModule not wired); sprint exit BLOCKED; issue OPEN |
 | #102 ✅ | arch(api): distributional scenario comparison variance/percentile | G4 | ✅ BPO ACCEPT 2026-06-24 — flat `CompareResponse` + `DistributionRecord` (variance/p10/p50/p90) + Zone 1A variance-band-toggle; issue CLOSED 2026-06-24 |
 | #22 ✅ | feat: uncertainty quantification — distributional scenario bands | G4 | ✅ BPO ACCEPT 2026-06-24 — `SyntheticDataEngine` + `quantity` table + Zone 1B cohort-tier-badge (SAD/T3/T4 data-driven); AC-F6 Zone 1D deferred per intent §6; issue CLOSED 2026-06-24 |
 | #1184 | ux(zone-1b): "SAD" badge not self-interpreting at L0 | G4 follow-up | Filed 2026-06-24 — CA-G4-1; pre-demo (#843) fix required before Demo 6 |
@@ -166,7 +166,8 @@ Implementation is now unblocked. A sprint entry document must be filed and EL-ap
 - ✅ **G5 sprint exit CONFIRMED 2026-06-23** — BPO ACCEPT (advisory; infrastructure sprint exception); PI confirmed; exit document PR #1158 merged; `docs/process/sprint-plans/m16-g5-sprint-exit.md`
 - ✅ G7 sprint entry filed and **EL-approved 2026-06-23** — `docs/process/sprint-plans/m16-g7-sprint-entry.md`; #3 → #6 dependency declared; actions may begin
 - ✅ **G4 implementation MERGED 2026-06-24** — PR #1182 merged to `release/m16`; all CI PASS; sprint entry + intent document + QA tests filed; EL approved 2026-06-24
-- ✅ **G4 Step 5 Validate COMPLETE 2026-06-24** — BPO CONDITIONAL ACCEPT; Customer Agent Layer 3 CONDITIONAL PASS (CA-G4-1 → #1184 pre-Demo 6; CA-G4-2 forward gap Zone 1D); 20 ACs PASS + AC-F6 deferred per intent §6; #22 (scoped) and #102 CLOSED; #275 remains OPEN; **sprint exit BLOCKED** — AC-EE-1/AC-EE-2 (EE DIC review on #275) pending; north star test PASS (SEN Article IV credibility protection + P10/P90 distributional argument); sprint exit document filed `docs/process/sprint-plans/m16-g4-sprint-exit.md`; PI Agent confirmation pending EE review on #275
+- ✅ **G4 Step 5 Validate COMPLETE 2026-06-24** — BPO CONDITIONAL ACCEPT; Customer Agent Layer 3 CONDITIONAL PASS (CA-G4-1 → #1184 pre-Demo 6; CA-G4-2 forward gap Zone 1D); 20 ACs PASS + AC-F6 deferred; #22 (scoped) and #102 CLOSED; #275 OPEN
+- ✅ **G4 EE VALIDATE COMPLETE 2026-06-24** — Ecological Economist DIC review filed on #275; AC-EE-2 SATISFIED; AC-EE-1 params confirmed (coefficient=0.35, ±30%, step 4, Zimbabwe 2000 anchor, `arable_land_degradation_rate` proxy=0.15, fiscal indicator `fiscal_revenue_pct_gdp`); **sprint exit BLOCKED — AC-EE-1 requires ExternalSectorModule engine wiring** (coefficient currently schema-only); sprint exit document `docs/process/sprint-plans/m16-g4-sprint-exit.md` status: BLOCKED (pi-confirmed: false)
 
 ---
 

--- a/docs/process/intents/M16-G4-2026-06-23-distributional-infrastructure.md
+++ b/docs/process/intents/M16-G4-2026-06-23-distributional-infrastructure.md
@@ -305,21 +305,30 @@ Delta between fiscal revenue values at each step: exactly 0.0.
 **AC-9 — api_contracts.yml documents ecological_shock_coefficient:**
 `docs/schema/api_contracts.yml` contains `"ecological_shock_coefficient"` in the simulation request schema, documented as optional (default 0.0, range [0.0, 1.0]), in the same commit as the backend implementation.
 
-**AC-EE-1 — Historical validation (EE-PENDING):**
-*EE review required on #275 before this AC finalizes. Placeholder:*
-Integration: ZMB scenario with `ecological_shock_coefficient={EE-confirmed value}` applied.
+**AC-EE-1 — Historical validation (EE parameters confirmed 2026-06-24; engine wiring required):**
+Integration: ZWE scenario with `ecological_shock_coefficient=0.35` applied.
 At step 4, the fiscal revenue trajectory delta from the baseline (no-coefficient) run is
-within ±{EE-confirmed tolerance}% of the documented historical Zimbabwe 2005 land-reform
-fiscal impact. EE must confirm: (a) coefficient value, (b) tolerance percentage, (c) step
-horizon for comparison, (d) fiscal indicator key to compare. Implementing agent records the
-validation result in the Step 4 Verify verdict.
+within ±30% of the documented historical Zimbabwe 2000 land-reform fiscal impact
+(~1.0–1.5% of GDP cumulative agricultural-channel-attributable reduction by step 4).
 
-**AC-EE-2 — Ecological Economist DIC review on record (gate):**
-*EE review required before this AC can be checked.*
-A comment from the Ecological Economist DIC agent on GitHub issue #275 is on record,
-confirming: (a) transmission pathway correctness; (b) Zimbabwe 2005 calibration anchor
-appropriateness; (c) tolerance parameters from AC-EE-1. The comment must be filed before
-the implementation PR merges — not before it opens.
+EE-confirmed parameters (EE review comment on #275, 2026-06-24):
+- `ecological_shock_coefficient`: **0.35** (35% transmission efficiency)
+- Tolerance band: **±30%** (proxy data limitations on `arable_land_degradation_rate`)
+- Step horizon: **step 4** (2000→2004; IMF Article IV 2004 documentation window)
+- `arable_land_degradation_rate` proxy: **0.15 per year** (tobacco yield decline rate 2001–2004; Tier 3 confidence)
+- `base_agricultural_export_share`: entity attribute ZWE 2000 ≈ 0.20 (WDI)
+- Fiscal indicator: `fiscal_revenue_pct_gdp` or equivalent — confirm exact attribute name in `docs/schema/simulation_state.yml` before authoring the integration test
+- Historical target: ~1.0–1.5% of GDP cumulative reduction at step 4
+- Calibration anchor: **Zimbabwe 2000 land reform shock, calibrated at step 4 (2004)** — *not* "Zimbabwe 2005" (EE correction: shock onset is 2000; post-2004 dominated by hyperinflationary dynamics that are outside ExternalSectorModule scope)
+
+Computed check: 0.35 × 0.20 × 0.15 = 0.0105 ≈ 1% of GDP per step; cumulated ≈ 4% of GDP (full-channel); agricultural-channel-attributable portion in historical record ≈ 1.0–1.5% of GDP by step 4.
+
+**Blocked pending engine wiring.** `ecological_shock_coefficient` is currently schema-only — the engine does not apply it. AC-EE-1 will produce a zero delta until the ExternalSectorModule wiring is complete. The implementing agent must wire the coefficient before authoring the AC-EE-1 integration test.
+
+**AC-EE-2 — Ecological Economist DIC review on record: ✅ SATISFIED 2026-06-24**
+EE review comment filed on GitHub issue #275 (comment https://github.com/PublicEnemage/worldsim/issues/275#issuecomment-4785674661).
+Confirmed: (a) transmission pathway correctness; (b) Zimbabwe 2000 calibration anchor (with correction from intent doc "2005" → "2000, calibrated at step 4"); (c) AC-EE-1 parameters specified above.
+AC-EE-2 is satisfied. AC-EE-1 remains blocked on engine wiring.
 
 ---
 
@@ -697,8 +706,8 @@ before Demo 6 (#843) runs.
 | AC-7 | `ecological_shock_coefficient` accepted, range [0.0, 1.0] | ✅ PASS |
 | AC-8 | Non-regression: coefficient=0.0 identical to no-coefficient | ✅ PASS |
 | AC-9 | api_contracts.yml documents `ecological_shock_coefficient` | ✅ PASS |
-| AC-EE-1 | Zimbabwe 2005 historical calibration validation | ⏳ EE-PENDING |
-| AC-EE-2 | Ecological Economist DIC review on record on #275 | ⏳ EE-PENDING |
+| AC-EE-1 | Zimbabwe 2000 calibration validation (engine wiring required) | ⏳ BLOCKED — engine not yet wired; parameters confirmed by EE 2026-06-24 |
+| AC-EE-2 | Ecological Economist DIC review on record on #275 | ✅ SATISFIED 2026-06-24 — comment filed on #275 |
 | AC-10 | `distribution` fields (variance/p10/p50/p90) in compare response | ✅ PASS |
 | AC-11 | Insufficient data → null distribution fields (HTTP 200) | ✅ PASS |
 | AC-12 | api_contracts.yml documents `distribution` fields | ✅ PASS |
@@ -714,7 +723,7 @@ before Demo 6 (#843) runs.
 
 **Confirmed pass: 20 ACs (AC-1–12, AC-F1–F5, AC-F7–F9)**
 **Conditionally deferred: 1 AC (AC-F6 — per intent doc §6 deferral clause)**
-**EE-PENDING: 2 ACs (AC-EE-1, AC-EE-2 — block full sprint exit; issue #275 remains open)**
+**EE-PENDING (updated 2026-06-24): AC-EE-2 ✅ SATISFIED. AC-EE-1 BLOCKED — engine wiring required before historical validation can run; parameters confirmed by EE; issue #275 remains open.**
 
 **North Star Test:**
 

--- a/docs/process/sprint-plans/m16-g4-sprint-exit.md
+++ b/docs/process/sprint-plans/m16-g4-sprint-exit.md
@@ -13,7 +13,7 @@ sop-reference: docs/process/sprint-planning-sop.md §Sprint Exit Gate
 
 # Sprint Exit — M16, G4: Distributional Infrastructure
 
-**Status:** Blocked — AC-EE-1 (Zimbabwe 2005 calibration) and AC-EE-2 (EE DIC review) pending on GitHub issue #275. Full sprint exit gate cannot confirm until Ecological Economist DIC review is on record.
+**Status:** Blocked — AC-EE-1 (Zimbabwe 2000 engine validation) pending on GitHub issue #275. AC-EE-2 SATISFIED 2026-06-24 (EE review comment on #275). Full sprint exit cannot confirm until engine wiring is complete and AC-EE-1 passes.
 **Date produced:** 2026-06-24
 **Release branch:** `release/m16`
 **Sprint entry document:** `docs/process/sprint-plans/m16-g4-sprint-entry.md` — EL Approved 2026-06-24
@@ -146,12 +146,21 @@ No REJECT verdicts were issued for any G4 deliverable.
   versus pre-G4 (T3→SAD correction prevents false precision; P10/P90 enables distributional
   argument). PI Agent confirms: specific, not aspirational. Gate satisfied.
 
-- [ ] **EE-PENDING ACs resolved — BLOCKING**
-  AC-EE-1 (Zimbabwe 2005 historical calibration of `ecological_shock_coefficient`) and
-  AC-EE-2 (Ecological Economist DIC review comment on GitHub issue #275) have not been
-  verified. Issue #275 remains open. The sprint entry §3.1 Observable State 6 is
-  EE-PENDING. Until the EE DIC agent files a review comment on #275 and AC-EE-1/AC-EE-2
-  are verified, the sprint exit gate does not confirm for issue #275.
+- [x] **AC-EE-2 SATISFIED 2026-06-24** — Ecological Economist DIC review comment filed
+  on GitHub issue #275 (comment https://github.com/PublicEnemage/worldsim/issues/275#issuecomment-4785674661).
+  Confirmed: (a) soil-degradation → agricultural-export → fiscal-revenue pathway correct;
+  (b) calibration anchor corrected to Zimbabwe 2000 (not 2005); step 4 (2004) horizon;
+  (c) AC-EE-1 parameters: coefficient=0.35, tolerance ±30%, `arable_land_degradation_rate`
+  proxy=0.15, fiscal indicator `fiscal_revenue_pct_gdp`, target ~1.0–1.5% GDP at step 4.
+
+- [ ] **AC-EE-1 BLOCKED — engine wiring required — BLOCKING**
+  `ecological_shock_coefficient` is schema-only. The simulation engine does not apply
+  the coefficient — a run with coefficient=0.35 currently produces output identical to
+  coefficient=0.0 (silent failure 3, intent doc §3.4). AC-EE-1 integration test cannot
+  pass until `ExternalSectorModule` is wired to read `ecological_shock_coefficient` from
+  `ScenarioConfigSchema`, read `base_agricultural_export_share` from entity attributes, and
+  emit a FINANCIAL framework fiscal revenue delta per step. Issue #275 remains OPEN.
+  Sprint exit gate does not confirm until engine wiring is complete and AC-EE-1 passes.
 
 **PI Agent sprint exit verdict: BLOCKED — EE review pending on #275**
 
@@ -177,7 +186,13 @@ No REJECT verdicts were issued for any G4 deliverable.
 >
 > G4 does not gate G8 (live stakeholder demo #843). G8 gate remains OPEN as of
 > 2026-06-24 — it requires G1/G2/G3 BPO-accepted (all satisfied) and Demo 6 preparation
-> items (#1162, #1177, #1178, #1179, #1183) resolved before the live session runs.
+> items (#1162, #1177, #1178, #1179, #1184) resolved before the live session runs.
+>
+> AC-EE-2 update (2026-06-24): Ecological Economist DIC review now on record on #275
+> (comment filed 2026-06-24). AC-EE-2 is SATISFIED. Remaining blocker: AC-EE-1 requires
+> ExternalSectorModule engine wiring before the historical validation test can run.
+> Issue #275 remains OPEN. Engine wiring is a future sprint deliverable — the EE review
+> provides the calibration parameters (coefficient=0.35, ±30%, step 4, proxy rate=0.15).
 >
 > — PI Agent, 2026-06-24
 
@@ -186,9 +201,10 @@ No REJECT verdicts were issued for any G4 deliverable.
 ## Sprint Exit Artifact Statement
 
 This document is the sprint exit artifact for M16-G4. It is filed at
-`docs/process/sprint-plans/m16-g4-sprint-exit.md`. Status is BLOCKED pending EE review on
-#275. When AC-EE-1/AC-EE-2 are verified in a future session, this document will be updated
-to status CONFIRMED and pi-confirmed: true.
+`docs/process/sprint-plans/m16-g4-sprint-exit.md`. Status is BLOCKED pending engine wiring
+for AC-EE-1. AC-EE-2 is SATISFIED (EE review on record 2026-06-24). When engine wiring is
+complete and AC-EE-1 passes in CI, this document will be updated to status CONFIRMED and
+pi-confirmed: true.
 
 The sprint exit is not confirmed until the PI Agent's verdict reads "Confirmed." Issues #22
 (scoped) and #102 may be closed on the basis of the ACCEPT verdicts in §3. Issue #275 must


### PR DESCRIPTION
## Summary

- Ecological Economist DIC review filed on GitHub issue #275 (2026-06-24)
- **AC-EE-2: SATISFIED** — EE confirmed: (a) soil-degradation→agricultural-export→fiscal-revenue pathway correct; (b) calibration anchor corrected to Zimbabwe 2000 (not "2005"); (c) AC-EE-1 parameters specified
- **AC-EE-1: BLOCKED** — `ecological_shock_coefficient` is schema-only; `ExternalSectorModule` engine wiring not yet implemented; coefficient=0.35 currently produces same output as 0.0 (silent failure 3)
- Sprint exit remains BLOCKED until engine wiring is complete and AC-EE-1 passes in CI
- Intent doc AC-EE-1 updated with confirmed EE parameters; AC-EE-2 marked SATISFIED

## AC-EE-1 confirmed parameters
| Parameter | Value |
|---|---|
| `ecological_shock_coefficient` | 0.35 |
| Tolerance | ±30% |
| Step horizon | Step 4 (Zimbabwe 2000→2004) |
| `arable_land_degradation_rate` proxy | 0.15/year |
| Fiscal indicator | `fiscal_revenue_pct_gdp` (confirm in simulation_state.yml) |
| Historical target | ~1.0–1.5% GDP cumulative at step 4 |

## Test plan
- [ ] CI passes (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)