### PR TITLE
fix(frontend): M18-G7-A — CI band geometry fix (additive formula, yDomain, opacity)

### DIFF
--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -161,14 +161,14 @@ export function computeCompositeHalfWidth(stepIndex: number, tier: number): numb
   return baseHW * multiplier;
 }
 
-function computeCompositeCIBounds(step: TrajectoryStep): { lower: number | null; upper: number | null } {
+export function computeCompositeCIBounds(step: TrajectoryStep): { lower: number | null; upper: number | null } {
   const score = computeEntityCompositeScore(step);
   if (score === null) return { lower: null, upper: null };
   const worstTier = getEntityWorstTier(step);
   const halfWidth = computeCompositeHalfWidth(step.step_index, worstTier);
   return {
-    lower: Math.max(0.0, score * (1 - halfWidth)),
-    upper: Math.min(1.0, score * (1 + halfWidth)),
+    lower: Math.max(0.0, score - halfWidth),
+    upper: Math.min(1.0, score + halfWidth),
   };
 }
 
@@ -413,8 +413,6 @@ function CompositeChartSVG({
       for (const step of traj.steps) {
         const s = computeEntityCompositeScore(step);
         if (s !== null) values.push(s);
-        const { upper } = computeCompositeCIBounds(step);
-        if (upper !== null && !isNaN(upper)) values.push(upper);
       }
       const floor = getEntityMdaFloor(traj.mda_floors);
       if (floor !== null) values.push(floor);
@@ -424,8 +422,6 @@ function CompositeChartSVG({
       for (const step of sc.trajectory.steps) {
         const s = computeEntityCompositeScore(step);
         if (s !== null) values.push(s);
-        const { upper } = computeCompositeCIBounds(step);
-        if (upper !== null && !isNaN(upper)) values.push(upper);
       }
       const floor = getEntityMdaFloor(sc.trajectory.mda_floors);
       if (floor !== null) values.push(floor);
@@ -539,7 +535,7 @@ function CompositeChartSVG({
             data-testid={`zone-1a-ci-ribbon-${code}`}
             d={ribbonD}
             fill={color}
-            opacity={0.10}
+            opacity={mode === "MODE_3" ? CI_BAND_OPACITY_MODE3 : CI_BAND_OPACITY}
             stroke="none"
           />
         );
@@ -556,7 +552,7 @@ function CompositeChartSVG({
             data-testid={`zone-1a-ci-ribbon-scenario-${slug}`}
             d={ribbonD}
             fill={palette.color}
-            opacity={0.10}
+            opacity={CI_BAND_OPACITY}
             stroke="none"
           />
         );

--- a/frontend/src/components/__tests__/TrajectoryView.test.ts
+++ b/frontend/src/components/__tests__/TrajectoryView.test.ts
@@ -958,6 +958,42 @@ describe("M18-G7-A: AC-A2 — yDomain trajectory-only values produce readable ra
   });
 });
 
+// ---------------------------------------------------------------------------
+// M18-G7-A: AC-A3 — CI ribbon opacity uses exported constants, not 0.10
+//
+// The fix replaces hard-coded `opacity={0.10}` in two SVG ribbon paths with:
+//   mode === "MODE_3" ? CI_BAND_OPACITY_MODE3 : CI_BAND_OPACITY
+//   CI_BAND_OPACITY (comparison scenarios path — always Mode 1/2)
+//
+// This unit test guards against regression back to the 0.10 literal by verifying
+// that neither constant equals 0.10 (so the fix is definitionally correct),
+// and that CI_BAND_OPACITY_MODE3 < CI_BAND_OPACITY (Mode 3 must be quieter).
+//
+// Source: M18-G7-A intent §AC-A3 + root cause analysis §Root Cause 1 §Fix item 3.
+// ---------------------------------------------------------------------------
+
+describe("M18-G7-A: AC-A3 — CI ribbon opacity constants are not 0.10", () => {
+  it("CI_BAND_OPACITY is not 0.10 (hard-coded value replaced by constant)", async () => {
+    const mod = await import("../TrajectoryView");
+    const { CI_BAND_OPACITY } = mod as unknown as Record<string, number>;
+    expect(CI_BAND_OPACITY).toBeDefined();
+    expect(CI_BAND_OPACITY).not.toBe(0.10);
+  });
+
+  it("CI_BAND_OPACITY_MODE3 is not 0.10 (hard-coded value replaced by constant)", async () => {
+    const mod = await import("../TrajectoryView");
+    const { CI_BAND_OPACITY_MODE3 } = mod as unknown as Record<string, number>;
+    expect(CI_BAND_OPACITY_MODE3).toBeDefined();
+    expect(CI_BAND_OPACITY_MODE3).not.toBe(0.10);
+  });
+
+  it("CI_BAND_OPACITY_MODE3 < CI_BAND_OPACITY (Mode 3 ribbons quieter than Mode 1/2)", async () => {
+    const mod = await import("../TrajectoryView");
+    const { CI_BAND_OPACITY, CI_BAND_OPACITY_MODE3 } = mod as unknown as Record<string, number>;
+    expect(CI_BAND_OPACITY_MODE3).toBeLessThan(CI_BAND_OPACITY);
+  });
+});
+
 describe("AC-1254-4 — computeYDomain includes CI upper values", () => {
   it("CI upper value 0.95 — yMax ≥ 0.95", () => {
     const [, hi] = computeYDomain([0.50, 0.60, 0.95]);


### PR DESCRIPTION
## Summary

- **DEMO-137 (#1466):** `computeCompositeCIBounds` multiplicative formula (`score * (1 ± halfWidth)`) corrected to additive (`score ± halfWidth`), capped to [0, 1]. Function exported for unit test coverage.
- **DEMO-138 (#1467):** `CompositeChartSVG` yDomain `useMemo` no longer pushes `ci_upper` values into the domain computation — y-axis now scales to trajectory composite score range, not CI band range.
- **DEMO-145 (#1474):** Hard-coded `opacity={0.10}` on both CI ribbon SVG paths replaced with exported constants: `CI_BAND_OPACITY_MODE3` (0.05) in Mode 3, `CI_BAND_OPACITY` (0.12) in Mode 1/2.

## AC coverage

| AC | Status | Test |
|---|---|---|
| AC-A1 (additive formula) | GREEN | Unit: `TrajectoryView.test.ts` — was RED in PR #1501 |
| AC-A2 (yDomain excludes CI) | GREEN | Unit: `TrajectoryView.test.ts` — was RED in PR #1501 |
| AC-A3 (opacity constants) | GREEN | Unit: AC-A3 block added this PR |

## Pre-push gate

`cd frontend && npm run build` — PASS (tsc-b + vite build, 0 TS errors).

## Intent document

`docs/process/intents/M18-G7-A-2026-06-29-ci-band-geometry.md`

## Root cause

`docs/demo/m18/reviews/2026-06-29-g7-root-cause-analysis.md §Root Cause 1`