### PR TITLE
infra(ci): integration test discovery by marker not directory (NM-078 / #1451)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd backend
-          pytest tests/integration -v || [ $? -eq 5 ]
+          pytest tests/ -m integration -v || [ $? -eq 5 ]
 
       - name: Run backtesting suite (skip without DATABASE_URL)
         run: |


### PR DESCRIPTION
## Summary

- Changes `pytest tests/integration -v` → `pytest tests/ -m integration -v` in the `test-backend` CI job
- All 17 milestone-specific test files (`test_m14_*`–`test_m18_*`) in `backend/tests/` root are marked `pytestmark = pytest.mark.integration` but were never discovered by the directory-based command
- All existing `tests/integration/` files carry the marker and continue to run — no regression
- Resolves #1451; filed as NM-078

## Root cause

`pytest tests/integration` discovers by path. Files in `tests/` root with `pytestmark = pytest.mark.integration` are not in that path. 17 milestone acceptance test files have never run in CI. The `distributional-differential` endpoint (G3) shipped with wrong column names for 3 sprint groups as a result.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: verify `test_m18_g3_counter_scenario_comparison.py` runs (depends on PR #1450 landing first)
- [ ] No previously-passing integration tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)