### PR TITLE
chore(m18): wave-level concurrency ceiling in sprint planning SOP

### DIFF
--- a/docs/process/agents.md
+++ b/docs/process/agents.md
@@ -223,15 +223,26 @@ dissent.
 `docs/process/sprint-planning-sop.md §Sprint Exit Gate` (Phase C output).
 Updated 2026-06-12 per Phase C. Changes to this section require PI Agent review and EL endorsement.*
 
+**At wave kickoff — before any group in the wave opens an implementation PR:**
+
+The PM Agent runs the wave kickoff coordination check defined in
+`docs/process/sprint-planning-sop.md §Wave Kickoff Coordination Check`. This check determines
+the coordination tier for the wave (Standard / Recommended / Required) based on the count of
+concurrently active implementation PRs across all sprint groups. The tier and any cross-group
+dependency merge sequence are recorded in every group's sprint entry document (Section 1)
+before the entry is routed to EL for approval. The hard ceiling is 5 concurrent groups — if
+5 are already active, no new group opens an implementation PR until one exits.
+
 **At sprint entry — before any implementation PR opens:**
 
 The PM Agent fills out the sprint entry template
 (`docs/process/sprint-plans/templates/sprint-entry-template.md`) and files it at
 `docs/process/sprint-plans/{milestone-slug}-sprint-{N}-entry.md`. The entry document must
 satisfy all five invariants in the template (release branch, CI trigger, ADR gates, intent
-documents, QA test authorship) before any implementation PR opens. A sprint that opens
-without a filed sprint entry template is a process deviation — the PM Agent may not authorize
-implementation to begin without the entry document filed and EL-approved.
+documents, QA test authorship) before any implementation PR opens, and must include the wave
+coordination tier from the wave kickoff check. A sprint that opens without a filed sprint entry
+template is a process deviation — the PM Agent may not authorize implementation to begin
+without the entry document filed and EL-approved.
 
 **What "EL-approved" means at entry:** The EL approves the sprint entry document either by
 adding the `el-approved` date in the frontmatter, or by confirming approval in a comment on

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -177,6 +177,51 @@ Sprint plan documents are not silently overwritten. Changes are visible through 
 
 ---
 
+## Wave Kickoff Coordination Check
+
+*Authority: NM-071 process improvement (2026-06-26). Changes to this section require PM Agent authorship and EL endorsement.*
+
+The wave kickoff coordination check is a PM Agent obligation executed before any sprint group in a new wave opens an implementation PR. It is distinct from the sprint entry gate (which is per-group) — this check is per-wave and asks whether the groups running concurrently are at a coordination tier where the PM Agent can reliably manage shared-file conflicts, cross-group dependencies, and PI Agent gate obligations alongside normal HORIZON sweep duties.
+
+The check produces a coordination tier assignment recorded in every sprint entry document for the wave.
+
+### Wave kickoff coordination fields
+
+PM Agent records these fields in each sprint group's entry document (Section 1 — Sprint Identification):
+
+1. **Groups in this wave** — list all sprint groups opening in the same wave, their primary implementation domains, and their shared-file write scope (`SESSION_STATE.md`, registry files, `CLAUDE.md`, DS-owned files). Use the file-conflict risk assessment (sprint entry §6.2) for each group to construct this list.
+
+2. **Cross-group dependency graph** — for each group, list any upstream group whose merged output is required before this group can begin implementation. Any group with an upstream dependency must have the dependency merge sequence documented before implementation begins — the downstream group may not open its integration PR until the upstream group's integration PR has merged to the release branch.
+
+3. **Coordination tier** — PM Agent determines the tier based on the count of groups actively running concurrently (not groups in the wave plan, but groups with open implementation PRs):
+
+| Concurrent groups | Tier | Required coordination protocol |
+|---|---|---|
+| 1–2 | **Standard** | Groups write to shared files in their own PRs; conflicts are recoverable at merge time. No additional coordination required beyond normal sprint entry. |
+| 3–4 | **Recommended coordination** | PM Agent coordination lane is recommended for shared-state files (`SESSION_STATE.md`, registry files). Groups flag shared-file changes in their exit PR description. PM Agent reviews exit PRs before PI Agent gate comment. |
+| 5 | **Required coordination** | PM Agent coordination lane is mandatory for all shared-state files. Sprint group sub-branches mandatory (per `docs/process/sprint-group-isolation.md`). No group may open an integration PR without PM Agent clearance. |
+
+**Hard ceiling: 5 concurrent groups per wave maximum.**
+
+If 5 groups are already actively running (implementation PRs open), no new group may open an implementation PR until at least one exits (integration PR merges to release branch). Exceeding this ceiling without explicit EL direction is a process deviation. The PM Agent is responsible for enforcing this ceiling — EL is accountable and may revise the ceiling after M18 experience.
+
+### Wave kickoff sequence
+
+1. PM Agent reviews all groups planned for the wave before any group opens an implementation PR.
+2. PM Agent determines the coordination tier for the wave.
+3. PM Agent records the tier and the dependency merge sequence in each group's sprint entry document (Section 1).
+4. EL approves the sprint entry documents (which now include the coordination tier).
+5. Implementation PRs may open once sprint entry documents are EL-approved.
+
+### When a new group joins mid-wave
+
+If a group not originally in the wave plan is added mid-wave:
+1. PM Agent re-runs the wave coordination check counting all currently open implementation PRs.
+2. If the new group's addition would push the concurrent count above 5, the group holds at sprint entry until a running group exits.
+3. The new group's entry document records the coordination tier at the time of its entry — not the tier from original wave planning.
+
+---
+
 ## Sprint Entry Gate
 
 *Authority: Phase C output (2026-06-12).

