### PR TITLE
feat(zone3): methodology panel Layer 3 polish — entity_id + CI labels (#1441)

### DIFF
--- a/backend/app/api/scenarios.py
+++ b/backend/app/api/scenarios.py
@@ -2927,11 +2927,11 @@ async def post_distributional_differential(
         ci_methodology=(
             f"±13–16% of point estimate — T3 placeholder "
             f"pending ADR-007 full CI band integration. "
-            f"Lower bound factor: {_CI_FACTOR_LOWER}; "
-            f"upper bound factor: {_CI_FACTOR_UPPER}."
+            f"Lower bound: ×{_CI_FACTOR_LOWER} (−13%); "
+            f"upper bound: ×{_CI_FACTOR_UPPER} (+16%)."
         ),
         extraction_path=(
-            "Q1 CHT cohort mean (entities matching '<entity_id>:CHT:1-*'); "
+            f"Q1 CHT cohort mean (entities matching '{entity_id}:CHT:1-*'); "
             "falls back to main entity poverty_headcount_ratio if no cohort data present."
         ),
         tier_rationale=(


### PR DESCRIPTION
## Summary

Two f-string polish changes to `post_distributional_differential` in `backend/app/api/scenarios.py`:

- **CI methodology labels**: `"Lower bound factor: X; upper bound factor: Y"` → `"Lower bound: ×X (−13%); upper bound: ×Y (+16%)"`. Percentage equivalents make the factor immediately legible in the Zone 3 methodology panel.
- **Extraction path interpolation**: `'<entity_id>:CHT:1-*'` (literal template) → `f'{entity_id}:CHT:1-*'` (actual runtime value). The methodology panel now shows e.g. `ZMB:CHT:1-*` rather than the angle-bracket placeholder.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — 70 source files, no issues
- [x] CA L3 forward notes from G5 sprint exit (#1435) — both items addressed

Closes #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)