### PR TITLE
fix(m18-g6): distributional-differential column names + narrated spec Guard 1

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -2875,16 +2875,16 @@ async def post_distributional_differential(
     snapshots_by_scenario: dict[str, dict[int, dict[str, Any]]] = {}
     for sid in scenario_ids:
         rows = await conn.fetch(
-            "SELECT step_index, state FROM scenario_state_snapshots"
-            " WHERE scenario_id = $1 ORDER BY step_index",
+            "SELECT step, state_data FROM scenario_state_snapshots"
+            " WHERE scenario_id = $1 ORDER BY step",
             sid,
         )
         if not rows:
             raise HTTPException(status_code=404, detail=f"No snapshots for scenario {sid!r}.")
         step_states: dict[int, dict[str, Any]] = {}
         for row in rows:
-            raw = row["state"]
-            step_states[row["step_index"]] = raw if isinstance(raw, dict) else json.loads(raw)
+            raw = row["state_data"]
+            step_states[row["step"]] = raw if isinstance(raw, dict) else json.loads(raw)
         snapshots_by_scenario[sid] = step_states
 
     shared_steps = sorted(

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -722,19 +722,19 @@ test(
       "The ministry's analyst is about to enter active control.",
     );
 
-    // Wait for Mode 2 column surface — G4 prerequisite
-    const mode2Surface = page.locator('[data-testid="mode2-column-surface"]');
-    const mode2Available = await mode2Surface.isVisible({ timeout: 8_000 }).catch(() => false);
+    // Enter Mode 3 via the header toggle.
+    // SEN scenario has no fiscal_multiplier config → mode stays MODE_1, so
+    // mode2-column-surface never renders. mode3-toggle in the App.tsx header
+    // directly activates MODE_3 (sets mode3Active=true), which renders ControlPlaneColumn.
+    const mode3ToggleBtn = page.locator('[data-testid="mode3-toggle"]');
+    const toggleAvailable = await mode3ToggleBtn.isVisible({ timeout: 5_000 }).catch(() => false);
 
-    if (!mode2Available) {
-      console.warn("mode2-column-surface not visible — G4 ControlPlaneColumn may not be implemented. Skipping Act 1 Mode 3 interaction.");
+    if (!toggleAvailable) {
+      console.warn("mode3-toggle not visible — skipping Act 1 Mode 3 interaction.");
     } else {
-      // Transition to Mode 3
-      const enterBtn = page.locator('[data-testid="enter-active-control-btn"]');
-      await expect(enterBtn).toBeVisible();
-      await enterBtn.click();
+      await mode3ToggleBtn.click();
 
-      // Form 1 must appear immediately (AC-G4-B)
+      // Form 1 must appear immediately (AC-G4-B) — ControlPlaneColumn rendered in MODE_3
       const form1 = page.locator('[data-testid="control-plane-form1"]');
       await expect(form1).toBeVisible({ timeout: 5_000 });
 


### PR DESCRIPTION
## Summary

- **Backend** (`backend/app/api/scenarios.py`): `POST /api/v1/scenarios/comparison/distributional-differential` was failing with `UndefinedColumnError: column "step_index" does not exist`. The `scenario_state_snapshots` table uses `step` and `state_data` (not `step_index`/`state`). Fixed column names in the SQL query and row accessors.
- **Frontend** (`frontend/tests/e2e/demo-narrated.spec.ts`): Guard 1 in Act 1 was checking for `mode2-column-surface` which never renders because the SEN scenario has no `fiscal_multiplier` config → mode stays MODE_1. Replaced with `mode3-toggle` button click (App.tsx header, `data-testid="mode3-toggle"`) which directly activates MODE_3 → ControlPlaneColumn renders → Act 1 Frame A/B can be captured.

## Verification

- Endpoint tested with real ZMB scenario IDs: returns distributional differential data (OptionA: +342,727 headcount, direction_stable=true; OptionB: +171,364)
- `mode3-toggle` confirmed at App.tsx:366; `control-plane-form1` confirmed at ControlPlaneColumn.tsx:252
- ruff + mypy PASS; frontend build PASS

## Test plan

- [ ] CI green
- [ ] Re-run narrated spec: `npx playwright test tests/e2e/demo-narrated.spec.ts --config playwright.demo.config.ts --headed`
- [ ] Verify all 5 frames captured in `docs/demo/m18/screenshots/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)