### PR TITLE
fix(m18-g3): correct table name + restore Zone 1B scroll contract (#1349)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -2626,7 +2626,7 @@ async def post_distributional_differential(
     snapshots_by_scenario: dict[str, dict[int, dict[str, Any]]] = {}
     for sid in scenario_ids:
         rows = await conn.fetch(
-            "SELECT step_index, state FROM scenario_snapshots"
+            "SELECT step_index, state FROM scenario_state_snapshots"
             " WHERE scenario_id = $1 ORDER BY step_index",
             sid,
         )

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -406,7 +406,7 @@ endpoints:
       status_400: "fewer than 2 scenarios, or reference not in scenario_ids"
       status_404: "any scenario has no snapshots"
       status_409: "no shared steps across all scenarios"
-    db_reads: [scenario_snapshots]
+    db_reads: [scenario_state_snapshots]
     notes:
       - "AC-1349-G: headcount_differential is integer; direction_stable = (ci_lower>0) OR (ci_upper<0)"
       - "AC-schema: fields headcount_differential, ci_lower, ci_upper, direction_stable, tier present"

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -721,10 +721,12 @@ function DistributionalComparisonSummary({ summary }: { summary: DistributionalS
     <div
       data-testid="distributional-comparison-summary"
       style={{
-        flexShrink: 0,
+        position: "sticky",
+        bottom: 0,
         borderTop: "1px solid #e5e7eb",
         padding: "6px 8px",
         background: "#fff",
+        zIndex: 1,
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 2 }}>
@@ -811,11 +813,10 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
   return (
     <div
       data-testid="zone-1b-cohort-impact"
-      style={{ borderTop: "1px solid #e0e0e0", flex: "1 1 0", display: "flex", flexDirection: "column", overflow: "hidden", background: "#fff" }}
+      style={{ borderTop: "1px solid #e0e0e0", paddingTop: 2, flex: "1 1 0", overflowY: "auto", background: "#fff", position: "relative" }}
     >
-      <div style={{ flex: "1 1 0", overflowY: "auto", paddingTop: 2 }}>
-        <div
-          data-testid="cohort-section-header"
+      <div
+        data-testid="cohort-section-header"
           style={{
             fontSize: 9,
             fontWeight: 600,
@@ -906,7 +907,6 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
             );
           })
         )}
-      </div>
       {distributionalSummary && distributionalSummary.pairs.length > 0 && (
         <DistributionalComparisonSummary summary={distributionalSummary} />
       )}


### PR DESCRIPTION
## Fixes two CI failures from #1407

**1. `asyncpg.exceptions.UndefinedTableError: relation "scenario_snapshots" does not exist`**

The G3 endpoint used `scenario_snapshots` — the actual table is `scenario_state_snapshots`. Fixed in `scenarios.py` and `api_contracts.yml`.

**2. `m17-g3-zone-1b-allocation.spec.ts:913` — `cohortInternallyScrollable` is `false`**

The G3 implementation restructured `CohortImpactSection` with an outer `overflow:hidden` + inner scrollable div. The existing test checks `scrollHeight > clientHeight` on the `zone-1b-cohort-impact` element, which is always false on an `overflow:hidden` flex container. Fix: revert outer div to `overflowY: auto` (original scroll contract). `DistributionalComparisonSummary` now uses `position: sticky; bottom: 0; zIndex: 1` to anchor to the visible bottom of the scroll area — a sticky element inside a scrollable container is the correct pattern for this use case.

## Pre-push gates
- `ruff check . && mypy app/`: PASS
- `npm run build`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)