### PR TITLE
fix(m18-g4): add branch-anchor-label to ControlPlaneColumn

### DIFF
--- a/frontend/src/components/ControlPlaneColumn.tsx
+++ b/frontend/src/components/ControlPlaneColumn.tsx
@@ -345,6 +345,15 @@ export function ControlPlaneColumn({
           {isDisabled ? "Recomputing…" : "Apply policy input"}
         </button>
 
+        {appliedInputs.length > 0 && (
+          <div
+            data-testid="branch-anchor-label"
+            style={{ fontSize: 10, color: "#888", fontStyle: "italic", marginTop: 4 }}
+          >
+            Branched from step {appliedInputs[0].step} — baseline locked
+          </div>
+        )}
+
         {/* History list */}
         <div style={{ marginTop: 8 }}>
           <span style={{ ...LABEL_STYLE, color: BLUE }}>Applied inputs</span>


### PR DESCRIPTION
## Summary

- `branch-anchor-label` existed in `ControlPlane.tsx` (old), rendered when `activeFromStep > 0`
- G4 replaced `ControlPlane.tsx` with `ControlPlaneColumn.tsx`; the element was not carried across
- `mode3-active-control.spec.ts:102` fails because `[data-testid="branch-anchor-label"]` is absent
- Fix: add equivalent element to `ControlPlaneColumn.tsx`, visible when `appliedInputs.length > 0`

## Root cause

PR #1426 fixed testid renames but missed that `branch-anchor-label` needed to be ported — it was an omitted element, not a renamed testid.

## Acceptance criteria

`mode3-active-control.spec.ts:34` passes: locator finds `branch-anchor-label` and it contains "Branched".

🤖 Generated with [Claude Code](https://claude.com/claude-code)