### PR TITLE
process(ds): replace CI polling with --auto merge + gh run watch; file KI-007

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,10 +385,15 @@ begins, no files are edited, and no git commands run until the user confirms the
 merge and Claude Code has executed `git pull origin main`.
 
 **Exception — PRs targeting a release branch (`release/m{N}`).** Release branch
-PRs are pre-authorized for autonomous merge. Claude Code polls `gh pr checks`
-until all checks have reached a terminal state (pass or skipped — no pending),
-then executes `gh pr merge <number> --merge` only if no check has failed.
-If any check has failed, stop and report to the user — do not attempt the merge.
+PRs are pre-authorized for autonomous merge. Immediately after opening the PR,
+set auto-merge: `gh pr merge <number> --merge --auto`. GitHub monitors CI and
+merges the PR the moment all required checks pass — no polling loop, no GraphQL
+quota consumption. If CI fails, `ci-failure-notify.yml` posts a comment and the
+auto-merge is abandoned; stop and report to the user.
+To observe CI output in real time (e.g. to diagnose a failure), use
+`gh run watch <run-id> --exit-status` — a single streaming connection, not a
+polling loop. Obtain the run ID with:
+`gh run list --branch <branch> --limit 1 --json databaseId --jq '.[0].databaseId'`
 `release/m{N}` branches are protected by the `release-branch-ci-gate` Ruleset —
 a failed required check will block the merge at the server regardless.
 See §Release Branch Workflow below.
@@ -416,8 +421,13 @@ during the milestone uses this pattern:
    and will be rejected by the `branch-naming` CI check. Use `feat/m14-g1-bugs`.
 2. Implement, run pre-push gates (lint, build), push feature branch
 3. Open PR targeting `release/m{N}` (not `main`)
-4. Poll CI; merge autonomously once all checks are terminal (pass or skipped, none failed): `gh pr merge <number> --merge`
-5. Pull from release branch: `git pull origin release/m{N}`
+4. Set auto-merge immediately after opening the PR:
+   `gh pr merge <number> --merge --auto`
+   GitHub merges when all required checks pass. The agent does not poll or wait —
+   move on to the next task or close the session. To observe CI in real time:
+   `gh run watch $(gh run list --branch <branch> --limit 1 --json databaseId --jq '.[0].databaseId') --exit-status`
+5. Pull from release branch before starting the next feature branch:
+   `git pull origin release/m{N}`
 6. Continue with next feature branch
 
 At milestone close, EL performs one admin bypass: `release/m{N}` → `main`.
@@ -426,10 +436,11 @@ always the Engineering Lead's action.
 
 `SESSION_STATE.md` updates during an active milestone target the release branch,
 not `main`, and follow the same autonomous merge rule as all release branch PRs:
-poll until all checks are terminal (pass or skipped, none failed), then
-`gh pr merge <number> --merge`. No `--admin` needed — the `release-branch-ci-gate`
-Ruleset treats skipped checks as passing. The `auto-merge-session-state` workflow
-only fires on PRs targeting `main` and does not apply here.
+set auto-merge immediately after opening the PR (`gh pr merge <number> --merge --auto`).
+No `--admin` needed — the `release-branch-ci-gate` Ruleset treats skipped checks
+as passing, and GitHub's auto-merge fires the moment all checks are terminal.
+The `auto-merge-session-state` workflow only fires on PRs targeting `main` and
+does not apply here.
 
 **Backend pre-push lint gate — mandatory before any `git push` touching Python files.**
 Before pushing any branch that modifies files under `backend/`, run:

--- a/docs/process/known-issues-registry.md
+++ b/docs/process/known-issues-registry.md
@@ -388,6 +388,92 @@ EX-001 (docs/compliance/exceptions.md): threshold exception active through M17 e
 
 ---
 
