### PR TITLE
chore(m18): record EL approval in GD + GR sprint entries — 2026-06-26

### DIFF
--- a/docs/process/sprint-plans/m18-gr-sprint-entry.md
+++ b/docs/process/sprint-plans/m18-gr-sprint-entry.md
@@ -3,17 +3,17 @@ name: m18-gr-sprint-entry
 type: sprint-entry
 milestone: M18 — Full Argument and Demo 7
 sprint-group: GR — Requirements Phase for Counter-Scenario Comparison
-status: Filed — awaiting EL approval
+status: EL-approved 2026-06-26
 authored-by: PM Agent
 authored-date: 2026-06-26
-el-approved: false
+el-approved: 2026-06-26
 release-branch: release/m18
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M18, GR: Requirements Phase for Counter-Scenario Comparison
 
-**Status:** Filed — awaiting EL approval before GR phase output is treated as entry-gate-complete for G3
+**Status:** EL-approved 2026-06-26
 **Date authored:** 2026-06-26
 **Release branch:** `release/m18`
 **Sprint plan:** `docs/process/sprint-plans/m18-sprint-plan.md` (EL-approved 2026-06-26, PR #1364)
@@ -196,7 +196,7 @@ GR's output is a downstream dependency for G3 (G3 sprint entry requires all thre
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-26
 
-> {EL approval statement — GR phase may proceed; artifact PRs may target release/m18 directly}
-> — @PublicEnemage ({date})
+> Approved: GR requirements phase as filed. The three activation calls in §4 may be issued. All three artifacts (UX journey, Customer Agent Layer 3, BPO business requirements) must be on record and PM Agent must record close confirmation on #1352 before G3 sprint entry is filed. GR close does not trigger G3 implementation — Architect ADR determination is still required at G3 sprint entry.
+> — @PublicEnemage (2026-06-26)


### PR DESCRIPTION
## Summary

- Records EL approval in `docs/process/sprint-plans/m18-gd-sprint-entry.md` (2026-06-26) — GD Phase 1 authorized; binding EL gate is Artifact 5 (#1359)
- Records EL approval in `docs/process/sprint-plans/m18-gr-sprint-entry.md` (2026-06-26) — GR phase authorized; three activation calls may be issued; PM Agent records GR close on #1352 before G3 sprint entry opens

## What changes

Both pre-wave sprint entry documents updated:
- Frontmatter: `status` and `el-approved` fields set to `2026-06-26`
- Header status line updated
- `## EL Approval Record` section populated with EL approval statement

## Next steps (GR)

PM Agent to issue activation calls to UX Designer, Customer Agent, and BPO (verbatim text in `m18-gr-sprint-entry.md §4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)