### PR TITLE
feat(api): threshold_crossings in compare response — M16-G9 #97

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -65,6 +65,7 @@ from app.schemas import (
     ScenarioRestoreResponse,
     ScheduledInputSchema,
     SnapshotRecord,
+    ThresholdCrossingItem,
     TrajectoryCompareResponse,
     TrajectoryCompareStep,
     TrajectoryFrameworkPoint,
@@ -595,6 +596,13 @@ async def compare_scenarios(
     state_a = snapmap_a[step_a]
     state_b = snapmap_b[step_b]
 
+    # Fetch MDA thresholds once for threshold_crossings population — M16-G9 #97.
+    mda_rows = await conn.fetch(
+        "SELECT mda_id, indicator_key, floor_value, comparison_operator FROM mda_thresholds"
+        " ORDER BY mda_id"
+    )
+    mda_threshold_list: list[dict[str, Any]] = [dict(r) for r in mda_rows]
+
     shared_entities = sorted(set(state_a) & set(state_b))
     flat_deltas: list[FlatDeltaRecord] = []
 
@@ -645,6 +653,30 @@ async def compare_scenarios(
                 except Exception:  # noqa: BLE001 S112
                     continue
 
+            # Compute threshold_crossings: check val_b against each matching MDA threshold.
+            # Only entries where the threshold IS crossed (crossed=True) are included.
+            # Empty list when no MDA threshold applies or none are violated — M16-G9 #97.
+            threshold_crossings: list[ThresholdCrossingItem] = []
+            try:
+                vb_dec = Decimal(vb)
+                for thr in mda_threshold_list:
+                    if str(thr["indicator_key"]) != key:
+                        continue
+                    floor = Decimal(str(thr["floor_value"]))
+                    op = str(thr.get("comparison_operator", "lte"))
+                    is_crossed = (
+                        vb_dec <= floor if op == "lte" else vb_dec >= floor
+                    )
+                    if is_crossed:
+                        threshold_crossings.append(
+                            ThresholdCrossingItem(
+                                threshold_name=str(thr["mda_id"]),
+                                crossed=True,
+                            )
+                        )
+            except Exception:  # noqa: BLE001 S110 S112
+                pass  # Non-fatal: leave threshold_crossings empty on Decimal parse failure
+
             flat_deltas.append(
                 FlatDeltaRecord(
                     entity_id=eid,
@@ -656,6 +688,7 @@ async def compare_scenarios(
                     confidence_tier=tier,
                     threshold_crossed=crossed,
                     distribution=_compute_distribution(delta_series),
+                    threshold_crossings=threshold_crossings,
                 )
             )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -561,6 +561,20 @@ class DeltaRecord(BaseModel):
     threshold_crossed: bool | None = None
 
 
+class ThresholdCrossingItem(BaseModel):
+    """One MDA threshold crossing entry within a FlatDeltaRecord — M16-G9 #97.
+
+    `threshold_name` identifies the MDA threshold (its mda_id).
+    `crossed` is True when scenario_b's value at the compared step violates
+    the threshold (value_b <= floor for "lte" operator; value_b >= floor for "gte").
+    Only entries with crossed=True are included; the list is empty when no threshold
+    is violated.
+    """
+
+    threshold_name: str
+    crossed: bool
+
+
 class FlatDeltaRecord(BaseModel):
     """Flat-list entry for GET /scenarios/compare — M16-G4 #102.
 
@@ -580,6 +594,7 @@ class FlatDeltaRecord(BaseModel):
     confidence_tier: int
     threshold_crossed: bool | None = None
     distribution: DistributionRecord = DistributionRecord()
+    threshold_crossings: list[ThresholdCrossingItem] = []
 
 
 class CompareResponse(BaseModel):

--- a/backend/tests/unit/test_compare_step_alignment.py
+++ b/backend/tests/unit/test_compare_step_alignment.py
@@ -49,17 +49,19 @@ def _make_conn(
     fetchrow_effects: list,  # type: ignore[type-arg]
     fetch_a: list,  # type: ignore[type-arg]
     fetch_b: list,  # type: ignore[type-arg]
+    mda_rows: list | None = None,  # type: ignore[type-arg]
 ) -> AsyncMock:
     """Build a mock DB connection.
 
     `fetchrow_effects` — side-effects for existence-check calls (2 entries).
     `fetch_a` — rows returned for scenario_a all-snapshots fetch.
     `fetch_b` — rows returned for scenario_b all-snapshots fetch.
+    `mda_rows` — rows returned for mda_thresholds fetch (M16-G9 #97); defaults to [].
     """
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(side_effect=list(fetchrow_effects))
-    # The endpoint calls conn.fetch twice in order: scenario_a then scenario_b
-    conn.fetch = AsyncMock(side_effect=[fetch_a, fetch_b])
+    # conn.fetch call order: scenario_a snapshots, scenario_b snapshots, mda_thresholds.
+    conn.fetch = AsyncMock(side_effect=[fetch_a, fetch_b, mda_rows or []])
     return conn
 
 

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -309,6 +309,16 @@ endpoints:
             direction: {type: string, values: ["increase", "decrease", "unchanged"]}
             confidence_tier: {type: integer, description: "max() of both tiers"}
             threshold_crossed: {type: "bool|null", description: "null when threshold_value not supplied"}
+            threshold_crossings:
+              type: array
+              description: >
+                MDA threshold crossing entries for this indicator at the compared step — M16-G9 #97.
+                Only entries where the threshold is violated (crossed=True) are included.
+                Empty list [] when no MDA threshold applies to this indicator or none are crossed.
+                Never null — always a list (empty or non-empty).
+              items:
+                threshold_name: {type: string, description: "mda_id of the crossed MDA threshold"}
+                crossed: {type: boolean, description: "Always true — only violated thresholds are listed"}
             distribution:
               type: object
               description: "Distributional statistics across all shared steps. All fields null when <3 shared steps (M16-G4 #102)."


### PR DESCRIPTION
## Summary

- Add `ThresholdCrossingItem` Pydantic schema: `{threshold_name: str, crossed: bool}`
- Add `threshold_crossings: list[ThresholdCrossingItem]` to `FlatDeltaRecord` (always present, never null)
- In `compare_scenarios()`: fetch MDA thresholds once, evaluate `value_b` against each matching threshold, populate list with violated entries only (empty list when no violations)
- Update `docs/schema/api_contracts.yml` with `threshold_crossings` field documentation (same commit, schema drift compliance)

## Acceptance criteria

AC-1: `threshold_crossings` field present in every `FlatDeltaRecord` ✓
AC-2: Non-empty with `crossed=True` for ZMB ECF at poverty floor crossing step ✓
AC-3: Non-empty with `crossed=True` for JOR ECF at crossing step ✓
AC-4: Empty list `[]` for steps where no thresholds are violated ✓
AC-5: `api_contracts.yml` contains `threshold_crossings`, `threshold_name`, `crossed` ✓
AC-6: Existing compare fields (`delta`, `direction`, `distribution`) unchanged ✓

## Test plan
- `backend/tests/test_m16_g9_compare_threshold_markers.py` — authored before implementation (PR #1198)
- Backend lint gate: `ruff check .` → All checks passed
- CI: `test-backend` + `playwright-e2e`

Sprint entry: `docs/process/sprint-plans/m16-g9-sprint-entry.md` (EL Approved 2026-06-24)
Intent document: `docs/process/intents/M16-G9-2026-06-24-compare-threshold-crossing-markers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)