+## KI-007 — GitHub GraphQL API: Personal token rate limit (5,000 req/hr) exhausted by concurrent sprint sessions
+
+**Date first observed:** 2026-06-18
+**Infrastructure:** GitHub GraphQL API (personal access token quota, shared across all `gh` CLI calls in a session)
+**Severity:** Medium — `gh pr create` and CI polling calls fail with "API rate limit already exceeded"; sprint sessions must wait up to 60 minutes for quota reset or switch to REST workarounds mid-session
+**Recurrence:** Consistent — reproducible when ≥ 3 concurrent sprint group sessions make GraphQL-heavy `gh` CLI calls in the same clock hour
+
+### Symptom
+
+`gh pr create` or `gh pr checks` fails with:
+
+```
+GraphQL: API rate limit already exceeded for user ID 140208420.
+gh: API rate limit already exceeded for user ID 140208420.
+```
+
+The GitHub GraphQL API enforces a limit of 5,000 requests per hour per authenticated
+personal access token. The `gh` CLI uses GraphQL internally for `gh pr create`,
+`gh pr checks`, `gh pr merge`, and `gh issue create`. During periods of parallel sprint
+group activity (≥ 3 concurrent groups each polling CI and opening PRs), the cumulative
+call volume exhausts this quota within a single clock hour.
+
+First confirmed in session logs from 2026-06-18 (M14 G6a/G6b/G6c parallel sprint exits):
+35+ rate limit errors across a single day, with sessions blocked for up to 14 minutes
+awaiting reset.
+
+### Trigger condition
+
+Multiple concurrent Claude Code sprint sessions each running:
+- `gh pr create` (1 GraphQL call per invocation — `gh` uses GraphQL for PR creation)
+- CI polling via `gh pr checks <number>` (1+ GraphQL calls per poll, repeated every
+  30 seconds for the duration of CI runs of 3–7 minutes each)
+- `gh issue create`, `gh issue comment`, `gh pr view` (additional GraphQL calls)
+
+With 3–4 parallel sprint groups each running 2–3 PRs per session, the polling loops
+alone can consume several hundred calls per hour. High-frequency CI polling is the
+primary driver.
+
+### Workaround (pre-M18 protocol)
+
+Replace GraphQL-heavy operations with REST equivalents, which do not count against
+the 5,000/hr GraphQL quota:
+
+**PR creation (REST instead of GraphQL):**
+```bash
+gh api repos/PublicEnemage/worldsim/pulls \
+  --method POST \
+  --field title="<title>" \
+  --field body="<body>" \
+  --field head="<branch>" \
+  --field base="release/m{N}" \
+  --jq '.html_url'
+```
+
+**CI status check (REST instead of GraphQL polling):**
+```bash
+gh api repos/PublicEnemage/worldsim/commits/<sha>/check-runs \
+  --jq '[.check_runs[] | {name, status, conclusion}]'
+```
+
+### Permanent mitigation (M18 CLAUDE.md update)
+
+The M18 `CLAUDE.md §Release Branch Workflow` update replaces the CI polling
+loop with two patterns that eliminate high-frequency GraphQL consumption:
+
+1. **`gh pr merge <number> --merge --auto`** — set immediately after PR creation.
+   GitHub monitors CI server-side and merges when all checks pass. Zero ongoing
+   API calls from the agent. REST, not GraphQL.
+
+2. **`gh run watch <run-id> --exit-status`** — when real-time CI observation is
+   needed. Opens a single streaming connection; exits on completion. One connection,
+   not a polling loop.
+
+With these patterns in place, GraphQL calls are limited to low-frequency operations
+(PR creation fallback, issue management) and the 5,000/hr limit is not approached
+under normal sprint workloads.
+
+### Upstream
+
+No upstream issue filed. The 5,000 GraphQL requests/hour limit is GitHub's documented
+rate limit for authenticated personal access tokens. It is not configurable at the
+free tier. The mitigation is to use REST endpoints and streaming alternatives that
+do not consume GraphQL quota.
+
+---
+
 ## KI-NNN — [Infrastructure]: [Short description]
 
 **Date first observed:** YYYY-MM-DD


### PR DESCRIPTION
## Summary

- Replaces the `gh pr checks` polling loop (primary GraphQL quota consumer) with `gh pr merge --auto` + `gh run watch` across all three autonomous merge sites in CLAUDE.md
- Files KI-007 documenting the GitHub GraphQL rate limit root cause observed on 2026-06-18 (35+ errors during M14 parallel sprint exits), REST workaround, and this change as the permanent mitigation

## What changed

**CLAUDE.md — three locations updated:**
1. `§PR merge gate` release branch exception: polling loop → `--auto` + `gh run watch` pattern with run ID retrieval command
2. `§Release Branch Workflow` step 4: `gh pr merge --merge` (polling) → `gh pr merge --merge --auto` (fire and move on)
3. `SESSION_STATE.md` release branch paragraph: same substitution

**`docs/process/known-issues-registry.md`:**
- KI-007 filed: GitHub GraphQL API 5,000 req/hr personal token limit; symptoms, trigger (≥3 concurrent sprint sessions), pre-M18 REST workaround commands, permanent mitigation (this change)

## Why this matters

The old protocol (`gh pr checks` polled every ~30s) made GraphQL calls continuously for every open PR across every concurrent session. With 3–4 parallel sprint groups, the 5,000/hr quota was exhausted, blocking PR creation and session progress for up to 60 minutes. The new protocol makes zero ongoing API calls — GitHub merges when CI passes.

## Test plan

- [ ] Verify `gh pr merge --auto` sets auto-merge on the next release branch PR (GitHub UI shows "Auto-merge enabled")
- [ ] Verify `gh run watch <id> --exit-status` streams CI output and exits 0/non-zero correctly
- [ ] Confirm no remaining `gh pr checks` polling loops in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)