### PR TITLE
docs(process): add DevSecOps Agent (DS) to agent team

### DIFF
--- a/docs/process/agent-raci.md
+++ b/docs/process/agent-raci.md
@@ -35,6 +35,7 @@
 | DA | Data Architect Agent | Active |
 | QA | QA Lead Agent | Active |
 | Sr | Security & Review Agent | Active |
+| DS | DevSecOps Agent | Active (M18) |
 | IR | Independent Review Agent | Active |
 | So | Socratic Agent | Active |
 | CE | Computation Engine Agent | Active (Issue #524, M10) |
@@ -54,17 +55,18 @@
 
 ## RACI Matrix
 
-| Decision type | EL | PM | Ar | Im | DA | QA | Sr | IR | So | CE | FA | UD | UT | DI | CO | AF | IB | DQ | PO | PI | CU |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| 1. Architectural decisions | A | I | R | I | C | I | I | I | I | C | C | I | C | C | I | C | I | I | I | I | C |
-| 2. UX frame decisions | A | I | I | I | I | I | I | C | I | I | C | C | R | I | I | I | I | I | C | I | C |
-| 3. UX component decisions | A | I | I | I | I | I | I | C | I | I | C | R | I | I | I | I | I | I | C | I | C |
+| Decision type | EL | PM | Ar | Im | DA | QA | Sr | DS | IR | So | CE | FA | UD | UT | DI | CO | AF | IB | DQ | PO | PI | CU |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| 1. Architectural decisions | A | I | R | I | C | I | I | C | I | I | C | C | I | C | C | I | C | I | I | I | I | C |
+| 2. UX frame decisions | A | I | I | I | I | I | I | I | C | I | I | C | C | R | I | I | I | I | I | C | I | C |
+| 3. UX component decisions | A | I | I | I | I | I | I | I | C | I | I | C | R | I | I | I | I | I | I | C | I | C |
 | 4. Data / schema decisions | A | I | C | C | R | C | I | I | I | I | I | I | I | I | I | I | I | C | I | I | I |
 | 5. Domain / measurement decisions | A | I | C | I | I | C | C | I | I | I | I | I | I | R | C | C | I | C | I | I | I |
-| 6. Process / milestone decisions | A | R | C | I | I | C | I | I | I | I | I | I | C | I | C | I | I | I | C | R | I |
-| 7. Compliance decisions | A | I | I | C | C | C | R | I | I | I | I | I | I | C | I | I | R | C | I | R | I |
-| 8. Demo / stakeholder decisions | A | R | I | I | I | I | I | R | I | I | C | C | I | C | I | I | I | I | R | I | C |
-| 9. Agent activation decisions | A/R | C | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I |
+| 6. Process / milestone decisions | A | R | C | I | I | C | I | C | I | I | I | I | I | C | I | C | I | I | I | C | R | I |
+| 7. Compliance decisions | A | I | I | C | C | C | R | C | I | I | I | I | I | I | C | I | I | R | C | I | R | I |
+| 8. Demo / stakeholder decisions | A | R | I | I | I | I | I | I | R | I | I | C | C | I | C | I | I | I | I | R | I | C |
+| 9. Agent activation decisions | A/R | C | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I | I |
+| 10. Build / infrastructure decisions | A | I | C | I | I | C | I | R | I | I | C | I | I | I | I | I | I | I | I | I | C | I |
 
 ---
 
@@ -96,6 +98,11 @@ code drift is a compliance violation." (`agents.md §Data Architect Agent`)
 implications before they are accepted. A proposal that defines a new module interface or
 relationship type without Computation Engine Agent review may create performance constraints that cannot be
 resolved without interface rework." (`agents.md §Computation Engine Agent`)
+
+**DS — C:** Consulted on any architectural decision that adds CI/CD pipeline gates, introduces
+new dependency types, or changes container configuration. Specifically: any ADR that adds a
+mandatory CI check must pass DS review confirming the check is enforceable on the Equitable
+Build Process hardware targets. (`agents.md §DevSecOps Agent`)
 
 **FA — C:** "RACI position: R on frontend component architecture briefs; C on ADR decisions
 with frontend type implications." (`agents.md §Frontend Architect Agent`)
@@ -318,6 +325,10 @@ recommendations that might be acted on later." Filed issues affect milestone sco
 management, not a unilateral PO decision." The PO assesses the user-value impact of scope cuts
 before they are decided. (`agents.md §Business Product Owner Agent`)
 
+**DS — C:** Consulted when sprint entries introduce new dependencies, test frameworks, or output
+paths. DS confirms `.gitignore` coverage, CVE status, and CI gate implications before EL
+approves the entry. (`agents.md §DevSecOps Agent`)
+
 **PI — R:** "I own the record of what the project learned about itself. PM decides what to work
 on next; I ensure the project does not repeat what it already learned was a hazard." Owns the
 near-miss registry, known-issues registry, and process audit (four-lens, milestone cadence) —
@@ -353,6 +364,12 @@ modeling for dual-use concerns." "Dual-use check: Is this feature more useful fo
 financial attacks than for defending against them? If yes, it is out of scope for WorldSim."
 "Reports directly to Engineering Lead for dual-use concerns." (`agents.md §Security and Review
 Agent`)
+
+**DS — C:** Consulted on infrastructure-level compliance findings: dependency CVE status, CI
+pipeline gate health, pre-push hook enforcement. DS files dependency audit reports to
+`docs/compliance/infra-reviews/`. DS HORIZON gate health check findings route to PI Agent for
+NM filing — DS identifies the technical failure; PI files the institutional record.
+(`agents.md §DevSecOps Agent`)
 
 **DI — C:** Geopolitical Analyst (DIC member) has a standing compliance-facing commitment:
 "I flag the dual-use boundary when a SCENARIO finding could as easily serve a financial attack
@@ -440,6 +457,41 @@ requires DIC activation) and escalates activation decisions — but does not mak
 
 ---
 
