### PR TITLE
infra(m18): extend branch-naming check to sprint/m* PR targets

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,23 +1,25 @@
 name: branch-naming
 
-# Enforces milestone-scoped branch naming for PRs targeting release/m* branches.
+# Enforces milestone-scoped branch naming for PRs targeting release/m* or sprint/m* branches.
 #
 # Problem: sprint group identifiers (G1, G2, …) are reused across every milestone.
 # A branch named feat/g1-bugs is ambiguous — it could belong to M13, M14, or M15.
 # Stale branches from prior milestones create collision and confusion risks.
 #
-# Rule: any branch targeting release/m{N} must contain "m{N}" in its name.
+# Rule: any branch targeting release/m{N} or sprint/m{N}-g{N} must contain "m{N}" in its name.
 #   PASS: feat/m14-g1-prerequisite-bugs  → release/m14
+#   PASS: feat/m14-g1-prerequisite-bugs  → sprint/m14-g1
 #   FAIL: feat/g1-prerequisite-bugs      → release/m14  (missing m14)
 #   FAIL: feat/m13-g1-prerequisite-bugs  → release/m14  (wrong milestone)
 #
-# The check name "branch-naming" is a required status check in the
-# release-branch-ci-gate Ruleset — a failure blocks the merge server-side.
+# The check name "branch-naming" is a required status check in both
+# release-branch-ci-gate and sprint-branch-ci-gate Rulesets.
 
 on:
   pull_request:
     branches:
       - release/m*
+      - sprint/m*
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -29,8 +31,19 @@ jobs:
           TARGET_BRANCH: ${{ github.base_ref }}
           HEAD_BRANCH: ${{ github.head_ref }}
         run: |
-          # Extract milestone prefix from target branch: "release/m14" → "m14"
-          MILESTONE="${TARGET_BRANCH##release/}"
+          # Extract milestone prefix from target branch.
+          # release/m14     → "m14"
+          # sprint/m14-g2   → "m14"
+          if echo "$TARGET_BRANCH" | grep -q "^release/"; then
+            MILESTONE="${TARGET_BRANCH##release/}"
+          elif echo "$TARGET_BRANCH" | grep -q "^sprint/"; then
+            # sprint/m14-g2 → strip "sprint/" → "m14-g2" → take up to first "-g" → "m14"
+            SPRINT_SUFFIX="${TARGET_BRANCH##sprint/}"
+            MILESTONE="${SPRINT_SUFFIX%%-g*}"
+          else
+            echo "Unexpected target branch pattern: $TARGET_BRANCH"
+            exit 1
+          fi
 
           echo "Target branch : $TARGET_BRANCH"
           echo "Head branch   : $HEAD_BRANCH"


### PR DESCRIPTION
## Summary

Fixes the root cause of PR #1398 hanging: `branch-naming.yml` only triggered on `release/m*` targets. The `sprint-branch-ci-gate` Ruleset requires `branch-naming`, but the workflow never fired for `feat/* → sprint/m*` PRs, leaving auto-merge waiting for a check that never reported.

**Changes:**
- Added `sprint/m*` to `pull_request.branches` trigger
- Milestone extraction handles both target patterns:
  - `release/m14` → `"m14"` (unchanged)
  - `sprint/m14-g2` → strip `sprint/` → take prefix before `-g` → `"m14"`

**Follow-up after merge:** Re-add `branch-naming` to `sprint-branch-ci-gate` Ruleset (removed temporarily to unblock #1398).

🤖 Generated with [Claude Code](https://claude.com/claude-code)