### PR TITLE
docs(m16-g6): NM-060 — fix CONTRIBUTING.md seed command + observability near-miss

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -951,21 +951,30 @@ docker compose restart frontend
 
 ---
 
-### Natural Earth loader not run — choropleth is empty or GRC entity missing
+### Natural Earth loader not run — scenario creation fails or choropleth is empty
 
-**Symptom:** The choropleth map is blank, or a backtesting run fails with
-`EntityNotFound: GRC`. The `simulation_entities` table is empty.
+**Symptom (most common):** Scenario creation returns an error in the UI —
+the scenario row never appears after clicking Create. The backend log shows:
+`POST /api/v1/scenarios HTTP/1.1" 422 Unprocessable Content`
+and the response body contains: `Entity IDs not found in simulation_entities: {'GRC'}.`
 
-**Cause:** The Natural Earth boundary loader seed script has not been run
-against this database.
+**Symptom (alternative):** The choropleth map is blank, or a backtesting run
+fails with `EntityNotFound: GRC`. The `simulation_entities` table is empty.
+
+**Cause:** The Natural Earth boundary loader has not been run against this
+database. `docker compose up` runs Alembic migrations (which create the schema)
+but does not seed `simulation_entities`. The API starts and appears healthy —
+`/api/v1/health` returns 200 and the choropleth loads — but any operation that
+validates entity IDs against `simulation_entities` will return 422. (NM-060)
 
 **Fix:**
 
 ```bash
-docker compose exec api python scripts/natural_earth_loader.py
+docker compose exec api python -m app.db.seed.natural_earth_loader
 ```
 
-The loader is idempotent — safe to run multiple times.
+The loader is idempotent — safe to run multiple times. Takes 30–60 seconds
+on first run (downloads Natural Earth 110m GeoJSON; cached after first run).
 
 ---
 

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -3007,6 +3007,67 @@ Both AC-009 (`trajectory-view.spec.ts`) and the MV-002 hardware test (`mv-002-ha
 
 ---
 
+## NM-060 — Startup Observability Gap: Empty simulation_entities Table Produces Silent 422 with No Diagnostic Signal (Reactive)
+
+**Date identified:** 2026-06-24
+**Severity:** Medium
+**Sprint:** M16-G6
+**Detection:** Reactive — caught when MV-002 ProBook hardware validation was blocked by
+422 errors on scenario creation. Root cause took multiple investigation steps to identify
+because no observability signal pointed to the seed gap.
+
+### What happened
+
+After `docker compose up --build` (and repeated with `down -v` for a fresh database),
+scenario creation returned `422 Unprocessable Content` on the ProBook. The backend log
+showed the 422 but not why. The frontend showed a generic error. The choropleth loaded
+correctly (GDP growth 200 OK), so the stack *appeared* healthy. The real cause —
+`simulation_entities` was empty because the Natural Earth loader had not been run —
+required inspecting the API source to discover.
+
+### Three-layer failure
+
+1. **No startup observability:** The backend logs `Application startup complete.` with no
+   check on whether `simulation_entities` is populated. A stack with zero entities is
+   indistinguishable from a healthy stack in the startup log. The API health endpoint
+   returns 200 regardless.
+
+2. **Wrong fix command in CONTRIBUTING.md:** The troubleshooting entry said
+   `docker compose exec api python scripts/natural_earth_loader.py` — a path that does
+   not exist. The correct command is `docker compose exec api python -m app.db.seed.natural_earth_loader`.
+
+3. **Wrong/incomplete symptom description:** CONTRIBUTING.md listed "choropleth is blank"
+   as the only symptom. In practice the choropleth loaded correctly and the failure was
+   a 422 on scenario creation — a completely different, unmatched symptom.
+
+### What was at risk
+
+Any developer or EL doing a first-time or fresh setup would hit this with no diagnostic
+path. CI avoids the problem by explicitly running the seed loader (`.github/workflows/ci.yml`
+line 232) — local and ProBook setups have no equivalent, and CONTRIBUTING.md's
+troubleshooting entry was not discoverable from the observed symptom.
+
+### Fix
+
+CONTRIBUTING.md updated in this commit:
+- Correct fix command: `python -m app.db.seed.natural_earth_loader`
+- Primary symptom updated to scenario creation 422 (first encounter for most users)
+- Explanation added that the stack appears healthy despite the empty table
+
+### Process improvement
+
+1. **GitHub issue filed for startup observability** (enhancement, M17): The backend
+   should log a structured `WARNING` at startup lifespan if `simulation_entities` is
+   empty, with the fix command in the log message. A zero-entity stack is never a valid
+   operating state — it should say so. Issue filed against M17.
+
+2. **Troubleshooting entry standard:** CONTRIBUTING.md symptoms must describe what a
+   developer *observes* (HTTP status codes, UI behaviour, log lines) — not internal
+   state requiring source inspection. "Choropleth is blank" was accurate but not the
+   first observable signal; scenario creation 422 is.
+
+---
+
 ## Registry Maintenance
 
 ### How to add an entry


### PR DESCRIPTION
## Summary

- NM-060 filed in near-miss registry: startup observability gap where empty `simulation_entities` table produces a silent 422 with no diagnostic signal
- CONTRIBUTING.md troubleshooting entry corrected: wrong fix command, wrong primary symptom
- GitHub issue #1214 filed for the upstream fix (startup WARNING log when `simulation_entities` is empty)

## What was wrong

| | Was | Now |
|---|---|---|
| Fix command | `python scripts/natural_earth_loader.py` (path doesn't exist) | `python -m app.db.seed.natural_earth_loader` |
| Primary symptom | "choropleth is blank" | 422 on scenario creation (first encounter for most users) |
| Stack appearance | Not described | Explicitly documented that stack appears healthy (200s) despite empty table |

## Test plan
- [ ] CI green (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)