### PR TITLE
feat(m16-g8): DEMO6-006 T3 confidence band Q&A + DEMO6-012 source ID formatting

### DIFF
--- a/docs/demo/m16/stakeholder-walkthrough.md
+++ b/docs/demo/m16/stakeholder-walkthrough.md
@@ -570,6 +570,35 @@ mediation — that is the capability change Demo 6 demonstrates.
 and the presenter should not need to look anything up. The T3 badge is on screen
 before the challenge arrives.)*
 
+### "What is the confidence interval on that 0.385 estimate?"
+
+> Tier 3 means we are working from ECOWAS regional comparable economy distributions
+> for West Africa 2022–2023. We have not run country-specific household survey
+> decomposition for this cohort at this level of granularity. That data is not
+> available for this scenario.
+>
+> The practical uncertainty band at T3 is approximately ±0.05 from 0.385 — meaning
+> the actual Q1 informal worker poverty headcount could plausibly range from 0.335
+> to 0.435. The 0.40 recovery floor is inside that range. The T3 label is not a
+> hedge around a known number. It is a precise statement about what we estimated
+> and how. The ECOWAS distributions are the best publicly available source for this
+> cohort at this geography. We chose to declare the inference rather than present a
+> falsely precise number and let you discover the source later.
+>
+> The question this analysis answers is not "is the poverty headcount exactly 0.385?"
+> It is: "under T3 ECOWAS comparable economy weights, which cohorts are in the
+> vicinity of the recovery floor, and what does the 25-year trajectory look like
+> if the programme proceeds as proposed?" That question is answerable at T3. The
+> ministry team can use this analysis to ask the IMF: "What does your distributional
+> model show for this cohort?" — and that question changes the character of
+> the conversation regardless of whether the T3 estimate is within ±0.01 of
+> the IMF's own figure.
+
+*(Presenter note: do not concede that T3 is "not good enough to cite." T3 Inferred
+is a citable, disclosed estimate. The citation is: ECOWAS Regional 2023, declared
+at T3. The IMF's own projections for this cohort are also estimates — the ministry
+team should ask what tier they are and what the source is.)*
+
 ### "How do you define 'bottom quintile informal workers'?"
 
 > The cohort is defined as `SEN:CHT:1-25-54-INFORMAL` in the WorldSim cohort

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -213,6 +213,19 @@ export function buildSparklinePoints(
 // ---------------------------------------------------------------------------
 
 /**
+ * Convert a raw source registry ID (e.g. "ECOWAS_REGIONAL_2023") to a
+ * human-readable label ("Ecowas Regional 2023") for display in Zone 1B.
+ * Numeric parts (year) are preserved unchanged; word parts are title-cased.
+ */
+export function formatSourceId(id: string | null | undefined): string {
+  if (!id) return "—";
+  return id
+    .split("_")
+    .map(part => /^\d+$/.test(part) ? part : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/**
  * Format the floor-distance label for a cohort threshold crossing entry.
  * Direction is determined by breaches_below (set by the backend based on
  * comparison_operator): gte thresholds breach when value falls BELOW the floor;
@@ -758,7 +771,7 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
                   <span data-testid={`cohort-value-${crossing.indicator_key}`}>
                     {valueDisplay}
                   </span>
-                  {` · ${crossing.source}`}
+                  {` · ${formatSourceId(crossing.source)}`}
                 </span>
               </span>
               <span

--- a/frontend/src/components/__tests__/MDAAlertPanelZone1B.test.ts
+++ b/frontend/src/components/__tests__/MDAAlertPanelZone1B.test.ts
@@ -18,6 +18,7 @@ import {
   truncateIndicatorName,
   buildSparklinePoints,
   formatCohortDistance,
+  formatSourceId,
   SEVERITY_ORDER,
   FRAMEWORK_ABBREV,
 } from "../MDAAlertPanelZone1B";
@@ -354,5 +355,39 @@ describe("formatCohortDistance — dynamic floor distance label", () => {
 
   it("zero pct: returns '0% below floor' (boundary — cohort exactly at floor)", () => {
     expect(formatCohortDistance("0", true, false)).toBe("0% below floor");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSourceId — human-readable source registry ID (Issue #DEMO6-012)
+// ---------------------------------------------------------------------------
+
+describe("formatSourceId — source registry ID to human-readable label", () => {
+  it("ECOWAS_REGIONAL_2023 → 'Ecowas Regional 2023'", () => {
+    expect(formatSourceId("ECOWAS_REGIONAL_2023")).toBe("Ecowas Regional 2023");
+  });
+
+  it("IMF_WEO_2023 → 'Imf Weo 2023'", () => {
+    expect(formatSourceId("IMF_WEO_2023")).toBe("Imf Weo 2023");
+  });
+
+  it("WORLD_BANK_WDI_2022 → 'World Bank Wdi 2022'", () => {
+    expect(formatSourceId("WORLD_BANK_WDI_2022")).toBe("World Bank Wdi 2022");
+  });
+
+  it("null → '—'", () => {
+    expect(formatSourceId(null)).toBe("—");
+  });
+
+  it("undefined → '—'", () => {
+    expect(formatSourceId(undefined)).toBe("—");
+  });
+
+  it("empty string → '—'", () => {
+    expect(formatSourceId("")).toBe("—");
+  });
+
+  it("numeric year part is preserved unchanged", () => {
+    expect(formatSourceId("V_DEM_2024")).toBe("V Dem 2024");
   });
 });


### PR DESCRIPTION
## Summary

- **DEMO6-006** (#1241): Adds Q&A entry "What is the confidence interval on that 0.385 estimate?" to `stakeholder-walkthrough.md` §Q&A Preparation, after the "What is T3 Inferred" block. Covers ±0.05 practical uncertainty band (range 0.335–0.435), notes that 0.40 recovery floor is within the band, establishes T3 as citable ("ECOWAS Regional 2023, declared at T3"), and reframes ministry posture to ask IMF for its distributional model.
- **DEMO6-012** (#1242): Exports `formatSourceId()` pure function from `MDAAlertPanelZone1B.tsx`. Converts raw registry IDs like `ECOWAS_REGIONAL_2023` to `Ecowas Regional 2023` by splitting on `_`, title-casing alphabetic parts, preserving numeric year parts. Applied at the cohort crossing source render site (`{` · ${formatSourceId(crossing.source)}`}`). 7 Vitest unit tests cover ECOWAS, IMF, World Bank, null, undefined, empty string, and year-preservation.

## Test plan

- [ ] `formatSourceId` describe block (7 tests) passes — confirmed green
- [ ] `formatCohortDistance` describe block (5 tests) still passes — confirmed green
- [ ] `npm run build` exits 0 — confirmed clean
- [ ] Pre-existing `getNegotiationLabel` Tier 4/5 failures are unchanged (pre-existing, not introduced here)
- [ ] No TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)