### PR TITLE
test(e2e+backend): M17-G5 QA tests — G3 soft-skip fix (#1220) + startup WARNING test (#1214)

### DIFF
--- a/backend/tests/test_m17_g5_startup_warning.py
+++ b/backend/tests/test_m17_g5_startup_warning.py
@@ -1,0 +1,250 @@
+"""QA tests for M17-G5 #1214: startup WARNING when simulation_entities is empty.
+
+Authored from sprint entry acceptance criteria at:
+  docs/process/sprint-plans/m17-g5-sprint-entry.md §2.4 #1214
+
+NM-060 upstream (M16-G6): startup observability gap — empty simulation_entities
+produces a silent 422 on scenario creation with no diagnostic signal. Fix is
+process improvement #1 from NM-060: the backend must log a structured WARNING
+at lifespan startup when simulation_entities is empty, including the correct
+fix command.
+
+These tests WILL FAIL until the implementation PR adds _check_startup_entities()
+to app/main.py and calls it from the lifespan after create_asyncpg_pool().
+
+Schema reference: docs/schema/database.yml (simulation_entities table).
+
+NM-056 rule: NO pytest.skip() conditionally. No soft-skips.
+
+AC coverage:
+  AC-1214-1  WARNING log emitted when simulation_entities count is 0 at startup
+  AC-1214-2  No WARNING emitted when simulation_entities count is ≥ 1
+  AC-1214-R  Startup not disrupted — function completes normally in both cases,
+             queries simulation_entities specifically, WARNING is at WARNING level
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.main import _check_startup_entities  # Added by implementation PR
+
+# ---------------------------------------------------------------------------
+# AC-1214-1 — WARNING emitted when simulation_entities is empty
+# ---------------------------------------------------------------------------
+
+
+class TestAC12141WarningWhenEmpty:
+    """AC-1214-1: structured WARNING log emitted when simulation_entities count is 0.
+
+    NM-060 §Process improvement 1: the startup log must make an empty entity table
+    self-diagnosable without source inspection.
+    """
+
+    @pytest.mark.asyncio
+    async def test_warning_emitted_when_entity_count_is_zero(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARNING is logged when simulation_entities returns 0 rows.
+
+        A developer who runs the stack with an unseeded database must see the
+        WARNING immediately in startup output — not discover the empty table
+        by inspecting source code after receiving a 422 on scenario creation.
+        """
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 0
+
+        with caplog.at_level(logging.WARNING, logger="app.main"):
+            await _check_startup_entities(mock_pool)
+
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warning_records) >= 1, (
+            "AC-1214-1: no WARNING logged when simulation_entities count is 0. "
+            "Implementation PR must add a WARNING log in _check_startup_entities() "
+            "when the entity count is 0. "
+            "NM-060: a zero-entity stack produces silent 422s — the startup log must say so."
+        )
+
+    @pytest.mark.asyncio
+    async def test_warning_contains_fix_command(self, caplog: pytest.LogCaptureFixture) -> None:
+        """WARNING log must contain the correct fix command.
+
+        NM-060 §Three-layer failure #2: CONTRIBUTING.md previously listed the wrong
+        fix command. The WARNING in the startup log must cite the correct invocation
+        so developers can self-diagnose from the log alone.
+        """
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 0
+
+        with caplog.at_level(logging.WARNING, logger="app.main"):
+            await _check_startup_entities(mock_pool)
+
+        fix_command = "python -m app.db.seed.natural_earth_loader"
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any(fix_command in r.message for r in warning_records), (
+            f"AC-1214-1: WARNING log must contain the fix command '{fix_command}'. "
+            "NM-060: the correct command was absent from prior diagnostics. "
+            "The log message must be self-contained — developers must not need to read "
+            "source or CONTRIBUTING.md to find the fix."
+        )
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_at_warning_level_not_info_or_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Diagnostic log must be at WARNING level — not INFO, ERROR, or CRITICAL.
+
+        INFO is invisible at default log filters; ERROR/CRITICAL implies a fatal
+        condition. WARNING is the correct level for a degraded-but-functional state.
+        """
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 0
+
+        with caplog.at_level(logging.DEBUG, logger="app.main"):
+            await _check_startup_entities(mock_pool)
+
+        levels = {r.levelname for r in caplog.records}
+        assert "WARNING" in levels, (
+            "AC-1214-1: startup diagnostic must be logged at WARNING level. "
+            f"Levels found: {levels}. "
+            "INFO is not visible at default log filters; "
+            "ERROR/CRITICAL level would imply a fatal startup condition."
+        )
+        non_warning_levels = levels - {"WARNING"}
+        fatal_levels = {"ERROR", "CRITICAL"} & non_warning_levels
+        assert not fatal_levels, (
+            "AC-1214-1: startup check must not emit ERROR or CRITICAL log entries "
+            "when entities are empty — empty entities is a setup gap, not a fatal error. "
+            f"Unexpected levels: {fatal_levels}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-1214-2 — No WARNING emitted when simulation_entities is populated
+# ---------------------------------------------------------------------------
+
+
+class TestAC12142NoWarningWhenPopulated:
+    """AC-1214-2: no WARNING emitted when simulation_entities has ≥ 1 row.
+
+    The observability signal must be silent on a healthy stack. Spurious WARNINGs
+    on populated databases would mask real issues and erode signal credibility.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_one_entity_row(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No WARNING when simulation_entities has exactly 1 row."""
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 1
+
+        with caplog.at_level(logging.WARNING, logger="app.main"):
+            await _check_startup_entities(mock_pool)
+
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warning_records) == 0, (
+            "AC-1214-2: WARNING emitted when simulation_entities has 1 row. "
+            "The observability signal must be silent on a populated stack. "
+            f"Unexpected WARNING records: {[r.message for r in warning_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_full_natural_earth_entity_set(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No WARNING when simulation_entities has Natural Earth entity count (249 typical).
+
+        249 is the approximate number of entities seeded by the Natural Earth loader.
+        A healthy stack must not emit any WARNING on startup.
+        """
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 249
+
+        with caplog.at_level(logging.WARNING, logger="app.main"):
+            await _check_startup_entities(mock_pool)
+
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warning_records) == 0, (
+            "AC-1214-2: WARNING emitted when simulation_entities has 249 rows. "
+            "A fully-seeded stack (Natural Earth) must not emit this WARNING. "
+            f"Unexpected WARNING records: {[r.message for r in warning_records]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-1214-R — Startup not disrupted
+# ---------------------------------------------------------------------------
+
+
+class TestAC1214RStartupNotDisrupted:
+    """AC-1214-R: _check_startup_entities completes normally in all cases.
+
+    The WARNING is informational. It must not raise an exception, must not
+    disrupt the lifespan, and must not cause the health endpoint to fail.
+    Existing startup behaviour — lifespan completes, health endpoint returns 200
+    — is unaffected by whether entities are empty or populated.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_exception_when_empty(self) -> None:
+        """Function completes without raising when simulation_entities is empty."""
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 0
+
+        # Must complete without raising — startup must not be disrupted.
+        await _check_startup_entities(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_no_exception_when_populated(self) -> None:
+        """Function completes without raising when simulation_entities is populated."""
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 249
+
+        await _check_startup_entities(mock_pool)
+
+    @pytest.mark.asyncio
+    async def test_queries_simulation_entities_table(self) -> None:
+        """Function must query simulation_entities — not any other table.
+
+        Per docs/schema/database.yml: simulation_entities is the canonical entities
+        table. The check must query this specific table to correctly detect the
+        NM-060 root cause (unseeded Natural Earth data).
+        """
+        mock_pool = AsyncMock()
+        mock_pool.fetchval.return_value = 0
+
+        await _check_startup_entities(mock_pool)
+
+        mock_pool.fetchval.assert_called_once()
+        call_args_list = mock_pool.fetchval.call_args_list
+        assert len(call_args_list) == 1, (
+            "AC-1214-R: _check_startup_entities must issue exactly one query to the pool."
+        )
+        query_str = (call_args_list[0].args[0] if call_args_list[0].args else "").lower()
+        assert "simulation_entities" in query_str, (
+            "AC-1214-R: _check_startup_entities must query 'simulation_entities'. "
+            f"Actual query: '{query_str}'. "
+            "Per docs/schema/database.yml: simulation_entities is the entities table "
+            "seeded by the Natural Earth loader. Querying any other table will not "
+            "detect the NM-060 root cause."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pool_called_exactly_once_regardless_of_result(self) -> None:
+        """Pool is queried exactly once whether entities are empty or populated.
+
+        The check must not issue multiple queries or retry on failure. One COUNT(*)
+        query at startup is the full scope of this observability addition.
+        """
+        for entity_count in (0, 1, 249):
+            mock_pool = AsyncMock()
+            mock_pool.fetchval.return_value = entity_count
+
+            await _check_startup_entities(mock_pool)
+
+            assert mock_pool.fetchval.call_count == 1, (
+                f"AC-1214-R: _check_startup_entities issued {mock_pool.fetchval.call_count} "
+                f"pool queries when entity count = {entity_count}, expected exactly 1. "
+                "The startup check must not retry or issue additional queries."
+            )

--- a/frontend/tests/e2e/m16-g3-25year-human-capital-trajectory.spec.ts
+++ b/frontend/tests/e2e/m16-g3-25year-human-capital-trajectory.spec.ts
@@ -21,9 +21,12 @@
  *   - MDA-HD-POVERTY-Q1 floor (≥ 0.40); recovery_horizon_years=10 → "a decade or more"
  *   - No MDA-HD-POVERTY-Q2 floor — Q2 cannot trigger milestone sentence
  *
- * NM-056 rule: NO test.skip() or conditional skip patterns. Pre-implementation
- * guard pattern: guard on primary testid → isVisible() returns false → return
- * without asserting (no-op, not a pass). Guards use .catch(() => false).
+ * NM-061 fix (M17-G5 #1220): createSen100StepScenario() creates the scenario via API
+ * but does not select it in the UI. HumanCapitalTrajectoryPanel renders only when
+ * (activeScenarioDetail?.configuration?.projection_steps ?? 0) > 8, which requires
+ * a UI-selected scenario. All tests now use createAndSelectSenProjection() or
+ * createAndSelectZmbScenario() to select the scenario before checking panel visibility.
+ * No soft-skip patterns remain (NM-056 + NM-061 guards applied).
  *
  * AC coverage:
  *   AC-F1   Projection panel visible in primary viewport without drawer
@@ -50,6 +53,9 @@ import { test, expect } from "@playwright/test";
 
 const API_BASE = "http://localhost:8000/api/v1";
 
+const _SEN_SCENARIO_NAME = "M16-G3 E2E — SEN 25-year projection";
+const _ZMB_SCENARIO_NAME = "M16-G3 E2E — ZMB 8-step non-regression";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -71,7 +77,7 @@ async function waitForAppReady(page: import("@playwright/test").Page): Promise<v
 
 /**
  * Create a SEN scenario with projection_steps=100, run it to completion.
- * Returns scenario_id or throws on failure.
+ * Returns scenario_id or null if backend rejects projection_steps.
  *
  * Synthetic SEN initial attributes (Tier 3 — CE Assessment Decision 3).
  * Fires gdp_growth_change at step 1 to trigger DemographicModule elasticity path.
@@ -81,7 +87,7 @@ async function createSen100StepScenario(): Promise<string | null> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      name: "M16-G3 E2E — SEN 25-year projection",
+      name: _SEN_SCENARIO_NAME,
       configuration: {
         entities: ["SEN"],
         n_steps: 8,
@@ -124,8 +130,6 @@ async function createSen100StepScenario(): Promise<string | null> {
       ],
     }),
   });
-  // Pre-implementation guard: if the backend does not yet accept projection_steps,
-  // the create or run will fail (422 / 500). Return null so callers can no-op.
   if (!createRes.ok) return null;
   const { scenario_id } = (await createRes.json()) as ScenarioCreateResponse;
 
@@ -145,7 +149,7 @@ async function createZmb8StepScenario(): Promise<string> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      name: "M16-G3 E2E — ZMB 8-step non-regression",
+      name: _ZMB_SCENARIO_NAME,
       configuration: { entities: ["ZMB"], n_steps: 8, timestep_label: "annual", start_date: "2023-01-01" },
       scheduled_inputs: [],
     }),
@@ -163,6 +167,51 @@ async function createZmb8StepScenario(): Promise<string> {
   return scenario_id;
 }
 
+/**
+ * NM-061 fix: create SEN 100-step scenario via API then select it in the UI.
+ * Throws if backend rejects projection_steps — test must FAIL, not skip.
+ * Uses .first() to tolerate multiple rows with the same name from parallel CI runs.
+ */
+async function createAndSelectSenProjection(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  const scenarioId = await createSen100StepScenario();
+  if (!scenarioId) {
+    throw new Error(
+      "createAndSelectSenProjection: backend rejected projection_steps — " +
+      "G3 (#274) is delivered; this must FAIL, not skip. " +
+      "Check that the backend accepts projection_steps in the scenario configuration.",
+    );
+  }
+  await page.goto("/");
+  await waitForAppReady(page);
+
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+  const row = page.locator(".scenario-row").filter({ hasText: _SEN_SCENARIO_NAME }).first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await row.getByTitle("Select as primary scenario").click();
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+}
+
+/**
+ * NM-061 fix: create ZMB 8-step scenario via API then select it in the UI.
+ * ZMB scenario must be selected for zone-1a-trajectory to reflect it.
+ * Uses .first() to tolerate multiple rows from parallel CI runs.
+ */
+async function createAndSelectZmbScenario(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await createZmb8StepScenario(); // throws on any failure
+  await page.goto("/");
+  await waitForAppReady(page);
+
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+  const row = page.locator(".scenario-row").filter({ hasText: _ZMB_SCENARIO_NAME }).first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await row.getByTitle("Select as primary scenario").click();
+  await page.getByRole("button", { name: /Scenarios/ }).click();
+}
+
 // ---------------------------------------------------------------------------
 // AC-F1 — Projection panel visible in primary viewport (no drawer)
 // ---------------------------------------------------------------------------
@@ -171,14 +220,10 @@ test.describe("AC-F1: Projection panel visible without drawer", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("human-capital-trajectory-panel present at 1280×800 without drawer", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
-
-    await expect(panel).toBeVisible();
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     // Panel must have non-zero dimensions — not hidden in a closed drawer (SF-3).
     const box = await panel.boundingBox();
@@ -203,12 +248,10 @@ test.describe("AC-F2: ≥3 indicator curves displayed", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("projection-curve-* count ≥ 3 within trajectory panel", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const curves = panel.locator('[data-testid^="projection-curve-"]');
     const count = await curves.count();
@@ -228,17 +271,13 @@ test.describe("AC-F3: Milestone sentence at L0 without hover", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("projection-milestone-sentence visible at L0 with year + [step N] content", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const sentence = page.locator('[data-testid="projection-milestone-sentence"]');
-    if (!(await sentence.isVisible({ timeout: 5_000 }).catch(() => false))) return;
-
-    await expect(sentence).toBeVisible();
+    await expect(sentence).toBeVisible({ timeout: 10_000 });
 
     // Must be in the normal flow — not hidden via CSS (SF-3 variant).
     const isInNormalFlow = await sentence.evaluate((el) => {
@@ -276,17 +315,13 @@ test.describe("AC-F4: Panel header exact string", () => {
   test(
     'projection-panel-header contains "25-year projection · quarterly resolution" (U+00B7 middle-dot)',
     async ({ page }) => {
-      if (!(await createSen100StepScenario())) return;
-      await page.goto("/");
-      await waitForAppReady(page);
+      await createAndSelectSenProjection(page);
 
       const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-      if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+      await expect(panel).toBeVisible({ timeout: 10_000 });
 
       const header = panel.locator('[data-testid="projection-panel-header"]');
-      if (!(await header.isVisible({ timeout: 5_000 }).catch(() => false))) return;
-
-      await expect(header).toBeVisible();
+      await expect(header).toBeVisible({ timeout: 10_000 });
 
       const text = ((await header.textContent()) ?? "").trim();
 
@@ -313,17 +348,13 @@ test.describe("AC-F5: 100-step axis present within projection panel", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("projection-panel-step-axis visible within panel", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const stepAxis = panel.locator('[data-testid="projection-panel-step-axis"]');
-    if (!(await stepAxis.isVisible({ timeout: 5_000 }).catch(() => false))) return;
-
-    await expect(stepAxis).toBeVisible();
+    await expect(stepAxis).toBeVisible({ timeout: 10_000 });
 
     // The axis may scroll/zoom internally; it must not cause Zone 1A/1C/1D to move
     // out of the viewport (that's tested in AC-F6).
@@ -341,17 +372,14 @@ test.describe("AC-F6: Zone 1A, 1C, 1D not displaced at 1280×800", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("zone-1a-trajectory visible within 800px viewport with projection panel present", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const zone1a = page.locator('[data-testid="zone-1a-trajectory"]');
-    if (!(await zone1a.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+    await expect(zone1a).toBeVisible({ timeout: 10_000 });
 
-    await expect(zone1a).toBeVisible();
     const box = await zone1a.boundingBox();
     expect(box).not.toBeNull();
     expect(box!.y + box!.height).toBeLessThanOrEqual(800 + 10, [
@@ -361,17 +389,14 @@ test.describe("AC-F6: Zone 1A, 1C, 1D not displaced at 1280×800", () => {
   });
 
   test("zone-1c-pmm visible within 800px viewport with projection panel present", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const zone1c = page.locator('[data-testid="zone-1c-pmm"]');
-    if (!(await zone1c.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+    await expect(zone1c).toBeVisible({ timeout: 10_000 });
 
-    await expect(zone1c).toBeVisible();
     const box = await zone1c.boundingBox();
     expect(box).not.toBeNull();
     expect(box!.y + box!.height).toBeLessThanOrEqual(800 + 10, [
@@ -380,17 +405,14 @@ test.describe("AC-F6: Zone 1A, 1C, 1D not displaced at 1280×800", () => {
   });
 
   test("zone-1d-four-framework visible within 800px viewport with projection panel present", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const zone1d = page.locator('[data-testid="zone-1d-four-framework"]');
-    if (!(await zone1d.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+    await expect(zone1d).toBeVisible({ timeout: 10_000 });
 
-    await expect(zone1d).toBeVisible();
     const box = await zone1d.boundingBox();
     expect(box).not.toBeNull();
     expect(box!.y + box!.height).toBeLessThanOrEqual(800 + 10, [
@@ -407,19 +429,14 @@ test.describe("AC-F7: ZMB 8-step render path unchanged (ADR-017 non-regression)"
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("ZMB 8-step: zone-1a visible, projection panel absent, zone-1a has 4 SVG paths", async ({ page }) => {
-    await createZmb8StepScenario();
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectZmbScenario(page);
 
     const zone1a = page.locator('[data-testid="zone-1a-trajectory"]');
-    if (!(await zone1a.isVisible({ timeout: 10_000 }).catch(() => false))) return;
-
-    // Zone 1A must render for ZMB 8-step (existing behavior).
-    await expect(zone1a).toBeVisible();
+    await expect(zone1a).toBeVisible({ timeout: 10_000 });
 
     // Projection panel must be absent for default-step scenarios (SF-4 guard).
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    const panelVisible = await panel.isVisible({ timeout: 3_000 }).catch(() => false);
+    const panelVisible = await panel.isVisible({ timeout: 3_000 });
     expect(panelVisible).toBe(false, [
       "AC-F7 violation: human-capital-trajectory-panel visible for a ZMB 8-step scenario.",
       "Observable state A: 'data-testid=human-capital-trajectory-panel is absent from",
@@ -430,7 +447,6 @@ test.describe("AC-F7: ZMB 8-step render path unchanged (ADR-017 non-regression)"
     // Zone 1A must have exactly 4 SVG path elements (N=1 Mode 1 four-framework encoding).
     const paths = zone1a.locator("path");
     const pathCount = await paths.count();
-    if (pathCount === 0) return; // pre-implementation guard — paths not yet rendered
     expect(pathCount).toBe(4, [
       `AC-F7 violation: zone-1a-trajectory has ${pathCount} SVG paths, expected 4.`,
       "Observable state A: 'zone-1a-trajectory contains exactly 4 SVG path elements",
@@ -467,9 +483,8 @@ test.describe("AC-F8: Panel renders within 60 seconds", () => {
     // Multiple G3 tests call createSen100StepScenario() within the same CI run, producing
     // several rows with the same name. Use .first() to avoid strict mode violation while
     // still selecting a valid completed projection scenario.
-    const scenarioName = "M16-G3 E2E — SEN 25-year projection";
     await page.getByRole("button", { name: /Scenarios/ }).click();
-    const row = page.locator(".scenario-row").filter({ hasText: scenarioName }).first();
+    const row = page.locator(".scenario-row").filter({ hasText: _SEN_SCENARIO_NAME }).first();
     await expect(row).toBeVisible({ timeout: 10_000 });
     await row.getByTitle("Select as primary scenario").click();
     await page.getByRole("button", { name: /Scenarios/ }).click();
@@ -496,16 +511,13 @@ test.describe("AC-CM-1: Exactly 3 named cohort curves (CM-confirmed 2026-06-23)"
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("projection panel contains exactly 3 projection-curve-* elements", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const curves = panel.locator('[data-testid^="projection-curve-"]');
     const count = await curves.count();
-    if (count === 0) return; // pre-implementation guard
 
     expect(count).toBe(3, [
       `AC-CM-1 violation: found ${count} projection-curve-* elements, expected exactly 3.`,
@@ -518,12 +530,10 @@ test.describe("AC-CM-1: Exactly 3 named cohort curves (CM-confirmed 2026-06-23)"
   });
 
   test("panel contains 'bottom quintile, informal workers' plain label", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     // Each curve must be labelled in plain language (kryptonite constraint).
     // The exact testid encoding of colons is implementation-defined (may be %3A or dashes).
@@ -531,32 +541,26 @@ test.describe("AC-CM-1: Exactly 3 named cohort curves (CM-confirmed 2026-06-23)"
     const informalLabel = panel.locator(
       ':text-matches("bottom quintile.*informal|informal.*bottom quintile", "i")',
     );
-    if (!(await informalLabel.isVisible({ timeout: 3_000 }).catch(() => false))) return;
-    await expect(informalLabel.first()).toBeVisible();
+    await expect(informalLabel.first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("panel contains 'bottom quintile, agricultural workers' plain label", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const agriLabel = panel.locator(
       ':text-matches("bottom quintile.*agricultur|agricultur.*bottom quintile", "i")',
     );
-    if (!(await agriLabel.isVisible({ timeout: 3_000 }).catch(() => false))) return;
-    await expect(agriLabel.first()).toBeVisible();
+    await expect(agriLabel.first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("no health_index or food_insecurity_rate curves present", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     // CM finding: health_index and food_insecurity_rate have no elasticity entries —
     // they must not appear as curves.
@@ -585,18 +589,16 @@ test.describe("AC-CM-2: Milestone sentence matches CM-confirmed template", () =>
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("sentence contains year, [step N], cohort plain name, and consequence phrase", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const sentence = page.locator('[data-testid="projection-milestone-sentence"]');
-    if (!(await sentence.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+    await expect(sentence).toBeVisible({ timeout: 10_000 });
 
     const text = ((await sentence.textContent()) ?? "").trim();
-    if (!text) return; // pre-implementation guard — element present but not yet populated
+    expect(text.length).toBeGreaterThan(0, "AC-CM-2: projection-milestone-sentence is visible but empty.");
 
     // Year anchor: 4-digit year in 2025–2050.
     expect(text).toMatch(/\b(202[5-9]|20[3-4]\d|2050)\b/, [
@@ -640,15 +642,13 @@ test.describe("AC-CM-2: Milestone sentence matches CM-confirmed template", () =>
     // CM finding: 'No MDA-HD-POVERTY-Q2 floor registered; Q2 curve does not trigger a sentence.'
     // This test confirms there is no fabricated Q2 floor. Pass if no sentence, or if sentence
     // (when present) was triggered by a Q1 cohort.
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const sentence = page.locator('[data-testid="projection-milestone-sentence"]');
-    const sentenceVisible = await sentence.isVisible({ timeout: 3_000 }).catch(() => false);
+    const sentenceVisible = await sentence.isVisible({ timeout: 3_000 });
     if (!sentenceVisible) return; // no sentence — correct for scenarios where Q1 doesn't cross
 
     const text = ((await sentence.textContent()) ?? "").toLowerCase();
@@ -676,16 +676,13 @@ test.describe("AC-CM-3: Tier 3 confidence badges for all three cohort curves", (
   test.use({ viewport: { width: 1280, height: 800 } });
 
   test("3 projection-tier-badge-* elements present with text 'T3'", async ({ page }) => {
-    if (!(await createSen100StepScenario())) return;
-    await page.goto("/");
-    await waitForAppReady(page);
+    await createAndSelectSenProjection(page);
 
     const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
-    if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
+    await expect(panel).toBeVisible({ timeout: 10_000 });
 
     const badges = panel.locator('[data-testid^="projection-tier-badge-"]');
     const count = await badges.count();
-    if (count === 0) return; // pre-implementation guard
 
     expect(count).toBe(3, [
       `AC-CM-3 violation: found ${count} projection-tier-badge-* elements, expected exactly 3.`,


### PR DESCRIPTION
## Summary

- **#1220** — Corrects `m16-g3-25year-human-capital-trajectory.spec.ts`: removes all soft-skip patterns from AC-F1 through AC-F7 and AC-CM-1 through AC-CM-3; adds `createAndSelectSenProjection()` / `createAndSelectZmbScenario()` helpers so every test selects the scenario in the UI before checking panel visibility (NM-061 pattern from AC-F8).
- **#1214** — Authors `backend/tests/test_m17_g5_startup_warning.py`: unit tests for `_check_startup_entities(pool)` covering WARNING-when-empty, no-WARNING-when-populated, and startup-not-disrupted (AC-1214-1/2/R). **Tests will fail until implementation PR adds `_check_startup_entities()` to `app/main.py`.**
- **#1251** — Not in scope; audit-first per sprint entry §2.4.

## Red-before-green confirmation (#1220)

Before this fix, AC-F1 through AC-F7 and AC-CM-1 through AC-CM-3 passed CI while asserting nothing. The pattern:

```typescript
if (!(await panel.isVisible({ timeout: 60_000 }).catch(() => false))) return;
```

fired silently on every test because `createSen100StepScenario()` created the scenario via API but never selected it in the UI. `HumanCapitalTrajectoryPanel` renders only when `(activeScenarioDetail?.configuration?.projection_steps ?? 0) > 8`, which requires UI selection. Without selection, `activeScenarioDetail` was null/undefined and the panel never rendered — the catch guard returned false, the tests returned without asserting.

After this fix, the pattern is replaced by:
```typescript
await createAndSelectSenProjection(page);
const panel = page.locator('[data-testid="human-capital-trajectory-panel"]');
await expect(panel).toBeVisible({ timeout: 10_000 });
```

The same playwright run that previously passed silently will now assert the panel is visible — and hard-fail if it isn't.

Post-fix audit: `grep -rn "isVisible().catch\|test\.skip\|test\.fixme" frontend/tests/e2e/m16-g3-25year-human-capital-trajectory.spec.ts` → 0 matches.

## Sprint entry gate

Sprint entry `docs/process/sprint-plans/m17-g5-sprint-entry.md` — EL approved 2026-06-25.
- #1220 QA test gate (§2.4): deliverable is the corrected spec file ✅
- #1214 QA test gate (§2.4): `backend/tests/test_m17_g5_startup_warning.py` authored before implementation PR ✅
- No soft-skip patterns introduced (NM-056/NM-061 guard) ✅
- Backend pre-push lint gate: `ruff check . && mypy app/` both exit 0 ✅
- Frontend pre-push build gate: not required — no `frontend/src/` changes in this PR ✅

## Test plan

- [ ] `playwright-e2e` CI: G3 spec now runs real assertions (previously silently passing) — expect failures on any unresolved UI rendering gaps
- [ ] `test-backend` CI: `test_m17_g5_startup_warning.py` fails with `ImportError: cannot import name '_check_startup_entities' from 'app.main'` until implementation PR; this is expected and correct (pre-implementation red)
- [ ] No regressions in other E2E specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)