### PR TITLE
chore(m18): record EL approval for G1 and G2 sprint entries

### DIFF
--- a/docs/process/sprint-plans/m18-g1-sprint-entry.md
+++ b/docs/process/sprint-plans/m18-g1-sprint-entry.md
@@ -3,23 +3,23 @@ name: m18-g1-sprint-entry
 type: sprint-entry
 milestone: M18 — Full Argument and Demo 7
 sprint-group: G1
-status: Filed — awaiting EL approval
+status: EL-approved 2026-06-26 — intent document, UX/UI mockups, panel review, and QA tests required before implementation PR opens
 authored-by: PM Agent
 authored-date: 2026-06-26
-el-approved: false
+el-approved: 2026-06-26
 release-branch: release/m18
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M18, G1: CI Bands on Zone 1A
 
-**Status:** Filed — awaiting EL approval before implementation PR opens
+**Status:** EL-approved 2026-06-26 — intent document, UX/UI mockups, panel review, and QA tests required before implementation PR opens
 **Date authored:** 2026-06-26
 **Release branch:** `release/m18`
 **Sprint plan:** `docs/process/sprint-plans/m18-sprint-plan.md` (EL-approved 2026-06-26, PR #1364)
 **Sprint journal issue:** #1367
 
-*No implementation PR may open until this entry document is EL-approved.*
+*EL-approved. Implementation PR may not open until intent document, UX/UI mockups, panel review, and QA tests are complete (§2.3 and §2.4).*
 
 ---
 
@@ -211,7 +211,7 @@ G1 does not write to `InstrumentCluster.tsx` structurally — CI bands are passe
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-26
 
-> {EL approval statement — implementation PR may not open until this record is complete}
-> — @PublicEnemage ({date})
+> G1 sprint entry approved. ADR prerequisites confirmed (ADR-007 and ADR-017 both ACCEPTED). Sprint sub-branch `sprint/m18-g1` is live. Implementation PR may not open until: intent document filed at `docs/process/intents/M18-G1-2026-06-26-ci-bands-zone-1a.md`, UX mockup and UI mockup complete, 5-agent panel review ACCEPT recorded, and QA tests authored (red before implementation).
+> — @PublicEnemage (2026-06-26)

--- a/docs/process/sprint-plans/m18-g2-sprint-entry.md
+++ b/docs/process/sprint-plans/m18-g2-sprint-entry.md
@@ -3,23 +3,23 @@ name: m18-g2-sprint-entry
 type: sprint-entry
 milestone: M18 — Full Argument and Demo 7
 sprint-group: G2
-status: Filed — awaiting EL approval
+status: EL-approved 2026-06-26 — intent document, UX mockup, panel review, and QA tests required before implementation PR opens
 authored-by: PM Agent
 authored-date: 2026-06-26
-el-approved: false
+el-approved: 2026-06-26
 release-branch: release/m18
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M18, G2: PSP Driver Decomposition
 
-**Status:** Filed — awaiting EL approval before implementation PR opens
+**Status:** EL-approved 2026-06-26 — intent document, UX mockup, panel review, and QA tests required before implementation PR opens
 **Date authored:** 2026-06-26
 **Release branch:** `release/m18`
 **Sprint plan:** `docs/process/sprint-plans/m18-sprint-plan.md` (EL-approved 2026-06-26, PR #1364)
 **Sprint journal issue:** #1368
 
-*No implementation PR may open until this entry document is EL-approved.*
+*EL-approved. Implementation PR may not open until intent document, UX mockup, panel review, and QA tests are complete (§2.3 and §2.4).*
 
 ---
 
@@ -210,7 +210,7 @@ G2 does not touch `InstrumentCluster.tsx` if decomposition is inline within the 
 
 ## EL Approval Record
 
-**EL approval:** Pending
+**EL approval:** 2026-06-26
 
-> {EL approval statement — implementation PR may not open until this record is complete}
-> — @PublicEnemage ({date})
+> G2 sprint entry approved. ADR prerequisite confirmed (ADR-015 ACCEPTED). Sprint sub-branch `sprint/m18-g2` is live. Implementation PR may not open until: intent document filed at `docs/process/intents/M18-G2-2026-06-26-psp-driver-decomposition.md`, UX mockup complete (UI mockup conditional — UX Designer determines at mockup authorship time whether Zone 1D structural change is required), 5-agent panel review ACCEPT recorded, and QA tests authored (red before implementation).
+> — @PublicEnemage (2026-06-26)

--- a/docs/process/sprint-plans/m18-sprint-plan.md
+++ b/docs/process/sprint-plans/m18-sprint-plan.md
@@ -391,8 +391,8 @@ Per `docs/process/sprint-planning-sop.md §Sprint Entry Gate`, implementation ma
 3. ✅ EL approves sprint plan — PR #1364 merged 2026-06-26
 4. ✅ PM Agent cuts `release/m18` from `main` — cut 2026-06-26 at commit 8cffc86 (sync PR #1366 merged)
 5. ✅ DS Agent: `backend/test-results/` already in `.gitignore` (PR #1346 — no action needed)
-6. ⬜ G1 sprint entry filed and EL-approved → Wave 1 begins
-7. ⬜ G2 sprint entry filed and EL-approved → Wave 1 parallel group open
+6. ✅ G1 sprint entry filed and EL-approved 2026-06-26 (PR #1369; approval recorded in entry doc)
+7. ✅ G2 sprint entry filed and EL-approved 2026-06-26 (PR #1369; approval recorded in entry doc)
 8. ⬜ GD Phase 1 begins (Artifacts 1 + 3) — immediately after EL sprint plan approval
 9. ⬜ GR begins (#1352) — immediately after EL sprint plan approval
 10. ⬜ Wave 1 exit gates confirmed by PI Agent (G1, G2)


### PR DESCRIPTION
## Summary

- `m18-g1-sprint-entry.md`: `el-approved: false` → `2026-06-26`; status line updated; EL Approval Record filled in (ADR-007 + ADR-017 confirmed, remaining gates listed)
- `m18-g2-sprint-entry.md`: `el-approved: false` → `2026-06-26`; status line updated; EL Approval Record filled in (ADR-015 confirmed, UI mockup conditional noted)
- `m18-sprint-plan.md`: kickoff sequence items 6 and 7 marked complete

Wave 1 is now open. Implementation PRs for G1 and G2 remain blocked until intent documents, UX/UI mockups, 5-agent panel reviews, and QA tests are on record.

Shared state lane PR — targets `release/m18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)