### PR TITLE
fix(m18-g4): update pre-G4 E2E tests broken by ADR-019 D-3 testid renames

### DIFF
--- a/frontend/tests/e2e/demo-narrated-m12.spec.ts
+++ b/frontend/tests/e2e/demo-narrated-m12.spec.ts
@@ -397,10 +397,11 @@ test(
 
     // Enable Mode 3 Active Control.
     await page.locator('[data-testid="mode3-toggle"]').click();
-    await expect(page.locator('[data-testid="fiscal-multiplier-slider"]')).toBeVisible({ timeout: 5_000 });
+    // G4: policy-param-slider replaces fiscal-multiplier-slider (ADR-019 D-3).
+    await expect(page.locator('[data-testid="policy-param-slider"]')).toBeVisible({ timeout: 5_000 });
 
     // Set fiscal multiplier to 1.30 using native input setter (required for React controlled inputs).
-    await page.locator('[data-testid="fiscal-multiplier-slider"]').evaluate(
+    await page.locator('[data-testid="policy-param-slider"]').evaluate(
       (el, value) => {
         const slider = el as HTMLInputElement;
         const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
@@ -415,7 +416,8 @@ test(
     await page.waitForTimeout(300);
 
     // Apply the branch — this runs the parallel trajectory from step 3 onward.
-    await page.locator('[data-testid="apply-control-change"]').click();
+    // G4: apply-policy-input replaces apply-control-change (ADR-019 D-3).
+    await page.locator('[data-testid="apply-policy-input"]').click();
 
     // Wait for branch computation to complete (recompute badge disappears).
     await expect(page.locator('[data-testid="recompute-badge"]')).not.toBeVisible({ timeout: 30_000 });

--- a/frontend/tests/e2e/demo-trajectory-mode3.spec.ts
+++ b/frontend/tests/e2e/demo-trajectory-mode3.spec.ts
@@ -102,12 +102,14 @@ test("G2/AC-1: Mode 3 comparison readout visible after branch recompute", async 
 
   // Enable Mode 3.
   await page.locator('[data-testid="mode3-toggle"]').click();
-  await expect(page.locator('[data-testid="apply-control-change"]')).toBeVisible({
+  // G4 renamed apply-control-change → apply-policy-input (ADR-019 D-3).
+  await expect(page.locator('[data-testid="apply-policy-input"]')).toBeVisible({
     timeout: 3_000,
   });
 
   // Set fiscal multiplier to 1.30.
-  await page.locator('[data-testid="fiscal-multiplier-slider"]').evaluate(
+  // G4 renamed fiscal-multiplier-slider → policy-param-slider (ADR-019 D-3).
+  await page.locator('[data-testid="policy-param-slider"]').evaluate(
     (el: HTMLInputElement) => {
       const setter = Object.getOwnPropertyDescriptor(
         window.HTMLInputElement.prototype,
@@ -121,8 +123,8 @@ test("G2/AC-1: Mode 3 comparison readout visible after branch recompute", async 
     page.locator('[data-testid="fiscal-multiplier-value"]'),
   ).toContainText("1.30", { timeout: 2_000 });
 
-  // Apply control change — triggers branch recompute.
-  await page.locator('[data-testid="apply-control-change"]').click();
+  // Apply policy input — triggers branch recompute.
+  await page.locator('[data-testid="apply-policy-input"]').click();
 
   // Wait for recompute to complete (badge disappears).
   await expect(page.locator('[data-testid="recompute-badge"]')).toBeVisible({

--- a/frontend/tests/e2e/m16-g9-mode3-branch-comparison.spec.ts
+++ b/frontend/tests/e2e/m16-g9-mode3-branch-comparison.spec.ts
@@ -128,16 +128,17 @@ async function enableMode3(page: import("@playwright/test").Page): Promise<boole
 }
 
 /**
- * Create a Mode 3 branch by setting fiscal-multiplier-slider to 1.30
- * and clicking apply-control-change. Returns false if controls are absent
- * (pre-implementation guard).
+ * Create a Mode 3 branch by setting policy-param-slider to 1.30
+ * and clicking apply-policy-input. Returns false if controls are absent
+ * (pre-implementation guard). G4 renamed: fiscal-multiplier-slider → policy-param-slider,
+ * apply-control-change → apply-policy-input (ADR-019 D-3).
  */
 async function applyControlChange(page: import("@playwright/test").Page): Promise<boolean> {
-  const applyBtn = page.locator('[data-testid="apply-control-change"]');
+  const applyBtn = page.locator('[data-testid="apply-policy-input"]');
   if (!(await applyBtn.isVisible({ timeout: 5_000 }).catch(() => false))) return false;
 
   // Set fiscal multiplier to 1.30 via DOM property setter (slider does not accept direct fill).
-  const slider = page.locator('[data-testid="fiscal-multiplier-slider"]');
+  const slider = page.locator('[data-testid="policy-param-slider"]');
   if (!(await slider.isVisible({ timeout: 2_000 }).catch(() => false))) return false;
   await slider.evaluate((el: HTMLInputElement) => {
     const setter = Object.getOwnPropertyDescriptor(

--- a/frontend/tests/e2e/mode-transition.spec.ts
+++ b/frontend/tests/e2e/mode-transition.spec.ts
@@ -473,9 +473,9 @@ test("Regression: fiscal multiplier mode derivation unchanged after mode-selecto
 
   await expect(modeIndicator).toHaveAttribute("data-mode", "MODE_2");
 
-  // The fiscal multiplier slider exists in Mode 2 — if visible, verify it is
-  // still functional (its change still drives mode correctly via the existing path)
-  const slider = page.locator('[data-testid="fiscal-multiplier-slider"]');
+  // The policy param slider exists in Mode 2 column — if visible, verify it is
+  // still functional. G4: fiscal-multiplier-slider renamed policy-param-slider (ADR-019 D-3).
+  const slider = page.locator('[data-testid="policy-param-slider"]');
   const sliderPresent = await slider.isVisible({ timeout: 1_000 }).catch(() => false);
   if (!sliderPresent) return;
 

--- a/frontend/tests/e2e/mode3-active-control.spec.ts
+++ b/frontend/tests/e2e/mode3-active-control.spec.ts
@@ -63,18 +63,14 @@ test("Mode 3 — enable, apply control change, recompute completes", async ({ pa
   // Enable Mode 3.
   await page.locator('[data-testid="mode3-toggle"]').click();
 
-  // ControlPlane should appear. zone-control-plane resolves to 2 elements (InstrumentCluster
-  // always renders a reserved zone; ControlPlane adds a second). Use apply-control-change,
-  // which only exists inside ControlPlane and is always rendered when ControlPlane is mounted.
-  await expect(page.locator('[data-testid="apply-control-change"]')).toBeVisible({
+  // ControlPlaneColumn should appear (G4: apply-policy-input is the Form 1 apply button).
+  await expect(page.locator('[data-testid="apply-policy-input"]')).toBeVisible({
     timeout: 3_000,
   });
 
-  // Move fiscal multiplier to 1.5 (default is 1.0 — drag or set via evaluate).
-  // Scenarios panel is closed so only the ControlPlane slider is in the DOM.
-  // Use the native HTMLInputElement property setter so React's onChange fires on
-  // this controlled input (plain el.value = x does not trigger React's event system).
-  await page.locator('[data-testid="fiscal-multiplier-slider"]').evaluate(
+  // Move fiscal multiplier to 1.5 (default is 1.0).
+  // G4 renamed fiscal-multiplier-slider → policy-param-slider (ADR-019 D-3).
+  await page.locator('[data-testid="policy-param-slider"]').evaluate(
     (el: HTMLInputElement) => {
       const setter = Object.getOwnPropertyDescriptor(
         window.HTMLInputElement.prototype, "value"
@@ -88,8 +84,8 @@ test("Mode 3 — enable, apply control change, recompute completes", async ({ pa
   // Verify display updated.
   await expect(page.locator('[data-testid="fiscal-multiplier-value"]')).toContainText("1.50");
 
-  // Click Apply Change — triggers branch creation and advance loop.
-  await page.locator('[data-testid="apply-control-change"]').click();
+  // Click Apply — triggers branch creation and advance loop.
+  await page.locator('[data-testid="apply-policy-input"]').click();
 
   // Recompute badge should appear while computing.
   await expect(page.locator('[data-testid="recompute-badge"]')).toBeVisible({
@@ -139,16 +135,15 @@ test("Mode 3 toggle resets to idle when scenario changes", async ({ page }) => {
   await page.locator(".scenario-row").filter({ hasText: scenarioA })
     .getByTitle("Select as primary scenario").click();
   await page.locator('[data-testid="mode3-toggle"]').click();
-  // apply-control-change is unambiguous: only exists inside ControlPlane (not in the
-  // always-rendered InstrumentCluster zone-control-plane div that causes strict-mode violation).
-  await expect(page.locator('[data-testid="apply-control-change"]')).toBeVisible({
+  // G4: apply-policy-input is the Form 1 apply button in ControlPlaneColumn (ADR-019 D-3).
+  await expect(page.locator('[data-testid="apply-policy-input"]')).toBeVisible({
     timeout: 3_000,
   });
 
   // Select scenario B — Mode 3 should turn off (mode3Active resets in handleSelectScenario).
   await page.locator(".scenario-row").filter({ hasText: scenarioB })
     .getByTitle("Select as primary scenario").click();
-  await expect(page.locator('[data-testid="apply-control-change"]')).not.toBeVisible({
+  await expect(page.locator('[data-testid="apply-policy-input"]')).not.toBeVisible({
     timeout: 3_000,
   });
 });


### PR DESCRIPTION
## Summary

- Fixes 3 CI failures on `sprint/m18-g4` from run 28332341391 (playwright-e2e)
- Proactively updates 2 more test files with the same stale testids

## Root cause

G4 (PR #1424) renamed two ControlPlane testids per ADR-019 D-3:
- `apply-control-change` → `apply-policy-input`
- `fiscal-multiplier-slider` → `policy-param-slider`

Pre-G4 E2E tests were authored against the old `ControlPlane.tsx` testids and were not updated when G4 changed the implementation to `ControlPlaneColumn.tsx`.

## Failing tests fixed

| Test | Spec | CI error |
|---|---|---|
| G2/AC-1: Mode 3 comparison readout visible after branch recompute | `demo-trajectory-mode3.spec.ts:73` | `apply-control-change` not found at line 105 |
| Mode 3 — enable, apply control change, recompute completes | `mode3-active-control.spec.ts:34` | `apply-control-change` not found at line 69 |
| Mode 3 toggle resets to idle when scenario changes | `mode3-active-control.spec.ts:110` | `apply-control-change` not found at line 144 |

## Proactive fixes (not yet failing in CI but would fail when those tests ran)

- `demo-narrated-m12.spec.ts` — `fiscal-multiplier-slider` and `apply-control-change`
- `m16-g9-mode3-branch-comparison.spec.ts` — `fiscal-multiplier-slider` and `apply-control-change` in helper
- `mode-transition.spec.ts` — `fiscal-multiplier-slider` (guarded with `.isVisible().catch()`)

Note: `m18-g4-control-plane-column.spec.ts` uses `.or()` fallback locators with old testids — these are intentional robustness guards and are not changed.
`fiscal-multiplier-value` testid is retained (unchanged in ControlPlaneColumn.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)