### PR TITLE
feat(m16-g8): Zone 1A adaptive y-axis scaling for curve separation (IR-001)

### DIFF
--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -66,6 +66,24 @@ export function getConfidenceBadgeVisible(confidenceTier: number): boolean {
   return confidenceTier >= 4;
 }
 
+/**
+ * Compute adaptive y-axis domain from a set of composite score values.
+ * Padding = max(0.05, 10% of range); result clamped to [0, 1].
+ * Used by both the recharts path and CompositeChartSVG to ensure curve separation
+ * is visible when scores cluster in a narrow band (e.g. FIN ~0.51–0.56, GOV ~0.51).
+ */
+export function computeYDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [0, 1];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  const padding = Math.max(0.05, range * 0.1);
+  return [
+    Math.max(0, parseFloat((min - padding).toFixed(2))),
+    Math.min(1, parseFloat((max + padding).toFixed(2))),
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Phase 4 — composite encoding constants and helpers (ADR-017 §Decision table)
 // ---------------------------------------------------------------------------
@@ -313,8 +331,29 @@ function CompositeChartSVG({
     return MARGIN.left + (i / (stepIndices.length - 1)) * chartW;
   };
 
-  const yScale = (score: number): number =>
-    MARGIN.top + (1 - Math.min(1, Math.max(0, score))) * chartH;
+  const [yMin, yMax] = useMemo(() => {
+    const values: number[] = [];
+    for (const traj of [...Object.values(activeTrajectories), ...Object.values(baselineTrajectories)]) {
+      for (const step of traj.steps) {
+        const s = computeEntityCompositeScore(step);
+        if (s !== null) values.push(s);
+      }
+    }
+    return computeYDomain(values);
+  }, [activeTrajectories, baselineTrajectories]);
+
+  const yScale = (score: number): number => {
+    const clamped = Math.min(yMax, Math.max(yMin, score));
+    return MARGIN.top + (1 - (clamped - yMin) / (yMax - yMin)) * chartH;
+  };
+
+  const yGridValues = [
+    yMin,
+    yMin + (yMax - yMin) * 0.25,
+    yMin + (yMax - yMin) * 0.5,
+    yMin + (yMax - yMin) * 0.75,
+    yMax,
+  ];
 
   const buildPathD = (steps: TrajectoryStep[]): string => {
     const pts: string[] = [];
@@ -346,8 +385,6 @@ function CompositeChartSVG({
         return aScore !== null && bScore !== null && Math.abs(aScore - bScore) > 0.001;
       });
     });
-
-  const yGridValues = [0, 0.25, 0.5, 0.75, 1.0];
 
   return (
     <svg width={width} height={height} style={{ display: "block", overflow: "visible" }}>
@@ -597,6 +634,23 @@ export function TrajectoryView({
     (d) => d.financial_scoring_basis === "normalized_absolute",
   );
 
+  const yDomain = useMemo<[number, number]>(() => {
+    const values: number[] = [];
+    const fields = [
+      "financial_active", "financial_baseline",
+      "human_development_active", "human_development_baseline",
+      "ecological_active", "ecological_baseline",
+      "governance_active", "governance_baseline",
+    ] as const;
+    for (const d of mergedData) {
+      for (const field of fields) {
+        const v = d[field];
+        if (typeof v === "number") values.push(v);
+      }
+    }
+    return computeYDomain(values);
+  }, [mergedData]);
+
   // ---------------------------------------------------------------------------
   // Phase 4 — composite encoding data (ADR-017 §Decision table)
   // ---------------------------------------------------------------------------
@@ -770,7 +824,7 @@ export function TrajectoryView({
           />
 
           <YAxis
-            domain={[0, "auto"]}
+            domain={yDomain}
             tick={{ fontSize: 11 }}
             width={44}
             tickFormatter={(v: number) => v.toFixed(2)}

--- a/frontend/src/components/__tests__/TrajectoryView.test.ts
+++ b/frontend/src/components/__tests__/TrajectoryView.test.ts
@@ -39,6 +39,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeDivergenceFill,
   getConfidenceBadgeVisible,
+  computeYDomain,
   FRAMEWORKS,
   CONNECT_NULLS,
 } from "../TrajectoryView";
@@ -413,5 +414,59 @@ describe("AC-006 — atomicity: Zustand store single-set() invariant", () => {
     useScenarioStepStore.getState().setCurrentStep(5);
 
     expect(useScenarioStepStore.getState().current_step).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeYDomain — adaptive y-axis domain (IR-001 fix)
+// ---------------------------------------------------------------------------
+
+describe("computeYDomain — adaptive y-axis domain from score values", () => {
+  it("empty array → [0, 1] fallback", () => {
+    expect(computeYDomain([])).toEqual([0, 1]);
+  });
+
+  it("all values equal — padding of 0.05 applied on each side", () => {
+    const [lo, hi] = computeYDomain([0.5, 0.5, 0.5]);
+    expect(lo).toBeCloseTo(0.45, 2);
+    expect(hi).toBeCloseTo(0.55, 2);
+  });
+
+  it("wide spread — padding is 10% of range, not flat 0.05", () => {
+    // range = 0.6, 10% = 0.06 > 0.05 → padding = 0.06
+    const [lo, hi] = computeYDomain([0.2, 0.8]);
+    expect(lo).toBeCloseTo(0.14, 1);
+    expect(hi).toBeCloseTo(0.86, 1);
+  });
+
+  it("narrow spread comparable to Demo 6 data (FIN 0.51–0.56, GOV 0.51, HD 0.24–0.25)", () => {
+    const scores = [0.5635, 0.5100, 0.2500, 0.5198, 0.5125, 0.2375];
+    const [lo, hi] = computeYDomain(scores);
+    expect(lo).toBeGreaterThanOrEqual(0);
+    expect(lo).toBeLessThan(0.24);  // padded below HD's minimum
+    expect(hi).toBeGreaterThan(0.56); // padded above FIN's maximum
+    expect(hi).toBeLessThanOrEqual(1);
+  });
+
+  it("min - padding < 0 → floor clamped to 0", () => {
+    const [lo] = computeYDomain([0.02, 0.03]);
+    expect(lo).toBeGreaterThanOrEqual(0);
+  });
+
+  it("max + padding > 1 → ceiling clamped to 1", () => {
+    const [, hi] = computeYDomain([0.97, 0.98]);
+    expect(hi).toBeLessThanOrEqual(1);
+  });
+
+  it("returns a tuple of exactly two numbers", () => {
+    const result = computeYDomain([0.3, 0.7]);
+    expect(result).toHaveLength(2);
+    expect(typeof result[0]).toBe("number");
+    expect(typeof result[1]).toBe("number");
+  });
+
+  it("lo is always ≤ hi", () => {
+    expect(computeYDomain([0.5])[0]).toBeLessThanOrEqual(computeYDomain([0.5])[1]);
+    expect(computeYDomain([0.1, 0.9])[0]).toBeLessThanOrEqual(computeYDomain([0.1, 0.9])[1]);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes IR-001: Financial (0.51–0.56) and Governance (~0.51 flat) composite curves visually overlap in Demo 6 because their separation is < 0.05 — less than 5% of the fixed 0–1 y-axis height
- Adds exported `computeYDomain(values: number[]): [number, number]` — computes adaptive domain with padding = max(0.05, 10% of range), clamped to [0, 1]
- Applied in both render paths: recharts single-entity (Mode 1/2, the Demo 6 path) and CompositeChartSVG (multi-entity / Mode 3)
- For Demo 6 data range 0.235–0.564: adaptive domain ≈ [0.19, 0.61] → FIN/GOV gap is now ~12% of chart height vs. 5%
- 7 new unit tests for `computeYDomain`; all 31 TrajectoryView tests pass

## Option 2 disposition

EL confirmed: governance recalibration (more divergence under fiscal conditionality) filed as M17 finding — not in scope for Demo 6.

## Test plan

- [x] `npm run build` — passes
- [x] `npx vitest run src/components/__tests__/TrajectoryView.test.ts` — 31 passed
- [ ] Live app verification: load Demo 6 completed scenario, confirm FIN/GOV/HD curves are visually distinct in Zone 1A

🤖 Generated with [Claude Code](https://claude.com/claude-code)