--- a/docs/process/sprint-plans/templates/sprint-entry-template.md
+++ b/docs/process/sprint-plans/templates/sprint-entry-template.md
@@ -34,6 +34,9 @@ Changes to this template require PM Agent authorship and EL endorsement.*
 | Sprint plan document | `docs/process/sprint-plans/{milestone-slug}-sprint-plan.md` |
 | Exit checklist issue | #{exit-checklist-issue-number} |
 | Sprint groups in scope | {G1, G2, G3, …} |
+| Wave coordination tier | {Standard / Recommended coordination / Required coordination — PM Agent determination per §Wave Kickoff Coordination Check} |
+| Concurrent groups at entry | {N of 5 max — count of implementation PRs open across all active sprint groups when this entry is filed} |
+| Cross-group dependencies | {None / See §6.4 for dependency merge sequence} |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Closes #1335 (NM-071):** Adds `§Wave Kickoff Coordination Check` to `docs/process/sprint-planning-sop.md` — a PM Agent obligation run before any group in a wave opens an implementation PR; produces a coordination tier (Standard / Recommended / Required) keyed to concurrent active group count; enforces a hard ceiling of 5 concurrent groups per wave.
- Updates `docs/process/agents.md §Sprint Boundary Obligations` with an explicit "At wave kickoff" step, making the check a named PM Agent obligation rather than an implied behavior.
- Adds three new fields to sprint entry template Section 1: `Wave coordination tier`, `Concurrent groups at entry`, and `Cross-group dependencies` — set by PM Agent at wave kickoff and verified by EL at entry approval.

## Root Cause (NM-071)

Sprint planning SOP had no wave-level check: groups could open implementation PRs without a coordination cost assessment. M17 ran 7 parallel groups with no ceiling and no coordination tier protocol, producing the coordination failures documented in NM-067.

## Coordination Tier Table

| Concurrent groups | Tier | Required protocol |
|---|---|---|
| 1–2 | Standard | Normal sprint entry; conflicts recoverable at merge time |
| 3–4 | Recommended coordination | PM Agent coordination lane recommended for shared-state files |
| 5 | Required coordination | Coordination lane mandatory; sub-branches mandatory; no integration PR without PM Agent clearance |

Hard ceiling: 5 concurrent groups. Exceeding without EL direction = process deviation.

## Files Changed

| File | Change |
|---|---|
| `docs/process/sprint-planning-sop.md` | New `§Wave Kickoff Coordination Check` section (50 lines) |
| `docs/process/agents.md` | "At wave kickoff" step added to `§Sprint Boundary Obligations` |
| `docs/process/sprint-plans/templates/sprint-entry-template.md` | Three coordination fields added to Section 1 |

## ADRs Affected

No ADR scope is touched by this PR.

## Note on sprint entry template

This PR and PR #1346 both modify `sprint-entry-template.md` in different sections (this PR: Section 1 table; #1346: Section 6.3a). GitHub should auto-merge both cleanly. Merge #1346 first to confirm, then merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)