### PR TITLE
feat(m16-g9): Greece 2010 investment climate backtesting fixture (#92)

### DIFF
--- a/backend/tests/backtesting/fidelity_report.py
+++ b/backend/tests/backtesting/fidelity_report.py
@@ -243,3 +243,18 @@ def _extract_health_expenditure_value(
         return Decimal(str(val))
     except (KeyError, TypeError, ValueError):
         return None
+
+
+def _extract_investment_climate_value(
+    snapshot: dict[str, Any], attribute: str, entity_id: str = "GRC"
+) -> Decimal | None:
+    """Extract an investment climate attribute Decimal value from a snapshot dict.
+
+    Supports: sovereign_risk_premium, fdi_stock_pct_gdp, portfolio_flow_velocity,
+    credit_rating_score. Returns None if the attribute is absent or unparseable.
+    """
+    try:
+        val = snapshot["state_data"][entity_id][attribute]["value"]
+        return Decimal(str(val))
+    except (KeyError, TypeError, ValueError):
+        return None

--- a/backend/tests/backtesting/test_greece_2010_2012.py
+++ b/backend/tests/backtesting/test_greece_2010_2012.py
@@ -31,6 +31,7 @@ import pytest_asyncio
 from tests.backtesting.fidelity_report import (
     _extract_gdp_value,
     _extract_health_expenditure_value,
+    _extract_investment_climate_value,
     _extract_unemployment_value,
     format_fidelity_report,
     write_fidelity_artifact,
@@ -193,6 +194,28 @@ async def test_greece_2010_2012_direction_only_fidelity(
             and unemp6 < unemp5
         )
 
+        # Investment climate deferred thresholds — Issue #92 (M16-G9).
+        # No endogenous module currently updates these attributes; they remain at initial state.
+        # These thresholds re-enable when an InvestmentClimateModule produces endogenous updates.
+        snap0 = snapshots_by_step.get(0)
+        srp0 = _extract_investment_climate_value(snap0, "sovereign_risk_premium") if snap0 else None
+        srp2 = _extract_investment_climate_value(snap2, "sovereign_risk_premium") if snap2 else None
+        fdi0 = _extract_investment_climate_value(snap0, "fdi_stock_pct_gdp") if snap0 else None
+        fdi2 = _extract_investment_climate_value(snap2, "fdi_stock_pct_gdp") if snap2 else None
+        crs0 = _extract_investment_climate_value(snap0, "credit_rating_score") if snap0 else None
+        crs2 = _extract_investment_climate_value(snap2, "credit_rating_score") if snap2 else None
+        pfv0 = (
+            _extract_investment_climate_value(snap0, "portfolio_flow_velocity") if snap0 else None
+        )
+        pfv2 = (
+            _extract_investment_climate_value(snap2, "portfolio_flow_velocity") if snap2 else None
+        )
+
+        srp_rising = srp0 is not None and srp2 is not None and srp2 > srp0
+        fdi_declining = fdi0 is not None and fdi2 is not None and fdi2 < fdi0
+        crs_declining = crs0 is not None and crs2 is not None and crs2 < crs0
+        pfv_deepening = pfv0 is not None and pfv2 is not None and pfv2 < pfv0
+
         deferred_thresholds: dict[str, str] = {
             "gdp_growth_step5_positive": (
                 "PASS" if val5 is not None and val5 > Decimal("0")
@@ -212,6 +235,22 @@ async def test_greece_2010_2012_direction_only_fidelity(
             "unemployment_declining_step4_to_step6": (
                 "PASS" if unemp_declining_4_to_6
                 else "FAIL — no endogenous module updates unemployment_rate (Issue #87)"
+            ),
+            "sovereign_risk_rising_step0_to_step2": (
+                "PASS" if srp_rising
+                else "FAIL — no endogenous module updates sovereign_risk_premium (Issue #92)"
+            ),
+            "fdi_stock_declining_step0_to_step2": (
+                "PASS" if fdi_declining
+                else "FAIL — no endogenous module updates fdi_stock_pct_gdp (Issue #92)"
+            ),
+            "credit_rating_declining_step0_to_step2": (
+                "PASS" if crs_declining
+                else "FAIL — no endogenous module updates credit_rating_score (Issue #92)"
+            ),
+            "portfolio_outflows_deepening_step0_to_step2": (
+                "PASS" if pfv_deepening
+                else "FAIL — no endogenous module updates portfolio_flow_velocity (Issue #92)"
             ),
         }
 

--- a/backend/tests/fixtures/greece_2010_2012_actuals.py
+++ b/backend/tests/fixtures/greece_2010_2012_actuals.py
@@ -21,6 +21,23 @@ Sources:
       health_expenditure_pct_gdp_2010  — 9.5% (initial state seed)
       health_expenditure_pct_gdp_2011  — 9.4% (slight decline; austerity begins)
       health_expenditure_pct_gdp_2012  — 8.7% (accelerated cuts in second program)
+  - Investment climate conditions — Issue #92 (M16-G9):
+      ECB Statistical Data Warehouse (ECB_SDW) — 10Y GRC-DEU sovereign spread:
+        sovereign_risk_premium_2010  — year-end ~850 bps = 0.085
+        sovereign_risk_premium_2011  — year-end ~1500 bps = 0.150 (escalation peak)
+        sovereign_risk_premium_2012  — mid-year ~2000 bps = 0.200 (near-default)
+      UNCTAD World Investment Report 2012/2013 (UNCTAD_WIR_2012) — FDI inward stock/GDP:
+        fdi_stock_pct_gdp_2010  — 10.5% = 0.105 (initial state baseline)
+        fdi_stock_pct_gdp_2011  — ~8.5% = 0.085 (capital flight; austerity)
+        fdi_stock_pct_gdp_2012  — ~7.0% = 0.070 (continued FDI decline)
+      S&P sovereign credit ratings (SP_SOVEREIGN_RATINGS_GRC_2010–2012):
+        credit_rating_score_2010  — BBB+ (Jan 2010) = 55; BB+ (Apr 2010) = 47
+        credit_rating_score_2011  — CCC+ = ~25 (multiple notch downgrades)
+        credit_rating_score_2012  — SD (selective default) = 5
+      IMF Balance of Payments Statistics 2012 (IMF_BOP_GRC_2012):
+        portfolio_flow_velocity_2010  — net portfolio investment ~-8% GDP = -0.080
+        portfolio_flow_velocity_2011  — accelerating outflows ~-12% GDP = -0.120
+        portfolio_flow_velocity_2012  — continued capital flight ~-15% GDP = -0.150
 
 These actuals define the benchmark against which backtesting fidelity is
 measured. ADR-004 Decision 3: M3 ships DIRECTION_ONLY thresholds only.
@@ -122,6 +139,33 @@ class GreeceActuals:
     health_expenditure_pct_gdp_2011: Decimal = Decimal("0.094")
     health_expenditure_pct_gdp_2012: Decimal = Decimal("0.087")
 
+    # Investment climate conditions — Issue #92 (M16-G9)
+    # ECB SDW 10Y GRC-DEU spread (expressed as ratio: 850bps = 0.085)
+    # Direction: UP (sovereign spread widened dramatically under programme pressure)
+    sovereign_risk_premium_2010_eoy: Decimal = Decimal("0.085")
+    sovereign_risk_premium_2011_eoy: Decimal = Decimal("0.150")
+    sovereign_risk_premium_2012_peak: Decimal = Decimal("0.200")
+
+    # UNCTAD World Investment Report — FDI inward stock/GDP
+    # Direction: DOWN (capital flight; deteriorating investment climate)
+    fdi_stock_pct_gdp_2010: Decimal = Decimal("0.105")
+    fdi_stock_pct_gdp_2011: Decimal = Decimal("0.085")
+    fdi_stock_pct_gdp_2012: Decimal = Decimal("0.070")
+
+    # S&P sovereign credit rating mapped to 0–100 index (AAA=100, D=0)
+    # BBB+=55 (Jan 2010), BB+=47 (Apr 2010), CCC+≈25 (2011), SD=5 (2012 PSI)
+    # Direction: DOWN (multiple-notch downgrade cascade through programme period)
+    credit_rating_score_2010_jan: Decimal = Decimal("55.0")
+    credit_rating_score_2010_apr: Decimal = Decimal("47.0")
+    credit_rating_score_2011: Decimal = Decimal("25.0")
+    credit_rating_score_2012: Decimal = Decimal("5.0")
+
+    # IMF BOP Statistics — net portfolio investment/GDP (negative = outflows)
+    # Direction: DOWN (net outflows intensified; more negative through programme)
+    portfolio_flow_velocity_2010: Decimal = Decimal("-0.080")
+    portfolio_flow_velocity_2011: Decimal = Decimal("-0.120")
+    portfolio_flow_velocity_2012: Decimal = Decimal("-0.150")
+
 
 ACTUALS = GreeceActuals()
 
@@ -180,6 +224,15 @@ class FidelityThresholds:
     unemployment_rising_step1_to_step2: bool = False
     health_expenditure_declining_step1_to_step2: bool = False
     unemployment_declining_step4_to_step6: bool = False
+    # Investment climate thresholds — deferred (Issue #92, M16-G9)
+    # No endogenous module currently updates sovereign_risk_premium, fdi_stock_pct_gdp,
+    # portfolio_flow_velocity, or credit_rating_score. These variables are seeded in the
+    # initial state but remain static across steps. Thresholds re-enable when an
+    # InvestmentClimateModule or equivalent produces endogenous updates.
+    sovereign_risk_rising_step0_to_step2: bool = False
+    fdi_stock_declining_step0_to_step2: bool = False
+    credit_rating_declining_step0_to_step2: bool = False
+    portfolio_outflows_deepening_step0_to_step2: bool = False
 
 
 THRESHOLDS = FidelityThresholds()


### PR DESCRIPTION
## Summary
- Extends `greece_2010_2012_actuals.py` with investment climate historical actuals: sovereign risk premium (ECB SDW), FDI stock/GDP (UNCTAD WIR), credit rating score (S&P), portfolio flow velocity (IMF BOP)
- Adds `_extract_investment_climate_value()` helper to `fidelity_report.py`
- Adds four DEFERRED direction thresholds in the primary backtesting test: SRP UP, FDI DOWN, credit rating DOWN, portfolio velocity DOWN — deferred because no `InvestmentClimateModule` produces endogenous updates yet

## Test plan
- [ ] Backend lint gate: `ruff check .` exits 0 (verified locally)
- [ ] CI backtesting suite (requires DATABASE_URL): thresholds appear in fidelity report; deferred thresholds do not block CI gate
- [ ] No new blocking thresholds added — deferred entries tracked in fidelity artifact only

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)