### PR TITLE
fix(m16-g10): pre-demo polish — five CA-condition legibility fixes

### DIFF
--- a/frontend/src/components/HumanCapitalTrajectoryPanel.tsx
+++ b/frontend/src/components/HumanCapitalTrajectoryPanel.tsx
@@ -190,21 +190,23 @@ export function HumanCapitalTrajectoryPanel({
 
       {/* Milestone sentence — AC-F3, AC-CM-2 (only when Q1 floor crossed) */}
       {milestone && (
-        <div
-          data-testid="projection-milestone-sentence"
-          style={{
-            marginBottom: 8,
-            padding: "4px 8px",
-            background: "#fee2e2",
-            border: "1px solid #fca5a5",
-            borderRadius: 4,
-            color: "#7f1d1d",
-            fontSize: 11,
-            lineHeight: 1.5,
-          }}
-        >
-          by {milestone.year} [step {milestone.step}], {milestone.cohortLabel} poverty headcount crosses
-          the recovery floor — at this level, capability restoration takes {Q1_RECOVERY_CONSEQUENCE}
+        <div data-testid="milestone-sentence">
+          <div
+            data-testid="projection-milestone-sentence"
+            style={{
+              marginBottom: 8,
+              padding: "4px 8px",
+              background: "#fee2e2",
+              border: "1px solid #fca5a5",
+              borderRadius: 4,
+              color: "#7f1d1d",
+              fontSize: 11,
+              lineHeight: 1.5,
+            }}
+          >
+            by {milestone.year} [step {milestone.step}], {milestone.cohortLabel} poverty headcount crosses
+            the recovery floor — at this level, capability restoration takes {Q1_RECOVERY_CONSEQUENCE}
+          </div>
         </div>
       )}
 
@@ -247,6 +249,25 @@ export function HumanCapitalTrajectoryPanel({
           </div>
         );
       })}
+
+      {/* Q2 suppression annotation — G10 #1179 */}
+      {!loading && (() => {
+        const q2Def = cohortDefs.find(d => !d.isQ1) ?? null;
+        return q2Def !== null && (trajectories[q2Def.entityId]?.length ?? 0) === 0 ? (
+          <div
+            data-testid="q2-suppression-legend"
+            style={{
+              fontSize: 10,
+              color: '#6b7280',
+              fontStyle: 'italic',
+              paddingLeft: 6,
+              marginBottom: 4,
+            }}
+          >
+            Q2 — floor threshold not registered (suppressed)
+          </div>
+        ) : null;
+      })()}
 
       {/* Step axis — AC-F5 */}
       <div

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -746,19 +746,29 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
                 </span>
               </span>
               <span
-                data-testid={`cohort-tier-badge-${crossing.indicator_key}`}
-                style={{
-                  fontSize: 8,
-                  fontWeight: 700,
-                  color: isSad ? "#7a0000" : "#005a9e",
-                  background: isSad ? "#ffe0e0" : "#e0eeff",
-                  borderRadius: 2,
-                  padding: "1px 3px",
-                  flexShrink: 0,
-                  display: "inline-block",
-                }}
+                data-testid="confidence-tier-badge"
+                style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 1, flexShrink: 0 }}
               >
-                {badgeText}
+                <span
+                  data-testid={`cohort-tier-badge-${crossing.indicator_key}`}
+                  style={{
+                    fontSize: 8,
+                    fontWeight: 700,
+                    color: isSad ? "#7a0000" : "#005a9e",
+                    background: isSad ? "#ffe0e0" : "#e0eeff",
+                    borderRadius: 2,
+                    padding: "1px 3px",
+                    display: "inline-block",
+                  }}
+                >
+                  {badgeText}
+                </span>
+                <span
+                  data-testid="confidence-tier-badge-sublabel"
+                  style={{ fontSize: 7, color: '#6b7280', fontWeight: 400, lineHeight: 1, whiteSpace: 'nowrap' }}
+                >
+                  {isSad ? "No primary data" : badgeText === "T4" ? "Model est." : "Inferred"}
+                </span>
               </span>
             </div>
           );

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -418,6 +418,23 @@ function CompositeChartSVG({
           );
         })}
 
+      {/* Divergence fill attribution — G10 #1162 */}
+      {hasDivergence && (
+        <text
+          data-testid="divergence-fill-attribution"
+          x={MARGIN.left + chartW / 2}
+          y={MARGIN.top + 10}
+          fontSize={9}
+          fill="#555"
+          textAnchor="middle"
+        >
+          {entityCodes
+            .filter((code) => activeTrajectories[code] && baselineTrajectories[code])
+            .join(" / ")}{" "}
+          — active vs. baseline
+        </text>
+      )}
+
       {/* MDA floor lines — one per entity (lowest non-trivial floor) */}
       {entityCodes.map((code, i) => {
         const active = activeTrajectories[code];


### PR DESCRIPTION
## Summary

Five CA-condition-bounded frontend legibility fixes required before Demo 6 (G8 gate). All five issues were named in G1/G3/G4 sprint exit confirmations as required before the live session (#843).

- **#1162** — `divergence-fill-attribution` SVG text added in `TrajectoryView.tsx` when Mode 3 divergence fill is active; absent in single-entity/MODE_1 rendering
- **#1177** — `milestone-sentence` wrapper added around existing `projection-milestone-sentence` in `HumanCapitalTrajectoryPanel.tsx`; year already leads text; G3 testid preserved  
- **#1178** — Cohort tier badges wrapped in `confidence-tier-badge` + `confidence-tier-badge-sublabel` ("Inferred" for T3, "Model est." for T4) in `MDAAlertPanelZone1B.tsx`
- **#1179** — `q2-suppression-legend` added when Q2 trajectory absent ("Q2 — floor threshold not registered (suppressed)") in `HumanCapitalTrajectoryPanel.tsx`
- **#1184** — SAD badge expanded via same sublabel component as T3 ("No primary data"); consistent DOM pattern per AC-10

**Badge pattern chosen: option (b) sub-label.** The outer `confidence-tier-badge` wrapper + inner `confidence-tier-badge-sublabel` span below the badge text. Same structure for both T3 and SAD (AC-10 consistency requirement).

**Existing testids preserved:**
- `projection-milestone-sentence` (G3 test) — unchanged, now wrapped
- `cohort-tier-badge-{indicator_key}` (G4 tests) — unchanged, now inside wrapper

## Test plan

- [ ] CI playwright-e2e: `m16-g10-predemo-polish.spec.ts` — all 11 ACs (pre-implementation guards active; post-fix assertions run where backend supports fixtures)
- [ ] CI does not regress G3 spec (`projection-milestone-sentence` testid still present inside `milestone-sentence` wrapper)
- [ ] CI does not regress G4 spec (`cohort-tier-badge-{indicator_key}` testid still present inside `confidence-tier-badge` wrapper)
- [ ] Frontend build: `npm run build` exits 0 ✓ (verified locally)

## Sprint entry reference

Intent: `docs/process/intents/M16-G10-2026-06-24-predemo-polish.md` (EL override of no-intent ruling)  
Sprint entry: `docs/process/sprint-plans/m16-g10-sprint-entry.md` (EL Approved 2026-06-24)  
Closes: #1162, #1177, #1178, #1179, #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)