### PR TITLE
feat(m18-g5): Zone 3 auditability panel for DistributionalComparisonSummary (#1422)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -58,6 +58,7 @@ from app.schemas import (
     InjectShockResponse,
     MDAAlert,
     MDAFloorRecord,
+    MethodologyDetail,
     MultiFrameworkOutput,
     PMMRecord,
     QuantitySchema,
@@ -2921,11 +2922,30 @@ async def post_distributional_differential(
             )
         pairs.append(DistributionalPairResult(scenario_id=sid, steps=steps_out))
 
+    methodology_detail = MethodologyDetail(
+        q1_population=_ENTITY_Q1_POPULATION.get(entity_id, 0),
+        ci_methodology=(
+            f"±13–16% of point estimate — T3 placeholder "
+            f"pending ADR-007 full CI band integration. "
+            f"Lower bound factor: {_CI_FACTOR_LOWER}; "
+            f"upper bound factor: {_CI_FACTOR_UPPER}."
+        ),
+        extraction_path=(
+            "Q1 CHT cohort mean (entities matching '<entity_id>:CHT:1-*'); "
+            "falls back to main entity poverty_headcount_ratio if no cohort data present."
+        ),
+        tier_rationale=(
+            "T3: derived from ECOWAS regional comparable economy distributions, "
+            "not calibrated country-level Q1 income share survey data. "
+            "Forward trace: ADR-007 full implementation will replace this T3 placeholder."
+        ),
+    )
     return DistributionalDifferentialResponse(
         entity_id=entity_id,
         reference_scenario_id=ref_id,
         terminal_step=terminal_step,
         tier=_DISTRIBUTIONAL_TIER,
         methodology_summary=_DISTRIBUTIONAL_METHODOLOGY,
+        methodology_detail=methodology_detail,
         pairs=pairs,
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1074,6 +1074,15 @@ class DistributionalPairResult(BaseModel):
     steps: list[DistributionalStepResult]
 
 
+class MethodologyDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    q1_population: int
+    ci_methodology: str
+    extraction_path: str
+    tier_rationale: str
+
+
 class DistributionalDifferentialResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -1082,4 +1091,5 @@ class DistributionalDifferentialResponse(BaseModel):
     terminal_step: int
     tier: str
     methodology_summary: str
+    methodology_detail: MethodologyDetail
     pairs: list[DistributionalPairResult]

--- a/backend/tests/test_m18_g3_counter_scenario_comparison.py
+++ b/backend/tests/test_m18_g3_counter_scenario_comparison.py
@@ -981,9 +981,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200, (
@@ -1015,9 +1015,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200
@@ -1069,9 +1069,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200
@@ -1125,9 +1125,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200
@@ -1173,9 +1173,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200
@@ -1224,9 +1224,9 @@ class TestAC1422GMethodologyDetail:
         response = await client.post(
             _ENDPOINT_PATH,
             json={
-                "primary_scenario_id": scenario_id,
-                "comparison_scenario_ids": [scenario_id],
                 "entity_id": "ZMB",
+                "scenario_ids": [scenario_id, scenario_id],
+                "reference_scenario_id": scenario_id,
             },
         )
         assert response.status_code == 200

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -947,6 +947,31 @@ def test_austerity_shock_human_cost_scales_with_shock_magnitude():
 
 The human cost ledger is never a footnote. Its test coverage reflects this.
 
+### Testid Rename Crosscheck (NM-076)
+
+When renaming a `data-testid` value in any component or application file, the
+implementing agent **must** run the following check before pushing:
+
+```
+grep -r 'old-testid-value' frontend/tests/e2e/
+```
+
+For every match found: update the E2E test reference in the same PR as the
+rename. A rename without an E2E corpus crosscheck is a compliance violation —
+tests that silently reference stale testids will pass CI (because they run against
+a non-existent element and the guard returns early) while asserting nothing.
+
+The check must also be run when **introducing** a new testid: confirm no
+existing test inadvertently references the same string, which would cause
+unexpected test interactions post-implementation.
+
+**Authority:** NM-076 (`docs/process/near-miss-registry.md`). Filed 2026-06-28
+after G4 testid renames (`apply-control-change → apply-policy-input`,
+`fiscal-multiplier-slider → policy-param-slider`) were not crosschecked against
+the E2E corpus; 3 tests merged broken and were caught only by a subsequent fix PR.
+
+---
+
 ### E2E Pre-implementation Test Categorization
 
 When implementation is decomposed into multiple Task Issues (one component per

--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -403,6 +403,23 @@ endpoints:
         terminal_step: {type: integer, description: "Highest step present across all scenarios."}
         tier: {type: string, enum: ["T2", "T3"], description: "Tier T3 for M18 (SSA regional average parameters)."}
         methodology_summary: {type: string, description: "One-sentence provenance for Zone 3 methodology disclosure."}
+        methodology_detail:
+          type: object
+          required: true
+          description: "Structured auditability detail for Zone 3 panel (AC-1422-C, M18-G5 #1422). All four sub-fields required."
+          properties:
+            q1_population:
+              type: integer
+              description: "Entity Q1 population used in headcount calculation. ZMB: 3,894,625 (UN WPP 2024, 20% Q1 fraction)."
+            ci_methodology:
+              type: string
+              description: "CI band computation method. ±13–16% of point estimate (T3 placeholder, ADR-007 pending)."
+            extraction_path:
+              type: string
+              description: "How Q1 poverty_headcount_ratio is extracted: Q1 CHT cohort mean; falls back to main entity."
+            tier_rationale:
+              type: string
+              description: "Plain-language T3 tier rationale: ECOWAS regional comparables, not calibrated country-level data."
         pairs:
           type: array
           description: "One entry per non-reference scenario. Reference scenario excluded."
@@ -439,6 +456,7 @@ endpoints:
       - "AC-1349-G: headcount_differential must be integer (not float composite delta)."
       - "AC-1349-G: direction_stable must equal (ci_lower > 0) OR (ci_upper < 0)."
       - "AC-schema: schema tests in backend/tests/test_m18_g3_counter_scenario_comparison.py assert 'distributional-differential', 'headcount_differential', 'direction_stable', 'tier', 'ci_lower', 'ci_upper' are all present in this file."
+      - "AC-1422-G(schema): M18-G5 #1422 — schema tests assert 'methodology_detail', 'q1_population', 'tier_rationale' present in this file (TestAC1422GSchemaDocumented)."
 
   - method: GET
     path: "/scenarios/{scenario_id}"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,6 +260,7 @@ export default function App() {
         if (!data || controller.signal.aborted) return;
         const refLabel = comparisonScenarios.find((c) => c.scenarioId === referenceScenarioId)?.label ?? "ref";
         const rawPairs = (data.pairs ?? []) as Array<Record<string, unknown>>;
+        const rawDetail = data.methodology_detail as Record<string, unknown> | undefined;
         const enriched: DistributionalSummaryData = {
           entity_id: String(data.entity_id ?? entityId),
           reference_scenario_id: String(data.reference_scenario_id ?? referenceScenarioId),
@@ -267,6 +268,16 @@ export default function App() {
           terminal_step: Number(data.terminal_step ?? 0),
           tier: String(data.tier ?? "T3"),
           methodology_summary: String(data.methodology_summary ?? ""),
+          ...(rawDetail
+            ? {
+                methodology_detail: {
+                  q1_population: Number(rawDetail.q1_population ?? 0),
+                  ci_methodology: String(rawDetail.ci_methodology ?? ""),
+                  extraction_path: String(rawDetail.extraction_path ?? ""),
+                  tier_rationale: String(rawDetail.tier_rationale ?? ""),
+                },
+              }
+            : {}),
           pairs: rawPairs.map((pair) => ({
             scenario_id: String(pair.scenario_id ?? ""),
             scenario_label: String(

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -708,6 +708,8 @@ function _formatK(n: number): string {
 }
 
 function DistributionalComparisonSummary({ summary }: { summary: DistributionalSummaryData }) {
+  const [panelOpen, setPanelOpen] = useState(false);
+
   const terminalPairs = summary.pairs.map((pair) => {
     const terminal = pair.steps.find((s) => s.step === summary.terminal_step) ?? pair.steps[pair.steps.length - 1];
     return { ...pair, terminal };
@@ -716,6 +718,9 @@ function DistributionalComparisonSummary({ summary }: { summary: DistributionalS
   const totalSteps = Math.max(...summary.pairs.flatMap((p) => p.steps.map((s) => s.step)));
   const allDirectionStable = terminalPairs.every((p) => p.terminal?.direction_stable ?? false);
   const refLabel = summary.reference_scenario_label;
+
+  const rowStyle: React.CSSProperties = { fontSize: 11, color: "#4b5563", marginBottom: 2, lineHeight: 1.4 };
+  const labelStyle: React.CSSProperties = { fontWeight: 500 };
 
   return (
     <div
@@ -747,6 +752,21 @@ function DistributionalComparisonSummary({ summary }: { summary: DistributionalS
         >
           {summary.tier}
         </span>
+        <button
+          data-testid="methodology-panel-toggle"
+          onClick={() => setPanelOpen((v) => !v)}
+          aria-expanded={panelOpen}
+          style={{
+            fontSize: 10,
+            color: "#6b7280",
+            cursor: "pointer",
+            background: "none",
+            border: "none",
+            padding: "0 2px",
+          }}
+        >
+          {panelOpen ? "▼ Methodology" : "▶ Methodology"}
+        </button>
       </div>
       <div style={{ fontSize: 11, color: "#4b5563", fontStyle: "italic", marginBottom: 4 }}>
         Poverty headcount differential
@@ -783,6 +803,26 @@ function DistributionalComparisonSummary({ summary }: { summary: DistributionalS
           ? "→ Direction stable across uncertainty range"
           : "→ Direction uncertain: CI spans zero"}
       </div>
+      {panelOpen && summary.methodology_detail && (
+        <div style={{ borderTop: "1px dashed #e5e7eb", marginTop: 4, paddingTop: 4 }}>
+          <div data-testid="methodology-q1-population" style={rowStyle}>
+            <span style={labelStyle}>Q1 population:</span>{" "}
+            {summary.entity_id}: {summary.methodology_detail.q1_population.toLocaleString("en-US")} (UN WPP 2024, 20% Q1 fraction)
+          </div>
+          <div data-testid="methodology-ci-band" style={rowStyle}>
+            <span style={labelStyle}>CI band:</span>{" "}
+            {summary.methodology_detail.ci_methodology}
+          </div>
+          <div data-testid="methodology-extraction-path" style={rowStyle}>
+            <span style={labelStyle}>Extraction path:</span>{" "}
+            {summary.methodology_detail.extraction_path}
+          </div>
+          <div data-testid="methodology-tier-rationale" style={rowStyle}>
+            <span style={labelStyle}>Tier rationale:</span>{" "}
+            {summary.methodology_detail.tier_rationale}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -118,6 +118,13 @@ export interface DistributionalPairSummary {
   steps: DistributionalStepSummary[];
 }
 
+export interface MethodologyDetail {
+  q1_population: number;
+  ci_methodology: string;
+  extraction_path: string;
+  tier_rationale: string;
+}
+
 export interface DistributionalSummaryData {
   entity_id: string;
   reference_scenario_id: string;
@@ -125,6 +132,7 @@ export interface DistributionalSummaryData {
   terminal_step: number;
   tier: string;
   methodology_summary: string;
+  methodology_detail?: MethodologyDetail;
   pairs: DistributionalPairSummary[];
 }
 


### PR DESCRIPTION
## Summary

- **Backend:** Add `MethodologyDetail` Pydantic model to `schemas.py`; populate 4 fields in `post_distributional_differential` from existing constants (`_ENTITY_Q1_POPULATION`, `_CI_FACTOR_LOWER/_UPPER`, `_DISTRIBUTIONAL_TIER`). New required `methodology_detail` field on `DistributionalDifferentialResponse`.
- **Frontend store:** Add `MethodologyDetail` interface + optional `methodology_detail` field to `DistributionalSummaryData`. Map field in `App.tsx` enriched object from raw API response.
- **Frontend component:** Add `▶/▼ Methodology` toggle (`data-testid="methodology-panel-toggle"`, `aria-expanded`) and 4-field panel to `DistributionalComparisonSummary` — collapsed by default, expands in-place below direction disclosure, no Zone 1 displacement at 1280×800.
- **Schema:** Add `methodology_detail` object with all 4 sub-field descriptions to `api_contracts.yml` (same PR as backend — mandatory per intent doc §6.3).
- **Test fix:** Correct wrong request body field names in AC-1422-G backend tests (`primary_scenario_id`/`comparison_scenario_ids` → `scenario_ids`/`reference_scenario_id`).
- **Process:** Add NM-076 testid rename crosscheck rule to `CODING_STANDARDS.md`.

## Acceptance criteria

| AC | Status |
|---|---|
| AC-1422-A: toggle present in COMPARE_VIEW | ✅ `methodology-panel-toggle` rendered in header row adjacent to T3 badge |
| AC-1422-B: panel collapsed by default | ✅ `panelOpen` initialises `false`; panel is `{panelOpen && ...}` |
| AC-1422-C: expand reveals 4 fields with expected content | ✅ ZMB Q1 pop "3,894,625"; CI band "13"/"16"; extraction path "Q1 CHT"; tier "T3" |
| AC-1422-D: Zone 1 visible at 1280×800 after expansion | ✅ Panel expands in-place within sticky container; no parent reflow |
| AC-1422-E: second click collapses panel | ✅ `setPanelOpen((v) => !v)` toggle |
| AC-1422-F: toggle absent in single-scenario mode | ✅ Component only renders in COMPARE_VIEW when `distributionalSummary` is non-null |
| AC-1422-G: backend returns `methodology_detail` object | ✅ `MethodologyDetail` constructed from constants; `q1_population=3_894_625` for ZMB |

## NM-076 crosscheck

All 5 new testids (`methodology-panel-toggle`, `methodology-q1-population`, `methodology-ci-band`, `methodology-extraction-path`, `methodology-tier-rationale`) verified confined to `m18-g5-zone3-auditability.spec.ts`.

## Pre-push gates

- Backend: ruff PASS, mypy PASS (70 source files)
- Frontend: `tsc -b && vite build` PASS

## Intent doc

`docs/process/intents/M18-G5-2026-06-28-zone3-auditability-panel.md` (PR #1437, merged)

Sprint journal: #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)