### PR TITLE
chore(m18-state-sync-030): process amendments — branch verification, scope lock, NM merge verification

### DIFF
--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -3073,7 +3073,9 @@ CONTRIBUTING.md updated in this commit:
 ### How to add an entry
 
 When a near-miss is identified — during a session, in a HORIZON sweep, or in post-session
-review — the PM Agent files a new entry following the template below:
+review — the PM Agent files a new entry following the template below.
+
+**Merge conflict resolution requirement (NM-077, Finding D; Issue #1486):** After resolving any merge conflict in this file, verify that all NM entries from both sides of the conflict are present in the resolved file before committing. Procedure: (1) note the highest NM number in the `HEAD` side before the merge, (2) note the highest NM number in the incoming branch, (3) confirm the resolved file contains all entries between the lowest and highest NM number across both sides, in ascending order, with no gaps. A resolved conflict that silently drops an NM entry is an integrity violation equivalent to deleting a filed entry — permanent institutional memory cannot be recovered once lost.
 
 ```markdown
 ## NM-061 — AC-F8 Silent No-Op: Scenario Created via API But Never Selected in UI; 60-Second Ceiling Gate Measuring Nothing Since G3 (Reactive)

--- a/docs/process/sprint-group-isolation.md
+++ b/docs/process/sprint-group-isolation.md
@@ -138,6 +138,13 @@ The entry document must be filed and EL-approved before any feature branch opens
 
 **2. During implementation (implementing agent)**
 
+**Session start checklist — required before any file edits (NM-079, NM-080; Issue #1484):**
+
+1. Confirm `git branch --show-current` matches the expected `feat/m{N}-g{N}-*` or `sprint/m{N}-g{N}` branch. If the branch does not match, checkout the correct branch or create the correct worktree before proceeding — do not begin implementation on the wrong branch.
+2. Confirm `git stash list` is empty, or that all stash entries belong to the current sprint group. A stash from a different sprint group can contaminate the pre-push gate with violations from foreign files and mislead debugging. Clear or annotate stash entries before cross-branch operations.
+
+If either check fails: stop, resolve the discrepancy, and re-confirm before writing any code.
+
 Cut feature branches from the sprint sub-branch, not from the release branch:
 ```bash
 git checkout -b feat/m{N}-g{N}-short-description sprint/m{N}-g{N}

--- a/docs/process/sprint-planning-sop.md
+++ b/docs/process/sprint-planning-sop.md
@@ -249,13 +249,27 @@ PM Agent records these fields in each sprint group's entry document (Section 1 �
 
 If 5 groups are already actively running (implementation PRs open), no new group may open an implementation PR until at least one exits (integration PR merges to release branch). Exceeding this ceiling without explicit EL direction is a process deviation. The PM Agent is responsible for enforcing this ceiling — EL is accountable and may revise the ceiling after M18 experience.
 
+### Scope lock precondition for sprint branch cut (NM-081; Issue #1485)
+
+Before cutting a sprint branch for group G{N}, the PM Agent must verify that all ADR decisions affecting G{N}'s scope are EL-approved and merged to `release/m{N}`.
+
+If a predecessor group's scope decisions are still in draft or pending EL approval, either:
+
+- **(a) Delay the branch cut** until the upstream decision merges to `release/m{N}`. Required when the pending decision may change G{N}'s data contracts, API shapes, or component interfaces.
+- **(b) Document the scope uncertainty** in the sprint entry document §Scope Declaration (Section 3.1 scope lock checkbox). Permitted when the uncertainty is bounded and the risk of implementation rework is low.
+
+Option (a) is the default. Option (b) requires EL acknowledgement in the sprint entry approval.
+
+**Why this matters:** If G{N} implements against a stale scope snapshot, the integration resolution commit absorbs the scope drift silently — G{N}'s tests validate the wrong contract, and no CI gate flags the divergence. This is a variant of the NM-078 pattern (test exists but validates the wrong version).
+
 ### Wave kickoff sequence
 
 1. PM Agent reviews all groups planned for the wave before any group opens an implementation PR.
-2. PM Agent determines the coordination tier for the wave.
-3. PM Agent records the tier and the dependency merge sequence in each group's sprint entry document (Section 1).
-4. EL approves the sprint entry documents (which now include the coordination tier).
-5. Implementation PRs may open once sprint entry documents are EL-approved.
+2. **PM Agent confirms scope lock precondition** for each group: all ADR decisions affecting that group's scope are EL-approved and on `release/m{N}`, or scope uncertainty is documented and EL-acknowledged.
+3. PM Agent determines the coordination tier for the wave.
+4. PM Agent records the tier, dependency merge sequence, and scope lock status in each group's sprint entry document (Section 1).
+5. EL approves the sprint entry documents (which now include the coordination tier and scope lock confirmation).
+6. Implementation PRs may open once sprint entry documents are EL-approved.
 
 ### When a new group joins mid-wave
 

--- a/docs/process/sprint-plans/templates/sprint-entry-template.md
+++ b/docs/process/sprint-plans/templates/sprint-entry-template.md
@@ -106,6 +106,16 @@ acceptance criteria BEFORE implementation code is written.
 
 ## Section 3 — Scope Declaration
 
+### 3.0 — Scope lock confirmation (NM-081; sprint-planning-sop.md §Scope lock precondition)
+
+*PM Agent must confirm before any sprint branch is cut.*
+
+- [ ] All ADR decisions affecting this sprint's scope are EL-approved and merged to `release/m{N}`
+
+If unchecked: describe the known scope uncertainty below and confirm EL has acknowledged it.
+
+**Scope uncertainty (if any):** {None / description of pending decision and risk assessment}
+
 ### 3.1 — Issues in scope
 
 *All issues assigned to this sprint, with group assignment.*


### PR DESCRIPTION
## Summary

Process document amendments resolving Issues #1484, #1485, #1486 — all arising from the DS Sprint Health Audit (PR #1482).

### `docs/process/sprint-group-isolation.md` — Issue #1484 (NM-079/080)

Added **Session start checklist** to Step 2 (During implementation):
1. Confirm `git branch --show-current` matches the expected sprint group branch before any edits
2. Confirm `git stash list` is empty or all stash entries belong to the current sprint group

Root cause of NM-079: G1 CI bands committed to G3 branch because session drifted during NM-075 working-tree thrash with no gate to catch it at session start.

### `docs/process/sprint-planning-sop.md` + `sprint-entry-template.md` — Issue #1485 (NM-081)

Added **Scope lock precondition** before Wave Kickoff Sequence: PM Agent must confirm all ADR decisions affecting a sprint group's scope are EL-approved and merged to `release/m{N}` before the sprint branch is cut. Option (a) delay or option (b) document uncertainty + EL acknowledgement.

Sprint entry template §3 gains a **Section 3.0 scope lock confirmation checkbox** so the precondition has an artifact trail on every sprint entry.

Root cause of NM-081: `sprint/m18-g3` cut before ADR-019 Decisions 4/5/6 merged; G3 implemented against stale 6-shock scope for its entire sprint; drift absorbed silently at integration.

### `docs/process/near-miss-registry.md` — Issue #1486 (Finding D)

Added **merge conflict resolution requirement** to §How to add an entry: after resolving any conflict in the NM registry, verify all NM entries from both sides are present (count highest NM on each side; confirm resolved file contains all entries, no gaps).

Root cause: multiple sprint groups appended to the registry simultaneously (M18 state-sync-012); conflict in append zone put entries at risk of silent loss.

## Test plan

- [ ] `sprint-group-isolation.md §Sprint Group Sub-Branch Protocol Step 2` contains the two-item session start checklist
- [ ] `sprint-planning-sop.md §Wave Kickoff Coordination Check` contains the scope lock precondition section before the Wave kickoff sequence
- [ ] Wave kickoff sequence is renumbered correctly (steps 1–6)
- [ ] `sprint-entry-template.md` Section 3 opens with Section 3.0 scope lock checkbox before Section 3.1
- [ ] `near-miss-registry.md §How to add an entry` contains the merge conflict resolution paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)