### PR TITLE
fix(m18-g6): narrated spec step-seam + evaluate closure for Act 1

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -205,6 +205,10 @@ export default function App() {
     (window as unknown as Record<string, unknown>).__worldsim_setComparisonScenarios = (
       configs: ScenarioComparisonConfig[],
     ) => setComparisonScenarios(configs);
+    // M18-G6 — allow narrated spec to initialize currentStep for in_progress scenarios
+    // (URL-loaded scenarios with status != "completed" stay at currentStep=null → 0).
+    (window as unknown as Record<string, unknown>).__worldsim_setCurrentStep = (step: number) =>
+      setCurrentStep(step);
   }, [setSelectedEntityId, setAttributeName]);
 
   // When a scenario is selected: fast-forward currentStep if already completed,

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -706,6 +706,16 @@ test(
     await page.goto(`/?scenario=${encodeURIComponent(senId)}`);
     await waitForAppReady(page);
 
+    // SEN scenario is in_progress at BRANCH_FROM_STEP — App.tsx only sets currentStep
+    // for completed scenarios, so currentStep stays null → 0, blocking trajectory fetch.
+    // Inject the current step via the DEV-only seam to match the backend state.
+    await page.evaluate((step: number) => {
+      const fn = (window as Record<string, unknown>).__worldsim_setCurrentStep as
+        | ((s: number) => void)
+        | undefined;
+      if (fn) fn(step);
+    }, BRANCH_FROM_STEP);
+
     // Zone 1A should show the mocked baseline trajectory on load.
     await expect(
       page.locator('[data-testid="zone-1a-trajectory-container"]'),
@@ -755,14 +765,14 @@ test(
         .or(page.locator('[data-testid="fiscal-multiplier-slider"]').first());
 
       if (await slider.count() > 0) {
-        await slider.evaluate((el: HTMLInputElement) => {
+        await slider.evaluate((el: HTMLInputElement, value: string) => {
           const setter = Object.getOwnPropertyDescriptor(
             window.HTMLInputElement.prototype,
             "value",
           )!.set!;
-          setter.call(el, String(FISCAL_MULTIPLIER_ACT1));
+          setter.call(el, value);
           el.dispatchEvent(new Event("input", { bubbles: true }));
-        });
+        }, String(FISCAL_MULTIPLIER_ACT1));
       }
 
       // Confirm branch anchor label shows the branch step


### PR DESCRIPTION
## Summary

Two bugs preventing Act 1 screenshots from capturing correctly:

**1. `FISCAL_MULTIPLIER_ACT1 is not defined` (ReferenceError at spec line 758)**
`slider.evaluate()` runs in the browser context — it cannot close over Node.js module-level constants. Fixed by passing the value as the `evaluate()` second argument: `slider.evaluate((el, value) => ..., String(FISCAL_MULTIPLIER_ACT1))`.

**2. Act 1 shows step 0/8 — Zone 1A empty (EL feedback)**
`App.tsx` only calls `setCurrentStep()` when `status === "completed"`. The SEN scenario is `in_progress` at step 3, so `currentStep` stays `null` → `0` (via `currentStep ?? 0` at App.tsx:433). `ScenarioInstrumentCluster` guards: `if (!scenarioId || currentStep === 0) return` — trajectory is never fetched → Zone 1A empty.

Fix: add `window.__worldsim_setCurrentStep` DEV-only seam to App.tsx (same pattern as `__worldsim_selectEntity`). Narrated spec calls it with `BRANCH_FROM_STEP=3` immediately after `waitForAppReady`, matching backend state and correcting the step display.

## Test plan

- [ ] CI green
- [ ] Re-run narrated spec — Act 1 Zone 1A shows mocked trajectory at step 3, Mode 3 active, slider 0.85
- [ ] All 5 frames captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)