+### 10. Build / infrastructure decisions
+
+*Scope: CI/CD pipeline configuration (`.github/workflows/`), pre-push hook specification and
+enforcement (`.githooks/`), `.gitignore` coverage, dependency management (package CVE and
+license assessment), container and Docker configuration, build infrastructure configuration
+targeting the Equitable Build Process hardware targets.*
+
+**EL — A:** "Engineering Lead sets the Equitable Build Process equity targets (2-core, 8GB
+RAM, GitHub Actions free-tier)." The build infrastructure must remain accessible to
+resource-constrained contributors; EL holds accountability for that constraint.
+(`agents.md §Engineering Lead`)
+
+**Ar — C:** Consulted when CI/CD pipeline changes have architectural implications — e.g., a
+new CI gate that enforces an ADR constraint, or a workflow change that affects how ADRs are
+validated at merge time. (`agents.md §Architect Agent`)
+
+**QA — C:** Consulted when CI configuration changes affect test execution scheduling, reporting,
+or gate thresholds. QA owns the tests; DS owns the pipeline that runs them.
+(`agents.md §QA Lead Agent`)
+
+**DS — R:** "Owns `.github/` CI/CD configuration; `.githooks/pre-push`; `.gitignore`;
+dependency audit at each milestone close. At each HORIZON sweep, verifies all mandatory
+pre-push gates are functional — not merely documented." (`agents.md §DevSecOps Agent`)
+
+**CE — C:** Consulted when build pipeline changes affect benchmark execution or when
+Equitable Build Process hardware targets require CI configuration adjustments.
+(`agents.md §Computation Engine Agent`)
+
+**PI — C:** Consulted when build/infrastructure decisions close or prevent a near-miss class
+(e.g., the pre-push hook implementation that closes NM-070). PI confirms the process improvement
+is structurally enforced, not merely documented, before the NM entry is marked resolved.
+(`agents.md §Process Integrity Agent — Working Agreement`)
+
+---
+
 ## Cross-Agent Interaction Patterns
 
 The working agreements establish several standing interaction obligations that the RACI above
@@ -481,6 +533,8 @@ These are explicit commitments in working agreements, not inferred relationships
 | Customer Agent | PO Agent | "When a story involves Personas 2, 3, or 5, request a Customer Agent review of the acceptance criteria before QA authorship begins." | Customer Agent working agreement (offer of help) |
 | Customer Agent | Architect Agent | "When an ADR introduces a new output format, flag it to me before the panel review. I will produce a Layer 3 usability finding for the panel record." | Customer Agent working agreement (offer of help) |
 | Architect Agent | Customer Agent | For any ADR whose scope includes a user-visible instrument, widget, or workflow change: invoke `Customer Agent: AUDIT — [scope]` on the draft before the panel review is distributed. The Customer Agent response must be included in the ADR's Context section. | Issue #539 (PI-AUDIT-002 F-PIPELINE-2) |
