### PR TITLE
fix(m18-g6): AC-4 trajectory timing fix — toContainText polling wait

### DIFF
--- a/frontend/tests/e2e/m14-g6-methodology-calibration.spec.ts
+++ b/frontend/tests/e2e/m14-g6-methodology-calibration.spec.ts
@@ -455,24 +455,22 @@ test.describe("AC-4: Zone 1A Y axis label 'Score' visible", () => {
 
     await expect(trajectoryContainer).toBeVisible();
 
-    // Locate the Y axis label SVG text element within the recharts YAxis group.
+    // Wait for the trajectory to load and recharts to render the chart with the Score label.
+    // toContainText polls (unlike isVisible which is a snapshot), so this handles the async
+    // trajectory fetch that fires after the scenario is selected from the URL param.
+    // NM-045: direct string-presence match.
+    await expect(trajectoryContainer).toContainText("Score", { timeout: 10_000 });
+
+    // Attempt to confirm the recharts-label class is present and well-formed.
     // recharts renders <text class="recharts-label"> for axis labels.
     const yAxisLabel = trajectoryContainer
       .locator("text.recharts-label")
       .filter({ hasText: "Score" })
       .first();
 
-    const hasLabel = await yAxisLabel.isVisible({ timeout: 3_000 }).catch(() => false);
+    const hasLabel = await yAxisLabel.isVisible().catch(() => false);
 
-    if (!hasLabel) {
-      // Pre-implementation fallback: check for "Score" anywhere in the container text
-      // The recharts label may not have the recharts-label class in all versions.
-      const containerText = await trajectoryContainer.textContent() ?? "";
-      // NM-045: direct string-presence match
-      expect(containerText).toContain("Score");
-    } else {
-      await expect(yAxisLabel).toBeVisible();
-
+    if (hasLabel) {
       // Confirm bounding box height > 0 (not hidden by CSS)
       const box = await yAxisLabel.boundingBox();
       expect(box).not.toBeNull();


### PR DESCRIPTION
## Summary

- AC-4 in `m14-g6-methodology-calibration.spec.ts` was failing with `expect(containerText).toContain("Score")` because `isVisible()` is a snapshot check (not polling), so it returned `false` immediately before the trajectory API fetch completed
- The narrated spec (`demo-narrated.spec.ts` added in #1448) creates 4 real scenarios in `beforeAll`, which — even though tests are sequential — puts more data in the database that the backend processes; the JOR trajectory fetch now completes slightly later than it did before
- Fix: replace the instant `isVisible()` + fallback pattern with `expect(trajectoryContainer).toContainText("Score", { timeout: 10_000 })` which polls until the recharts chart with the Score label renders

## Root cause

`yAxisLabel.isVisible({ timeout: 3_000 })` does NOT poll for 3 seconds — in Playwright, `isVisible()` is a snapshot, returning `false` immediately if no matching element exists. The `timeout` parameter has no effect on element discovery. The recharts chart (with the "Score" YAxis label) renders asynchronously after the trajectory fetch completes; the fallback was reading `containerText` before the chart appeared.

## Test plan

- [ ] `m14-g6-methodology-calibration.spec.ts` AC-4 passes in CI playwright-e2e run
- [ ] All other 325 tests continue to pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)