### PR TITLE
fix(m18-g4): remove AC-009 test.fixme — EX-001 closed Won't Fix

### DIFF
--- a/frontend/tests/e2e/trajectory-view.spec.ts
+++ b/frontend/tests/e2e/trajectory-view.spec.ts
@@ -147,73 +147,17 @@ test("AC-008: step navigation render ≤ 100ms on throttled CPU", async ({
 });
 
 // ---------------------------------------------------------------------------
-// AC-009: Full Mode 3 component set ≤ 100ms on CI 4× throttled profile
-// Source: FA brief §Performance Acceptance Criteria; QA Lead AC-009 correction
-// Mode 3 component count: 8 Lines + 4 Area divergence fills + 3 shock ReferenceLines
-// (MDA floor ReferenceLines excluded from M9 per EL Decision A)
+// AC-009: Mode 3 full component set render ≤ 100ms — REMOVED FROM CI suite.
+// Resolution: Won't Fix — KI-006 (GHA 2-core shared runners return 700ms+ vs the
+// 100ms threshold; external infrastructure limitation, not an application regression).
+// MV-002 local ProBook measurement (unthrottled, 2026-06-28):
+//   Run 1: 67.40ms / Run 2: 85.50ms / Run 3: 64.40ms — all ≤ 100ms. PASS.
+// G4 render optimization (lazy ControlPlaneColumn + Recharts memoization, PR #1424)
+// confirmed effective on target hardware.
+// EX-001 closure record: docs/compliance/exceptions.md §EX-001.
+// Measurement approach for local developer gate: performance.mark/measure wrapping
+// mode3-toggle click, two RAF cycles inside page.evaluate() — see NM-059 for rationale.
 // ---------------------------------------------------------------------------
-
-// KI-006 + NM-064: 4× CDP throttle on GHA 2-core shared runners consistently returns
-// 700ms+ vs the 200ms EX-001 threshold. Disabled in CI — run locally to validate perf.
-test.fixme("AC-009: Mode 3 full component set render ≤ 100ms on throttled CPU", async ({
-  page,
-}) => {
-  await page.setViewportSize({ width: 1280, height: 800 });
-
-  const cdp = await page.context().newCDPSession(page);
-  await cdp.send("Emulation.setCPUThrottlingRate", { rate: 4 });
-
-  await page.goto("/");
-
-  // mode3-toggle is inside {selectedScenarioId && (...)} in App.tsx — must select a
-  // scenario first. Pattern mirrors mode3-active-control.spec.ts createAndSelectScenario.
-  await page.waitForFunction(
-    () => typeof (window as Record<string, unknown>).__worldsim_selectEntity === "function",
-    { timeout: 10_000 },
-  );
-  const scenarioName = "AC-009-perf";
-  await page.getByRole("button", { name: /Scenarios/ }).click();
-  await page.locator('input[placeholder="Scenario name"]').fill(scenarioName);
-  await page.locator(".scenario-btn--create").click();
-  const row = page.locator(".scenario-row").filter({ hasText: scenarioName });
-  await expect(row).toBeVisible({ timeout: 10_000 });
-  await row.getByTitle("Select as primary scenario").click();
-  // Close Scenarios panel so mode3-toggle is the only toggle in the DOM.
-  await page.getByRole("button", { name: /Scenarios/ }).click();
-
-  // Mode 3 shipped M12 (PR #778). mode3-toggle is the delivered testid (App.tsx:293).
-  // Guard removed per NM-058: if mode3-toggle is absent the test must FAIL, not skip.
-  const mode3Trigger = page.locator('[data-testid="mode3-toggle"]');
-  await expect(mode3Trigger).toBeVisible({ timeout: 5_000 });
-
-  // Measurement runs entirely inside a single page.evaluate to eliminate CDP round-trip
-  // latency from the measurement window. NM-059: the prior multi-CDP approach (three
-  // separate evaluate calls with waitForTimeout between them) produced 179ms–802ms variance
-  // on CI because external queue time landed inside the measurement window. Two RAF cycles
-  // give React time to commit the synchronous state update from the programmatic click.
-  // EX-001 (docs/compliance/exceptions.md): CI throttled threshold 200ms, expiry M17 exit.
-  const renderMs = await page.evaluate(() => {
-    return new Promise<number>((resolve) => {
-      const btn = document.querySelector(
-        '[data-testid="mode3-toggle"]',
-      ) as HTMLElement;
-      performance.mark("mode3-start");
-      btn.click();
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => {
-          performance.mark("mode3-end");
-          performance.measure("mode3-render", "mode3-start", "mode3-end");
-          const m = performance.getEntriesByName("mode3-render")[0];
-          resolve(m?.duration ?? 0);
-        }),
-      );
-    });
-  });
-
-  expect(renderMs).toBeGreaterThan(0);
-  // EX-001 (docs/compliance/exceptions.md): threshold raised 100ms → 200ms, expiry M17 exit.
-  expect(renderMs).toBeLessThanOrEqual(200);
-});
 
 // ---------------------------------------------------------------------------
 // AC-011: Mode 1 step annotation renders three-line tick at ≥ 1024px viewport


### PR DESCRIPTION
## Summary

Removes `test.fixme()` for AC-009 from `trajectory-view.spec.ts` per ADR-019 §D-10 step 4.

- **MV-002 PASS:** ProBook unthrottled 67.40ms / 85.50ms / 64.40ms — all ≤ 100ms
- **Won't Fix on CI:** KI-006 persists (GHA 2-core returns 700ms+)
- Test structure replaced with comment block referencing EX-001 closure record

EX-001 closure record: `docs/compliance/exceptions.md §EX-001` (chore/m18-state-sync-024, PR #1430).

🤖 Generated with [Claude Code](https://claude.com/claude-code)