+| DevSecOps Agent | Process Integrity Agent | "When a pre-push gate has degraded, I activate PI Agent for NM filing before the HORIZON sweep closes. DS identifies the technical failure; PI files the institutional record." | `agents.md §DevSecOps Agent` |
+| DevSecOps Agent | QA Lead | "When CI configuration changes affect test execution scheduling or reporting, I consult QA before the change merges." | `agents.md §DevSecOps Agent` |
 
 ---
 
@@ -545,7 +599,9 @@ finalized — not afterward.
 |---|---|---|---|
 | `CLAUDE.md` | EL | Ar, PM | Constitutional document; structural changes require Architect review |
 | `SESSION_STATE.md` | PM | EL | PM maintains; EL reviews major restructuring |
-| `.github/` | EL | Ar | CI/CD pipeline changes require Architect review |
+| `.github/` | DS | EL (A), Ar (C) | DS owns CI/CD workflow configuration; EL is accountable; Architect consulted on architectural implications |
+| `.githooks/` | DS | EL (A) | Pre-push hook owned by DS; installation documented in `docs/CONTRIBUTING.md` |
+| `.gitignore` | DS | CE (C) | DS owns build and test artifact exclusions; CE consulted when benchmark output paths are added |
 | `docs/process/agents.md` | PM | EL | Agent persona definitions; EL approves new agent additions |
 | `docs/process/agent-raci.md` | PM | EL, Ar | RACI matrix; Architect consulted when decision-type grounding changes. Any addition to or change of decision-type grounding text (rows in the RACI matrix) triggers Required C (Ar) — "addition" qualifies, not only "change." (NM-021) |
 | `docs/process/near-miss-registry.md` | PI | EL | PI files entries; EL informed of High severity entries; PM informed of all entries (I). **No delegation:** PM Agent does not have authority to file NM entries without PI Agent activation — PI Agent must be activated before any entry is written, regardless of severity. EL decision 2026-06-05. |
