### PR TITLE
infra(m18): block direct CLI push to release/* branches in pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,6 +15,29 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Release branch push guard — NM-080 process improvement (Issue #1483)
+# Block direct CLI push to release/* branches; all updates must go via PR.
+# ---------------------------------------------------------------------------
+PUSH_REFS=$(cat)  # capture stdin once; pre-push receives refspecs on stdin
+
+while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
+  if [[ "$remote_ref" == refs/heads/release/* ]]; then
+    BRANCH="${remote_ref#refs/heads/}"
+    echo ""
+    echo "ERROR: Direct push to '$BRANCH' is blocked."
+    echo ""
+    echo "Release branches may only be updated via pull request."
+    echo "Create a feature/sprint/chore/infra branch, push it, and open a PR"
+    echo "targeting '$BRANCH'."
+    echo ""
+    echo "Emergency bypass (EL authorization required + NM entry immediately after):"
+    echo "  git push --no-verify"
+    echo ""
+    exit 1
+  fi
+done <<< "$PUSH_REFS"
+
+# ---------------------------------------------------------------------------
 # Detect changed files in this push.
 # Compare against upstream if tracked; fall back to HEAD~1.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

NM-080 process improvement — Issue #1483.

The `release-branch-ci-gate` Ruleset requires required-status-checks on PRs targeting `refs/heads/release/m*` but does not block a direct CLI push from a user with admin rights. During M18 G3, an admin-rights session committed G3 test files directly to `release/m18` (recovered via `git reset --soft HEAD~1` before push, but if the push had fired first there would have been no gate to stop it).

**Change:** `.githooks/pre-push` now reads stdin refspecs at hook start. If any refspec targets `refs/heads/release/*`, the hook aborts with an error message directing to the PR process. Emergency bypass remains via `--no-verify` (requires EL authorization + NM entry).

**Scope:** hook-layer defence-in-depth only. Server-side Ruleset push restriction (`restrict_pushes` rule on `refs/heads/release/m*`) is the stronger fix and should be added via GitHub Settings by EL — documented in Issue #1483. This PR delivers the immediate local gate.

**Note on stdin:** The hook captures stdin once at the top (`PUSH_REFS=$(cat)`) before any other code runs, so the refspec data is available for the guard while remaining transparent to the downstream CHANGED detection (which uses `git diff`, not stdin).

## Test plan

- [ ] `git push origin HEAD:release/m18` from any local branch is blocked by the hook with an error message
- [ ] `git push --no-verify origin HEAD:release/m18` bypasses the hook (emergency path)
- [ ] Normal feature branch push (`feat/m18-*`, `sprint/m18-*`, `chore/m18-*`, `infra/m18-*`) is unaffected
- [ ] Backend and frontend gates still fire correctly when `.githooks/pre-push` runs on non-release pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)