### PR TITLE
feat(m16-g8): add breaches_below to CohortThresholdCrossing; fix Zone 1B distance label (#1239, #1238)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -2497,6 +2497,7 @@ async def get_measurement_output(
                                     else None
                                 ),
                                 value=qty.value,
+                                breaches_below=True,  # gte: breach = value below floor
                             )
                         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -756,6 +756,7 @@ class CohortThresholdCrossing(BaseModel):
     is_synthetic: bool
     synthetic_method: str | None
     value: str
+    breaches_below: bool
 
 
 class FrameworkOutput(BaseModel):

--- a/backend/tests/unit/test_measurement_output.py
+++ b/backend/tests/unit/test_measurement_output.py
@@ -583,3 +583,146 @@ def test_multiframework_output_default_single_entity_warning_is_false() -> None:
         ia1_disclosure=IA1_CANONICAL_PHRASE,
     )
     assert obj.single_entity_warning is False
+
+
+# ---------------------------------------------------------------------------
+# CohortThresholdCrossing.breaches_below — Issue #1239 (DEMO6-010)
+# ---------------------------------------------------------------------------
+
+
+def test_cohort_threshold_crossing_schema_accepts_breaches_below_true() -> None:
+    """CohortThresholdCrossing: gte threshold — breaches_below=True (value below floor = breach)."""
+    from app.schemas import CohortThresholdCrossing
+
+    crossing = CohortThresholdCrossing(
+        quintile_key="Q1",
+        cohort_label="Bottom Quintile Informal Workers",
+        indicator_key="poverty_headcount_ratio",
+        indicator_label="Poverty Headcount Ratio",
+        severity="CRITICAL",
+        step_crossed=1,
+        above_floor_pct="3.75",
+        tier=3,
+        source="ECOWAS_REGIONAL_2023",
+        is_synthetic=True,
+        synthetic_method="regional_statistical_inference",
+        value="0.385",
+        breaches_below=True,
+    )
+    assert crossing.breaches_below is True
+
+
+def test_cohort_threshold_crossing_schema_accepts_breaches_below_false() -> None:
+    """CohortThresholdCrossing: lte threshold (future) — breaches_below=False."""
+    from app.schemas import CohortThresholdCrossing
+
+    crossing = CohortThresholdCrossing(
+        quintile_key="Q1",
+        cohort_label="Bottom Quintile",
+        indicator_key="debt_to_gdp",
+        indicator_label="Debt to GDP",
+        severity="WARNING",
+        step_crossed=3,
+        above_floor_pct="5.20",
+        tier=2,
+        source="IMF_WEO_2023",
+        is_synthetic=False,
+        synthetic_method=None,
+        value="0.852",
+        breaches_below=False,
+    )
+    assert crossing.breaches_below is False
+
+
+_SEN_GRP_ATTR = {
+    "_envelope_version": "1",
+    "value": "0.039",
+    "unit": "dimensionless",
+    "variable_type": "ratio",
+    "confidence_tier": 2,
+    "observation_date": None,
+    "source_registry_id": "IMF_WEO_2023",
+    "measurement_framework": "financial",
+}
+
+_SEN_CHT_BREACH_ATTR = {
+    "_envelope_version": "1",
+    "value": "0.385",  # below floor 0.40 → breach for gte threshold
+    "unit": "dimensionless",
+    "variable_type": "ratio",
+    "confidence_tier": 3,
+    "observation_date": None,
+    "source_registry_id": "ECOWAS_REGIONAL_2023",
+    "measurement_framework": "human_development",
+}
+
+_SEN_CHT_SAFE_ATTR = {
+    "_envelope_version": "1",
+    "value": "0.42",   # above floor 0.40 → no breach for gte threshold
+    "unit": "dimensionless",
+    "variable_type": "ratio",
+    "confidence_tier": 3,
+    "observation_date": None,
+    "source_registry_id": "ECOWAS_REGIONAL_2023",
+    "measurement_framework": "human_development",
+}
+
+_SEN_BREACH_STATE = {
+    "_envelope_version": "2",
+    "_modules_active": [],
+    "SEN": {"gdp_growth": _SEN_GRP_ATTR},
+    "SEN:CHT:1-25-54-INFORMAL": {"poverty_headcount_ratio": _SEN_CHT_BREACH_ATTR},
+}
+
+_SEN_SAFE_STATE = {
+    "_envelope_version": "2",
+    "_modules_active": [],
+    "SEN": {"gdp_growth": _SEN_GRP_ATTR},
+    "SEN:CHT:1-25-54-INFORMAL": {"poverty_headcount_ratio": _SEN_CHT_SAFE_ATTR},
+}
+
+
+def _make_sen_conn(state: dict, fetchval_return: int | None) -> AsyncMock:
+    conn = _make_conn(
+        {"scenario_id": "scen-sen"},
+        _snap_row(state=state),
+        _entity_row("Senegal"),
+    )
+
+    async def _fetch_side_effect(query: str, *_args: object) -> list[dict]:
+        if "mda_thresholds" in query:
+            return [
+                {
+                    "indicator_key": "poverty_headcount_ratio",
+                    "floor_value": "0.40",
+                    "comparison_operator": "gte",
+                }
+            ]
+        return []  # ecological boundary constants and any other fetch
+
+    conn.fetch = AsyncMock(side_effect=_fetch_side_effect)
+    conn.fetchval = AsyncMock(return_value=fetchval_return)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_gte_threshold_crossing_sets_breaches_below_true() -> None:
+    """get_measurement_output: gte threshold crossing emits breaches_below=True."""
+    conn = _make_sen_conn(_SEN_BREACH_STATE, fetchval_return=1)
+    result = await get_measurement_output(
+        scenario_id="scen-sen", entity_id="SEN", step=2, conn=conn
+    )
+    hd = result.outputs["human_development"]
+    assert len(hd.cohort_threshold_crossings) == 1
+    assert hd.cohort_threshold_crossings[0].breaches_below is True
+
+
+@pytest.mark.asyncio
+async def test_value_above_floor_emits_no_crossing() -> None:
+    """get_measurement_output: cohort value at or above gte floor emits no crossing."""
+    conn = _make_sen_conn(_SEN_SAFE_STATE, fetchval_return=None)
+    result = await get_measurement_output(
+        scenario_id="scen-sen", entity_id="SEN", step=2, conn=conn
+    )
+    hd = result.outputs["human_development"]
+    assert len(hd.cohort_threshold_crossings) == 0

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -212,6 +212,23 @@ export function buildSparklinePoints(
 // No longer rendered by MDAAlertPanelZone1B itself.
 // ---------------------------------------------------------------------------
 
+/**
+ * Format the floor-distance label for a cohort threshold crossing entry.
+ * Direction is determined by breaches_below (set by the backend based on
+ * comparison_operator): gte thresholds breach when value falls BELOW the floor;
+ * lte thresholds (future) breach when value rises ABOVE the floor.
+ */
+export function formatCohortDistance(
+  pct: string | null,
+  breachesBelow: boolean,
+  isSad: boolean,
+): string {
+  if (isSad || pct == null) return "—";
+  return breachesBelow ? `${pct}% below floor` : `${pct}% above floor`;
+}
+
+// ---------------------------------------------------------------------------
+
 interface AlertDetailPanelProps {
   alert: Zone1BAlert;
   onClose: () => void;
@@ -704,7 +721,7 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
       ) : (
         crossings.map((crossing, idx) => {
           const color = COHORT_SEVERITY_COLOR[crossing.severity];
-          const isSad = crossing.is_synthetic && crossing.synthetic_method === "STRUCTURAL_ABSENCE";
+          const isSad = !!crossing.is_synthetic && crossing.synthetic_method === "STRUCTURAL_ABSENCE";
           const badgeText = isSad
             ? "SAD"
             : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_MODEL"
@@ -712,7 +729,7 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
               : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_COMPARABLE"
                 ? "T3"
                 : `T${crossing.tier}`;
-          const valueDisplay = isSad ? "—" : (crossing.above_floor_pct != null ? `${crossing.above_floor_pct}% above floor` : "—");
+          const valueDisplay = formatCohortDistance(crossing.above_floor_pct, crossing.breaches_below !== false, isSad);
           return (
             <div
               key={`${crossing.quintile_key}-${crossing.indicator_key}`}

--- a/frontend/src/components/__tests__/MDAAlertPanelZone1B.test.ts
+++ b/frontend/src/components/__tests__/MDAAlertPanelZone1B.test.ts
@@ -17,6 +17,7 @@ import {
   formatAlertText,
   truncateIndicatorName,
   buildSparklinePoints,
+  formatCohortDistance,
   SEVERITY_ORDER,
   FRAMEWORK_ABBREV,
 } from "../MDAAlertPanelZone1B";
@@ -325,5 +326,33 @@ describe("buildSparklinePoints: SVG polyline generation", () => {
     const firstPair = result!.split(" ")[0];
     const x = parseFloat(firstPair.split(",")[0]);
     expect(x).toBeCloseTo(padding, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCohortDistance — dynamic floor distance label (Issue #1239 / DEMO6-010)
+// ---------------------------------------------------------------------------
+
+describe("formatCohortDistance — dynamic floor distance label", () => {
+  it("gte threshold (breachesBelow=true): returns 'X% below floor'", () => {
+    expect(formatCohortDistance("3.75", true, false)).toBe("3.75% below floor");
+  });
+
+  it("lte threshold (breachesBelow=false): returns 'X% above floor'", () => {
+    expect(formatCohortDistance("2.00", false, false)).toBe("2.00% above floor");
+  });
+
+  it("SAD case (isSad=true): returns '—' regardless of breachesBelow", () => {
+    expect(formatCohortDistance("3.75", true, true)).toBe("—");
+    expect(formatCohortDistance("2.00", false, true)).toBe("—");
+  });
+
+  it("null pct: returns '—' regardless of direction", () => {
+    expect(formatCohortDistance(null, true, false)).toBe("—");
+    expect(formatCohortDistance(null, false, false)).toBe("—");
+  });
+
+  it("zero pct: returns '0% below floor' (boundary — cohort exactly at floor)", () => {
+    expect(formatCohortDistance("0", true, false)).toBe("0% below floor");
   });
 });

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -95,6 +95,9 @@ export interface CohortThresholdCrossing {
   is_synthetic?: boolean;
   synthetic_method?: "STRUCTURAL_ABSENCE" | "SYNTHETIC_COMPARABLE" | "SYNTHETIC_MODEL" | null;
   value?: string | null;
+  /** Issue #1239 (DEMO6-010): True when the breach direction is value below floor (gte threshold).
+   *  False when breach is value above floor (lte threshold — future). Drives label in Zone 1B. */
+  breaches_below?: boolean;
 }
 
 interface ScenarioStepState {

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -401,13 +401,14 @@ test(
       "Step two. Q2 2024. Six months into the programme. " +
       "Fiscal conditionality has begun: social spending cut by three percent of GDP. " +
       "Look at Zone one B — the alert and cohort panel. " +
-      "The cohort impact section shows: bottom quintile informal workers poverty headcount. " +
-      "Current value: approaching the recovery floor. " +
+      "The cohort impact section shows confirmed threshold entries: " +
+      "bottom quintile informal workers, bottom quintile agricultural workers — " +
+      "all four sectors in Q1 flagged CRITICAL. " +
       "The badge reads: T3 — Inferred. " +
       "The demographic weighting comes from ECOWAS comparable economy distributions. " +
-      "Tier three means the calibration is from regional comparables, not primary survey data. " +
-      "That is exactly what T3 Inferred signals. The precision of who bears the cost is visible. " +
-      "Not aggregate poverty. Not a trend. This cohort, on this trajectory.",
+      "T3 Inferred means the calibration is from regional comparables — not primary survey data. " +
+      "The poverty headcount at programme entry is below the recovery floor. " +
+      "Not aggregate poverty. Not a trend. This cohort, at this step, named with precision.",
     );
 
     // Frame A (THESIS): Zone 1B cohort impact section showing Q1 informal threshold crossing.


### PR DESCRIPTION
## Summary

- **DEMO6-009 (#1238):** Frame A TTS narration updated from "approaching the recovery floor" to "confirmed threshold entries" language — matches populated Zone 1B state (8 crossing rows at step 2)
- **DEMO6-010 (#1239):** `breaches_below: bool` field added to `CohortThresholdCrossing` schema, backend sets it `True` for all current `gte` thresholds. Exports `formatCohortDistance` from `MDAAlertPanelZone1B.tsx` — renders "X% below floor" for gte crossings, "X% above floor" for future lte crossings. Fixes inverted "above floor" label visible in Zone 1B during Demo 6.
- `isSad` narrowed from `boolean | undefined` to `boolean` via `!!` double-negation (fixes TypeScript strict error exposed by new function signature)

## Test plan

- [x] 4 new backend unit tests: `CohortThresholdCrossing` schema accepts `breaches_below`; `gte` threshold crossing produces `breaches_below=True`; value above floor emits no crossing
- [x] 5 new Vitest unit tests: `formatCohortDistance` returns correct label for gte / lte / SAD / null / zero-boundary cases
- [x] `ruff check .` passes
- [x] `npm run build` passes
- [ ] CI full run (playwright + backend tests)

## Closes

- #1238 (DEMO6-009 narration fix)
- #1239 (DEMO6-010 dynamic label fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)