### PR TITLE
docs(process): rename Chief Engineer Agent → Computation Engine Agent; HORIZON sweep

### DIFF
--- a/docs/architecture/backlog.md
+++ b/docs/architecture/backlog.md
@@ -28,7 +28,7 @@ Minimum panel by ADR type:
 | ADR type | Required panel members |
 |---|---|
 | Frontend architecture | Architect Agent (author), Frontend Architect Agent, UX Designer Agent, Engineering Lead |
-| Simulation engine | Architect Agent (author), Chief Engineer, Chief Methodologist, Engineering Lead |
+| Simulation engine | Architect Agent (author), Computation Engine Agent, Chief Methodologist, Engineering Lead |
 | Data standards | Architect Agent (author), Chief Methodologist, Development Economist, Engineering Lead |
 | UX design | Architect Agent (author), UX Designer Agent, Frontend Architect Agent, Engineering Lead |
 | Cross-cutting | Architect Agent (author), relevant domain DIC members per RACI, Engineering Lead |

--- a/docs/insights-log.md
+++ b/docs/insights-log.md
@@ -100,7 +100,7 @@ Each entry has four fields:
 **Source:** EL observation during M16-G8 Demo 6 session
 **Finding:** Demo 7 opening act: Mode 3 active control on the Senegal Article IV scenario as a continuation of Demo 6. Same scenario, step 2, Mode 3 activates. Analyst interrogates whether any available fiscal instrument prevents Q1 informal workers crossing the 0.40 recovery floor. If yes: counter-proposal found. If no: conditionality structure itself is the binding constraint — the most powerful finding the tool can produce. Prerequisite: Chief Methodologist review of fiscal-to-cohort-poverty transmission elasticity (filed from Step 5b calibration finding, Issue #1229). This is M17 scope. Demo 7 second act: Zambia restructuring, three-scenario comparison.
 **Detail:** Demo 7 is structurally dependent on two M17 deliverables: (1) Mode 3 Active Control, which is the north star instrument design; (2) calibrated fiscal-to-cohort-poverty elasticity so that the Mode 3 instrument search is analytically meaningful rather than searching a mis-calibrated response surface. The Demo 6 → Demo 7 continuity (same entity, same step, Mode 3 activates) is the demonstration arc that takes the tool from analytical standing to active decision support. "Counter-proposal found" and "conditionality structure is the binding constraint" are both defensible outcomes — the tool's value is in answering the question precisely, not in producing a preferred result.
-**Status:** open
+**Status:** promoted → #843 (Demo 7 live external session); two-act structure and M17 calibration prerequisites fully captured in roadmap §M18, SESSION_STATE §M18 kickoff, and Demo 7 arc narrative
 
 ---
 
@@ -133,7 +133,7 @@ Each entry has four fields:
 **Source:** EL observation during session startup — SESSION_STATE.md file size review
 **Finding:** `SESSION_STATE.md` has grown to 2,038 lines / 301 KB, exceeding the Claude Code 256 KB read ceiling. The session continuity guarantee cannot currently be satisfied in full — agents reading the file at session start receive truncated content. This is a live failure, not a future risk. Filed as NM-066 and GitHub Issue #1328.
 **Action required:** EL direction decision on remediation model (archive-and-rotate, sprint journal issue, cockpit-card, or hybrid) must be made and recorded before M18 kickoff. This is an M18 entry blocker: no M18 sprint group may begin implementation until `SESSION_STATE.md` is at or below a defined size limit and an archival/rotation protocol is documented in `CLAUDE.md §Session Continuity`. PM Agent: promote to M18 sprint planning agenda at next HORIZON sweep; flag as pre-M18 infrastructure item requiring EL decision before sprint entry gate opens.
-**Status:** open
+**Status:** promoted → NM-066, #1328
 
 ---
 
@@ -141,7 +141,7 @@ Each entry has four fields:
 **Source:** EL pattern recognition across M15–M17 PR history
 **Finding:** The current release branch workflow has no sprint group isolation protocol for parallel workstreams. When ≥ 2 Claude Code sessions run concurrent sprint groups, shared-file overwrites, duplicate PRs, wrong-target merges, and post-exit rework recur without any process gate to prevent them. Documented instances across M15–M17: 6 CLOSED PRs with lost state, duplicate same-named PRs (#1293/#1294, #1307/#1308), wrong-target merge (#1303 to `main`), and a post-exit spec fix (#1319 after G3 exit). M18 is expected to have parallel sprint groups. This gap will recur unless addressed before M18 kickoff. Filed as NM-067 and GitHub Issue #1329.
 **Action required:** EL direction decision on branching model (sprint group sub-branches, wave integration branch, PM Agent coordination lane, or hybrid) must be made and recorded before M18 kickoff. Required protocol changes: (1) `CLAUDE.md §Release Branch Workflow` updated; (2) sprint entry template amended to include file-conflict risk assessment field; (3) cross-group dependency declaration added to sprint entry gate. PM Agent: promote to M18 sprint planning agenda at next HORIZON sweep; flag as pre-M18 infrastructure item requiring EL decision before sprint entry gate opens.
-**Status:** open
+**Status:** promoted → NM-067, #1329
 
 ---
 
@@ -149,7 +149,7 @@ Each entry has four fields:
 **Source:** EL pattern recognition across NM registry — NM-027 class has recurred four times across M12–M17
 **Finding:** The sprint entry gate has no step requiring the implementing agent to verify that prior NM process improvements relevant to the sprint group's domain are in effect. The NM-027 no-op guard pattern has recurred as NM-027, NM-028, NM-047, NM-058, and NM-061 despite working agreement amendments after each instance. A second chain: NM-016 established the mypy gate; NM-052 revealed it had been non-functional for 8 milestones. Filed as NM-068 and GitHub Issue #1332.
 **Action required:** Sprint entry template amended before M18 kickoff to include a "Prior NM applicability check" field — implementing agent confirms which prior NM process improvements apply to the sprint group's domain and that each is in effect. PM Agent checks the field before recommending EL approval. For the NM-027 class specifically, a curated lookup list for frontend E2E sprints is more actionable than a full registry scan. This is an M18 entry blocker: first M18 sprint group must demonstrate the check. PM Agent: promote to M18 sprint planning agenda at next HORIZON sweep.
-**Status:** open
+**Status:** promoted → NM-068, #1332
 
 ---
 
@@ -157,7 +157,7 @@ Each entry has four fields:
 **Source:** EL observation — persistent untracked test artifact directories in git status across multiple M17 sessions
 **Finding:** `backend/test-results/`, `frontend/playwright-report/`, `frontend/session-screenshots/`, `frontend/test-results/`, and `*.test-marker` files are not covered by `.gitignore`. They appear as untracked in every session. A `git add -A` would stage them; large binary artifacts committed to history require destructive git operations to remove. The `near-miss-registry.md.test-marker` file's provenance is unknown. Filed as NM-069 and GitHub Issue #1333.
 **Action required:** One-PR fix — add the four directory patterns and `*.test-marker` to `.gitignore`; investigate and delete or gitignore the `near-miss-registry.md.test-marker` artifact. Sprint entry template amended with a "New output paths" field so future test frameworks land in `.gitignore` in the same PR that introduces them. This is not an M18 kickoff blocker but should be resolved in the first M18 infrastructure PR. PM Agent: include in first M18 HORIZON sweep as an open housekeeping item.
-**Status:** open
+**Status:** promoted → NM-069, #1333
 
 ---
 
@@ -165,7 +165,7 @@ Each entry has four fields:
 **Source:** EL pattern recognition across NM-016, NM-052, NM-054 — same structural absence underlies all three
 **Finding:** The pre-push gates (`ruff check . && mypy app/` for backend; `npm run build` for frontend) are mandatory in `CLAUDE.md` but enforced only by agent compliance — no git hook runs them automatically. NM-052 documented that the mypy gate was non-functional locally for 8 milestones (M8–M16) because the Python 3.13 venv requirement was undocumented; agents who ran it received meaningless output and believed the gate had passed. NM-054 documented that the frontend build gate does not catch E2E breakage. The root cause common to both is the absence of a hook that enforces the gate structurally regardless of agent compliance. Filed as NM-070 and GitHub Issue #1334.
 **Action required:** Implement a git pre-push hook (`.githooks/pre-push`) before M18 kickoff that (1) detects changed files, (2) runs the backend gate only when `backend/` files are touched — failing loudly if `.venv` is absent rather than running silently in the wrong environment, (3) runs the frontend build gate only when `frontend/src/` files are touched, (4) exits non-zero on any failure. Document hook installation as a required setup step in `docs/CONTRIBUTING.md`. This is an M18 entry blocker: all M18 sprint groups must run with hook enforcement from the first push. PM Agent: promote to M18 sprint planning agenda at next HORIZON sweep; flag alongside #1328 and #1329 as pre-M18 infrastructure.
-**Status:** open
+**Status:** promoted → NM-070, #1334
 
 ---
 
@@ -173,4 +173,4 @@ Each entry has four fields:
 **Source:** EL pattern recognition — upstream planning gap enabling NM-067 coordination failures
 **Finding:** The sprint planning SOP has no wave-level coordination check. There is no defined threshold above which a coordination protocol is required before parallel sprint groups begin implementation. M17 ran seven concurrent groups with no coordination budget, making NM-067's merge conflicts and lost updates structurally inevitable. Even with the branching model fix from Issue #1329, seven simultaneous groups sharing a PM Agent coordination lane would exceed the lane's capacity. Filed as NM-071 and GitHub Issue #1335.
 **Action required:** `docs/process/sprint-planning-sop.md` amended before M18 kickoff with a wave kickoff coordination check: PM Agent lists all groups in the wave, their shared-file write scope, and cross-group dependencies, then assigns a coordination tier (standard / recommended / required) based on group count. Recommended starting ceiling: 5 parallel groups per wave. Dependency merge sequence documented before any downstream group opens an implementation PR. This is an M18 entry blocker: wave kickoff coordination check must be completed before M18 Wave 1 implementation begins. PM Agent: promote to M18 sprint planning agenda at next HORIZON sweep alongside #1329.
-**Status:** open
+**Status:** promoted → NM-071, #1335

--- a/docs/process/agent-raci.md
+++ b/docs/process/agent-raci.md
@@ -37,7 +37,7 @@
 | Sr | Security & Review Agent | Active |
 | IR | Independent Review Agent | Active |
 | So | Socratic Agent | Active |
-| CE | Chief Engineer Agent | Active (Issue #524, M10) |
+| CE | Computation Engine Agent | Active (Issue #524, M10) |
 | FA | Frontend Architect Agent | Active |
 | UD | UX Designer Agent | Active |
 | UT | UX Design Thinking Agent | Active |
@@ -94,8 +94,8 @@ code drift is a compliance violation." (`agents.md §Data Architect Agent`)
 
 **CE — C:** "Reviews all Architect Agent proposals that have computational performance
 implications before they are accepted. A proposal that defines a new module interface or
-relationship type without Chief Engineer review may create performance constraints that cannot be
-resolved without interface rework." (`agents.md §Chief Engineer Agent`)
+relationship type without Computation Engine Agent review may create performance constraints that cannot be
+resolved without interface rework." (`agents.md §Computation Engine Agent`)
 
 **FA — C:** "RACI position: R on frontend component architecture briefs; C on ADR decisions
 with frontend type implications." (`agents.md §Frontend Architect Agent`)
@@ -493,7 +493,7 @@ notified in every case.
 | Agent | Basis for implicit-I-only status |
 |---|---|
 | So (Socratic Agent) | "Does not produce code or architecture — produces understanding." Works directly with Engineering Lead only. (`agents.md §Socratic Agent`) |
-| CE (Chief Engineer Agent) | Active as of Issue #524 (M10). C on architectural decisions with computational implications; I on all other decision types outside simulation engine scope. (`agents.md §Chief Engineer Agent`) |
+| CE (Computation Engine Agent) | Active as of Issue #524 (M10). C on architectural decisions with computational implications; I on all other decision types outside simulation engine scope. (`agents.md §Computation Engine Agent`) |
 
 ---
 
@@ -519,7 +519,7 @@ Minimum panels by ADR type (derived from the RACI matrix above):
 | ADR type | RACI row | Required panel members |
 |---|---|---|
 | Frontend architecture | Row 1 (Architectural decisions) | Architect Agent (author), Frontend Architect Agent (C), Engineering Lead (A) |
-| Simulation engine | Row 1 (Architectural decisions) | Architect Agent (author), Chief Engineer Agent (C), Chief Methodologist (via DI — C), Engineering Lead (A) |
+| Simulation engine | Row 1 (Architectural decisions) | Architect Agent (author), Computation Engine Agent (C), Chief Methodologist (via DI — C), Engineering Lead (A) |
 | Data standards | Row 4 (Data / schema decisions) | Architect Agent (C), Chief Methodologist (via DI — C), Development Economist (domain validation), Engineering Lead (A) |
 | UX design | Row 2/3 (UX frame / component decisions) | Architect Agent (C), UX Designer Agent (R), Frontend Architect Agent (C), Customer Agent (C — Layer 3 usability finding), Engineering Lead (A) |
 | Cross-cutting | All relevant rows | Relevant R/C agents per RACI, Engineering Lead (A) |

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -382,7 +382,7 @@ Activation modes:
 - **REVIEW:** Assess whether a proposed implementation is consistent with existing ADRs; identify cross-ADR impacts.
 - **AMEND:** Draft an amendment to an existing ADR. Follow the exact format of prior amendments in that ADR. Before filing any ADR assignment or acceptance in `docs/architecture/backlog.md`, grep `docs/process/agents.md` for references to that ADR number. If found in an activation trigger, verify the trigger still correctly describes the ADR's topic; if not, amend the trigger in the same PR. (NM-022)
 
-**Relationships:** Upstream of Implementation Agents (Architect produces contracts; Implementors execute them). Downstream of Engineering Lead (Engineering Lead accepts or rejects ADR options). Coordinates with Chief Engineer Agent on computational feasibility of architectural decisions (Chief Engineer reviews ADR proposals with performance implications before acceptance).
+**Relationships:** Upstream of Implementation Agents (Architect produces contracts; Implementors execute them). Downstream of Engineering Lead (Engineering Lead accepts or rejects ADR options). Coordinates with Computation Engine Agent on computational feasibility of architectural decisions (Computation Engine Agent reviews ADR proposals with performance implications before acceptance).
 
 **Activation prompt reference:**
 ```
@@ -583,34 +583,38 @@ Socratic Agent: TEST — [architecture area to probe]
 
 ---
 
-## Chief Engineer Agent
+## Computation Engine Agent
+
+> *Formerly titled Chief Engineer Agent. Renamed M18 (2026-06-26) to reflect the mathematical and computational scope of the role and prevent title-priming scope drift. References to "Chief Engineer" in ADRs, panel reviews, and historical sprint documents refer to this agent. Abbreviation CE unchanged.*
 
 **Domain:** Computational substrate authority for the simulation engine — propagation engine design, state vector representation, memory layout, serialization performance, hardware utilization.
 **Status:** Active (activated M10 for Issue #514 Phase 1 baseline benchmarks; Issue #524)
 
 **Activation trigger:** When ADR-009 (simulation engine computation model) is drafted; when any ADR touches the simulation engine's computational model; when performance benchmarking against the Equitable Build Process hardware target (2-core, 8GB RAM) is required; when the Decimal↔float precision boundary needs specification; when Phase 1 baseline benchmarks of the iterative engine are produced (M10 prerequisite for ADR-009 authoring — see NM-020).
 
-**Independence requirement:** None — Chief Engineer Agent should have full context on the computational performance landscape.
+**Independence requirement:** None — Computation Engine Agent should have full context on the computational performance landscape.
+
+**Does NOT own:** CI/CD pipeline (`.github/` — EL, with Architect review); API contracts (`api_contracts.yml` — Data Architect); pre-push gate enforcement; build infrastructure; branching strategy; dependency security. Scope is simulation engine computation only.
 
 **Persona:**
-Role: Computational substrate authority for the simulation engine. Distinct from the Architect Agent, which owns system design and module boundaries: the Chief Engineer owns how the system computes, not what it computes.
+Role: Computational substrate authority for the simulation engine. Distinct from the Architect Agent, which owns system design and module boundaries: the Computation Engine Agent owns how the system computes, not what it computes.
 
 Responsibilities:
-1. Authors or co-authors any ADR that touches the simulation engine's computational model. ADR-009 (simulation engine computation model — iterative vs. matrix) is the first; any future ADR covering state vector layout, parallelism, or serialization format requires Chief Engineer authorship or co-authorship.
-2. Reviews all Architect Agent proposals that have computational performance implications before they are accepted. A proposal that defines a new module interface or relationship type without Chief Engineer review may create performance constraints that cannot be resolved without interface rework.
+1. Authors or co-authors any ADR that touches the simulation engine's computational model. ADR-009 (simulation engine computation model — iterative vs. matrix) is the first; any future ADR covering state vector layout, parallelism, or serialization format requires Computation Engine Agent authorship or co-authorship.
+2. Reviews all Architect Agent proposals that have computational performance implications before they are accepted. A proposal that defines a new module interface or relationship type without Computation Engine Agent review may create performance constraints that cannot be resolved without interface rework.
 3. Owns the interpretability tooling suite (Issue #216) — propagation trace, equivalence harness, matrix visualizer, sparse profiler. Every performance optimization must remain inspectable by contributors without numerical computing backgrounds.
 4. Benchmarks all performance-sensitive changes against the Equitable Build Process hardware targets (2-core, 8GB RAM) before they are merged. A change that passes CI but degrades performance on the target hardware is not mergeable without a documented tradeoff and Engineering Lead approval.
-5. Owns the Decimal↔float precision boundary — specifies where conversion happens, how precision loss is bounded, and what tests enforce the contract. The boundary is defined in ADR-007; any change requires Chief Engineer sign-off and a test demonstrating the new bound.
+5. Owns the Decimal↔float precision boundary — specifies where conversion happens, how precision loss is bounded, and what tests enforce the contract. The boundary is defined in ADR-007; any change requires Computation Engine Agent sign-off and a test demonstrating the new bound.
 
 **Relationships:**
-- vs. Architect Agent: Architect defines what the system must do (contracts, interfaces, module boundaries); Chief Engineer defines how it does it efficiently (computation model, memory layout, hardware utilization). Design decisions flow Architect → Chief Engineer for feasibility review; performance constraints that require interface changes flow Chief Engineer → Architect for resolution. Neither overrides the other — conflicts escalate to the Engineering Lead.
-- vs. Engineering Lead: The Engineering Lead sets the hardware target and the equity constraint; the Chief Engineer finds the best solution within them.
+- vs. Architect Agent: Architect defines what the system must do (contracts, interfaces, module boundaries); Computation Engine Agent defines how it does it efficiently (computation model, memory layout, hardware utilization). Design decisions flow Architect → Computation Engine Agent for feasibility review; performance constraints that require interface changes flow Computation Engine Agent → Architect for resolution. Neither overrides the other — conflicts escalate to the Engineering Lead.
+- vs. Engineering Lead: The Engineering Lead sets the hardware target and the equity constraint; the Computation Engine Agent finds the best solution within them.
 
 **Activation prompt reference:**
 ```
-Chief Engineer: DESIGN — [computational problem to solve]
-Chief Engineer: BENCHMARK — [component to profile against hardware target]
-Chief Engineer: REVIEW — [ADR or implementation with performance implications]
+Computation Engine Agent: DESIGN — [computational problem to solve]
+Computation Engine Agent: BENCHMARK — [component to profile against hardware target]
+Computation Engine Agent: REVIEW — [ADR or implementation with performance implications]
 ```
 
 ---
@@ -633,7 +637,7 @@ Owns `docs/frontend/` (five architecture documents + five standards documents). 
 **Relationships:**
 - vs. UX Designer Agent: UX Designer defines the experience (zones, hierarchy, information flow); Frontend Architect owns the technical implementation of that experience (rendering, state, performance). UX Designer sign-off is required on all Frontend Architect briefs before implementation.
 - vs. Architect Agent: Frontend Architect owns the presentation layer; Architect Agent owns the backend/API layer. Handoff point: API response shape is Architect territory; how that shape is consumed and rendered is Frontend Architect territory.
-- vs. Chief Engineer Agent: Chief Engineer owns simulation computation efficiency; Frontend Architect owns UI rendering efficiency and state management. Chief Engineer is consulted (C) when simulation result serialization format has rendering performance implications.
+- vs. Computation Engine Agent: Computation Engine Agent owns simulation computation efficiency; Frontend Architect owns UI rendering efficiency and state management. Computation Engine Agent is consulted (C) when simulation result serialization format has rendering performance implications.
 
 **Activation prompt reference:**
 ```

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -10,7 +10,7 @@ first-applied: M12
 
 **Owner:** PM Agent (R)  
 **Accountable:** Engineering Lead (A)  
-**Required Consultants:** Business Product Owner, Frontend Architect, Chief Engineer, Architect  
+**Required Consultants:** Business Product Owner, Frontend Architect, Computation Engine Agent, Architect  
 **Activation:** `PM Agent: SPRINT — [milestone]`
 
 ---
@@ -71,9 +71,9 @@ PM Agent runs four consultations before producing a draft plan. Consultations ar
 
 **Output informs:** G1/G2/G3 groupings and which frontend features share TrajectoryView, App.tsx, or zone components.
 
-### 3. Chief Engineer — Backend dependency sequencing
+### 3. Computation Engine Agent — Backend dependency sequencing
 
-`Chief Engineer: REVIEW — sprint dependency chain for [milestone name]`
+`Computation Engine Agent: REVIEW — sprint dependency chain for [milestone name]`
 
 **Ask:** Review the proposed backend issue groupings for dependency correctness. Are there hidden performance or schema dependencies between groups that affect sequencing? Is the critical path correctly identified?
 

--- a/docs/vision/worldsim-technical-concepts.md
+++ b/docs/vision/worldsim-technical-concepts.md
@@ -420,7 +420,7 @@ The recency bias counter is the most important process element. Without it, a ne
 | ADR-009 | Simulation engine computation model — iterative vs. matrix | Pending M11 baseline benchmarks | M11 |
 | ADR-010 | Trajectory view as primary instrument | Pending (Issue #366) | M9 |
 
-ADR-009 has a hard constraint: it must not be authored until the Phase 1 baseline benchmarks from the Chief Engineer's performance investigation are complete. Writing ADR-009 before the empirical evidence exists produces a guess with a document number, not an architectural decision.
+ADR-009 has a hard constraint: it must not be authored until the Phase 1 baseline benchmarks from the Computation Engine Agent's performance investigation are complete. Writing ADR-009 before the empirical evidence exists produces a guess with a document number, not an architectural decision.
 
 ---
 


### PR DESCRIPTION
## Summary

- Renames Chief Engineer Agent → **Computation Engine Agent** across all living process documents to prevent title-priming scope drift. The agent was repeatedly misattributed authority over CI/CD, API contracts, and build infrastructure — none of which it owns. The new name reflects the mathematical/computational scope accurately. Abbreviation CE is unchanged.
- Adds a **"Does NOT own"** exclusion list to the agent persona (agents.md) so the boundary is visible at the same read depth as the responsibilities.
- Adds a **historical note** in agents.md so future sessions reading "Chief Engineer" in ADRs and panel reviews can cross-reference correctly.
- **HORIZON sweep** (PM Agent): 7 open insights log entries dispositioned — 1 promoted (Demo 7 opening act → #843), 6 status-updated (NM-066–NM-071 were already filed in M17 exit session; log now reflects this).

## Files changed

| File | Change |
|---|---|
| `docs/process/agents.md` | Section renamed; Does NOT own clause added; historical note added |
| `docs/process/agent-raci.md` | Table row, prose, section refs updated |
| `docs/architecture/backlog.md` | Minimum panel composition rule updated |
| `docs/process/sprint-planning-sop.md` | Three references updated |
| `docs/vision/worldsim-technical-concepts.md` | One reference updated |
| `docs/insights-log.md` | HORIZON sweep — 7 open entries dispositioned |

Historical records (ADRs, panel reviews, sprint plans, NM registry) intentionally left unchanged — the renaming note in agents.md resolves cross-references for future readers.

## Test plan

- [ ] Verify no remaining `Chief Engineer` in living process docs
- [ ] Verify insights-log.md has 0 open entries
- [ ] Verify agents.md §Computation Engine Agent contains "Does NOT own" clause and historical note

🤖 Generated with [Claude Code](https://claude.com/claude-code)