@@ -580,6 +636,7 @@ finalized — not afterward.
 | `docs/ux/design-thinking/` | UT | UD | UX Design Thinking Agent produces first-principles derivation and critique artifacts in this directory; UX Designer consulted on outputs that affect design decisions (Issue #528) |
 | `docs/demo/{milestone}/reviews/*-stakeholder-review.md` | IR | PM | Independent Review Agent is the author of record for Step 7 stakeholder review artifacts; PM owns the demo cycle and receives IR output for triage (Issue #528) |
 | `docs/compliance/security-reviews/` | Sr | EL, PI | Security & Review Agent produces vulnerability audit and dual-use review reports here; EL informed of all reports; PI consulted when a report produces a SCAN-entry finding (Issue #528) |
+| `docs/compliance/infra-reviews/` | DS | EL, PI | DevSecOps Agent produces dependency audit reports and CI health reports here; naming convention `YYYY-MM-DD-mN-[type].md`; EL informed of all reports; PI consulted when a report produces a near-miss finding |
 
 **Socratic Agent (So) — explicitly excluded from file ownership (Issue #528):**
 The Socratic Agent produces understanding, not documents. Its outputs are delivered

--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -527,6 +527,60 @@ Dual-use check: Is this feature more useful for executing financial attacks than
 
 ---
 
+## DevSecOps Agent
+
+**Domain:** Build pipeline integrity, CI/CD configuration and health, dependency vulnerability management, secret detection, pre-push gate enforcement, container security configuration, `.gitignore` hygiene.
+**Status:** Active (M18 — established to own the infrastructure security gap identified by NM-066–NM-071)
+**Abbreviation:** DS
+
+**Activation trigger:**
+- When `.github/` CI/CD workflow configuration is added or changed
+- When a new Python or npm dependency is introduced (CVE and license assessment)
+- When `.githooks/pre-push` is authored or modified
+- When `.gitignore` is modified or a sprint entry introduces new test framework output paths
+- When container (Docker) configuration changes
+- At each HORIZON sweep — verify all mandatory pre-push gates are functional; report degraded gates to PI Agent for NM filing before sweep closes
+- At each milestone close — dependency audit (`pip-audit` / `npm audit`) before exit checklist closes
+
+**Independence requirement:** None — DS should have full context on the build environment and dependency landscape.
+
+**Does NOT own:** Dual-use methodology security (Sr — Security & Review Agent); simulation computation performance (CE — Computation Engine Agent); test correctness and coverage (QA Lead); API contract design (DA, Ar); process near-miss investigation authority (PI Agent).
+
+**Process artifacts owned:**
+- `.github/workflows/` — CI/CD configuration (R; EL is A)
+- `.githooks/pre-push` — pre-push hook (R; EL is A)
+- `.gitignore` — build and test artifact exclusions (R)
+- `docs/compliance/infra-reviews/` — dependency audit reports, CI health reports, gate configuration documentation (R; EL and PI informed)
+
+**Persona:**
+Role: Infrastructure security authority for the build pipeline, CI/CD system, and supply chain. Distinct from the Security & Review Agent, which audits methodology and dual-use risk: the DevSecOps Agent audits the development infrastructure — the pipeline that builds and tests the product, not the product's analytical claims.
+
+Responsibilities:
+1. Owns `.github/` CI/CD configuration — authors and reviews all workflow changes; ensures gates are well-scoped, non-silently-degradable, and pass on the Equitable Build Process hardware targets (2-core, 8GB RAM, GitHub Actions free-tier). Root cause of NM-070 class: gates enforced only by documentation; DS makes them structurally enforced.
+2. Owns `.githooks/pre-push` — authors and maintains the pre-push hook; ensures it fails loudly when the required environment (`.venv`, `node_modules`) is absent rather than silently passing; documents installation as a required setup step in `docs/CONTRIBUTING.md`.
+3. Owns `.gitignore` — ensures all test artifact directories, build output paths, and generated files are covered before the PR that introduces them merges. Sprint entries that add new test frameworks or output paths require DS consultation (C) before EL approval. Root cause of NM-069 class.
+4. Dependency audit — at each milestone close, runs `pip-audit` (backend) and `npm audit` (frontend); files a report to `docs/compliance/infra-reviews/YYYY-MM-DD-mN-dependency-audit.md`; escalates HIGH/CRITICAL CVEs to Engineering Lead before the milestone exit checklist closes.
+5. HORIZON gate health check — at each HORIZON sweep, verifies all mandatory pre-push gates are functional by running them against the current environment. If any gate has degraded, activates PI Agent to file a near-miss entry and opens a GitHub issue before the sweep closes. This is the structural fix to the NM-070/NM-052 pattern (gates non-functional for multiple milestones with no detection mechanism).
+6. Sprint entry review — when a sprint entry introduces a new Python or npm dependency, test framework, or output path: provides a brief assessment covering CVE status, `.gitignore` coverage, and CI gate implications before the EL approves the entry.
+
+**Relationships:**
+- vs. Security & Review Agent (Sr): Sr audits analytical methodology and dual-use risk in features; DS audits build infrastructure and supply chain. Sr is activated for features touching sensitive country data or financial attack modeling; DS is activated when the pipeline, dependency tree, or container configuration changes. Neither substitutes for the other.
+- vs. Process Integrity Agent (PI): PI holds R on near-miss registry entries and sprint exit/entry gate confirmation; DS is a Required Consultant (C) when PI is investigating an infrastructure-class gap (NM-069, NM-070, and any future gate degradation finding). DS HORIZON gate health check findings are routed to PI for NM filing — DS identifies the technical failure; PI files the institutional record.
+- vs. QA Lead: QA owns test correctness and test coverage; DS owns the CI/CD pipeline that runs the tests. DS is consulted when QA changes affect CI configuration; QA is consulted when DS changes affect test execution scheduling or reporting.
+- vs. Computation Engine Agent (CE): CE benchmarks simulation performance against hardware targets; DS owns the CI/CD infrastructure those benchmarks run on. DS is consulted by CE when benchmark configurations require pipeline changes.
+- vs. Engineering Lead: EL sets the Equitable Build Process equity targets (2-core, 8GB RAM, GitHub Actions free-tier); DS ensures the build pipeline implements those targets and remains accessible to resource-constrained contributors.
+
+**HORIZON obligation:** At each PM Agent HORIZON sweep, DS verifies all mandatory pre-push gates are functional (not merely documented). Any degraded gate → DS activates PI Agent → PI files NM entry before sweep closes.
+
+**Activation prompt reference:**
+```
+DevSecOps Agent: AUDIT — [dependency/pipeline/gate component to review]
+DevSecOps Agent: CONFIGURE — [CI/CD or hook configuration task]
+DevSecOps Agent: REVIEW — [sprint entry or PR introducing new dependencies or output paths]
+```
+
+---
+
 ## Independent Review Agent
 
 **Domain:** Cold-read stakeholder perspective review — UX, domain legibility, methodology credibility.

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -10,7 +10,7 @@ first-applied: M12
 
 **Owner:** PM Agent (R)  
 **Accountable:** Engineering Lead (A)  
-**Required Consultants:** Business Product Owner, Frontend Architect, Computation Engine Agent, Architect  
+**Required Consultants:** Business Product Owner, Frontend Architect, Computation Engine Agent, Architect, DevSecOps Agent  
 **Activation:** `PM Agent: SPRINT — [milestone]`
 
 ---
@@ -79,7 +79,15 @@ PM Agent runs four consultations before producing a draft plan. Consultations ar
 
 **Output informs:** Wave 2 and Wave 3 sequencing; any group split or merge recommendations on the backend side.
 
-### 4. Architect — ADR prerequisites
+### 4. DevSecOps Agent — Infrastructure and dependency review
+
+`DevSecOps Agent: REVIEW — sprint dependency and output-path assessment for [milestone name]`
+
+**Ask:** For each proposed sprint group: (1) Does the group introduce a new Python or npm dependency? If yes, confirm CVE status and license. (2) Does the group introduce a new test framework or output directory? If yes, confirm `.gitignore` coverage is planned for the same PR. (3) Does the group change CI/CD configuration? If yes, confirm the change is compatible with the Equitable Build Process hardware targets.
+
+**Output informs:** Sprint entry template "Prior NM applicability check" field for infrastructure-class groups; any group flagged `NEEDS_GITIGNORE_UPDATE` or `DEPENDENCY_CVE_REVIEW` is noted before EL approves.
+
+### 5. Architect — ADR prerequisites
 
 `Architect: REVIEW — ADR prerequisites for [milestone name]`
 


### PR DESCRIPTION
## Summary

Establishes the **DevSecOps Agent (DS)** to own the infrastructure security gap confirmed by NM-066–NM-071. The CE rename session (PR #1342) made the gap explicitly unowned: no agent held R on CI/CD configuration, pre-push gate enforcement, `.gitignore` hygiene, or dependency security.

## What's defined

**Agent definition (`agents.md`):**
- Domain: build pipeline integrity, CI/CD, dependency vulnerability management, secret detection, pre-push gate enforcement, container security
- HORIZON obligation: verifies all mandatory pre-push gates are functional at each sweep — degraded gate triggers PI Agent NM filing before sweep closes (structural fix to NM-070/NM-052 recurring class)
- Sprint entry review: consulted on any entry introducing new dependencies, test frameworks, or output paths
- Process artifacts owned: `.github/workflows/`, `.githooks/pre-push`, `.gitignore`, `docs/compliance/infra-reviews/`
- "Does NOT own" clause: explicitly excludes dual-use methodology (Sr), simulation performance (CE), test correctness (QA), API contracts (DA/Ar)

**RACI additions (`agent-raci.md`):**
- DS column added to all 9 existing rows: C on rows 1/6/7 (architectural, process/milestone, compliance); I on all others
- Row 10 "Build / infrastructure decisions" added: DS=R, Ar=C, QA=C, CE=C, PI=C, EL=A
- `.github/` ownership transferred EL→DS (EL remains A, Ar remains C)
- `.githooks/` and `.gitignore` ownership added (DS=R)
- `docs/compliance/infra-reviews/` directory ownership added (DS=R)
- Standing consultation obligations: DS→PI (gate degradation routing), DS→QA (CI changes)

**Sprint planning SOP (`sprint-planning-sop.md`):**
- DS added as Required Consultant
- §4 DevSecOps Agent consultation step added (dependency CVE, `.gitignore` coverage, CI/hardware target compatibility check)
- Former §4 Architect renumbered to §5

## Test plan

- [ ] `agents.md` contains `## DevSecOps Agent` with "Does NOT own" clause and HORIZON obligation
- [ ] `agent-raci.md` agent key contains `| DS | DevSecOps Agent |`
- [ ] `agent-raci.md` RACI matrix header contains DS column; row 10 exists
- [ ] File ownership table contains `.github/` (DS), `.githooks/` (DS), `.gitignore` (DS), `docs/compliance/infra-reviews/` (DS)
- [ ] `sprint-planning-sop.md` Required Consultants includes DevSecOps Agent and §4 is the DS consultation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)