### PR TITLE
fix(frontend): M18-G7-B — Zone 1B layout: distributional summary first, PSP visible

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -465,9 +465,11 @@ export function FourFrameworkZone1D({
         );
       })}
 
-      {/* #1276 — Governance horizon disclosure (No False Precision; Placement A — always visible). */}
+      {/* #1276 — Governance horizon disclosure (No False Precision; Placement A — always visible).
+          M18-G7-B DEMO-149: single-line with tooltip prevents clipping of PSP section. */}
       <div
         data-testid="governance-horizon-disclosure"
+        title="Governance indicators (rule of law, democratic quality) respond to fiscal adjustment over 3–6 year horizons in this model's calibration. An 8-step quarterly window captures the beginning of the governance stress trajectory; full divergence requires a 12–24 step analysis."
         style={{
           fontSize: 8,
           color: "#888",
@@ -475,11 +477,13 @@ export function FourFrameworkZone1D({
           paddingTop: 3,
           paddingLeft: 9,
           fontStyle: "italic",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          cursor: "help",
         }}
       >
-        Governance indicators (rule of law, democratic quality) respond to fiscal adjustment over
-        3–6 year horizons in this model&apos;s calibration. An 8-step quarterly window captures the
-        beginning of the governance stress trajectory; full divergence requires a 12–24 step analysis.
+        Gov. horizon: 3–6yr; 8-step window shows early trend only. (hover for detail)
       </div>
 
       {/* M16-G2 #987 — Political Risk sub-section (replaces G1 political economy elements).
@@ -546,7 +550,11 @@ export function FourFrameworkZone1D({
                     >
                       {severity}
                     </span>
-                    {` (${pspPct}%) — `}
+                    {" ("}
+                    <span data-testid="psp-value" style={{ fontWeight: 700, color: severityColor }}>
+                      {`${pspPct}%`}
+                    </span>
+                    {") — "}
                     <span style={{ color: "#555" }}>
                       {legitimacyDirection === "declining" || eliteCaptureDirection === "widening"
                         ? "DECLINING"

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -65,6 +65,9 @@ interface InstrumentClusterProps {
   /** ADR-019 D-1: slot for Mode 2 (Mode2ColumnSurface) or Mode 3 (ControlPlaneColumn) content.
    *  When undefined (Mode 1), ghost text is shown in the reserved zone. */
   controlPlane?: React.ReactNode;
+  /** M18-G7-B — DistributionalComparisonSummary slot. When provided (comparison sessions),
+   *  renders as the first child of zone-1b before the MDA alert panel. (ADR-008 Amendment 2) */
+  distributionalSummarySlot?: React.ReactNode;
 }
 
 export function InstrumentCluster({
@@ -79,6 +82,7 @@ export function InstrumentCluster({
   entityBaselineTrajectories,
   comparisonScenarios,
   controlPlane,
+  distributionalSummarySlot,
 }: InstrumentClusterProps) {
   const bp = useViewportBreakpoint();
   const layout = LAYOUT[bp];
@@ -141,8 +145,14 @@ export function InstrumentCluster({
           }}
         >
           <div style={{ position: "absolute", top: 4, right: 6, fontSize: 9, fontWeight: 700, letterSpacing: 0.5, color: "#666", backgroundColor: "rgba(255,255,255,0.88)", borderRadius: 2, padding: "1px 5px", userSelect: "none", zIndex: 10, lineHeight: 1.5 }}>Zone 1B</div>
+          {/* M18-G7-B: DistributionalComparisonSummary first in comparison sessions (ADR-008 Amendment 2) */}
+          {distributionalSummarySlot && (
+            <div style={{ flex: "0 0 auto", minHeight: 160, overflow: "hidden" }}>
+              {distributionalSummarySlot}
+            </div>
+          )}
           {/* Sub-zone A — MDA alert panel; permanent 80px floor (ADR-018) */}
-          <div data-testid="zone-1b-mda-panel-wrapper" style={{ flex: "1 1 80px", minHeight: 80, overflow: "hidden" }}>
+          <div data-testid="mda-alert-list" style={{ flex: "1 1 80px", minHeight: 80, overflow: "hidden" }}>
             {mdaPanel ?? (
               <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
                 MDA Alert Panel (Zone 1B)

--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -707,8 +707,15 @@ function _formatK(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-function DistributionalComparisonSummary({ summary }: { summary: DistributionalSummaryData }) {
+export function DistributionalComparisonSummary({ summary }: { summary: DistributionalSummaryData }) {
   const [panelOpen, setPanelOpen] = useState(false);
+  const methodologyPanelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (panelOpen && methodologyPanelRef.current) {
+      methodologyPanelRef.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [panelOpen]);
 
   const terminalPairs = summary.pairs.map((pair) => {
     const terminal = pair.steps.find((s) => s.step === summary.terminal_step) ?? pair.steps[pair.steps.length - 1];
@@ -804,7 +811,11 @@ function DistributionalComparisonSummary({ summary }: { summary: DistributionalS
           : "→ Direction uncertain: CI spans zero"}
       </div>
       {panelOpen && summary.methodology_detail && (
-        <div style={{ borderTop: "1px dashed #e5e7eb", marginTop: 4, paddingTop: 4 }}>
+        <div
+          ref={methodologyPanelRef}
+          data-testid="zone3-methodology-panel"
+          style={{ borderTop: "1px dashed #e5e7eb", marginTop: 4, paddingTop: 4, overflowY: "auto" }}
+        >
           <div data-testid="methodology-q1-population" style={rowStyle}>
             <span style={labelStyle}>Q1 population:</span>{" "}
             {summary.entity_id}: {summary.methodology_detail.q1_population.toLocaleString("en-US")} (UN WPP 2024, 20% Q1 fraction)
@@ -842,7 +853,7 @@ const COHORT_SEVERITY_COLOR: Record<CohortThresholdCrossing["severity"], string>
 };
 
 export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boolean }) {
-  const { cohort_threshold_crossings: crossings, distributionalSummary } = useScenarioStepStore();
+  const { cohort_threshold_crossings: crossings } = useScenarioStepStore();
   const bp = useViewportBreakpoint();
   const isNarrow = bp === 1024; // covers all viewports < 1280px, including 768px (#1250)
   const headerLabel = isCompleted ? "COHORT IMPACT (HISTORICAL)" : "COHORT IMPACT";
@@ -947,9 +958,6 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
             );
           })
         )}
-      {distributionalSummary && distributionalSummary.pairs.length > 0 && (
-        <DistributionalComparisonSummary summary={distributionalSummary} />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -31,7 +31,7 @@
 import { useEffect, useRef, useState } from "react";
 import { InstrumentCluster, LAYOUT, useViewportBreakpoint } from "./InstrumentCluster";
 import { type ScenarioComparisonConfig, type ScenarioComparisonThresholdCrossing } from "./TrajectoryView";
-import { MDAAlertPanelZone1B, CohortImpactSection } from "./MDAAlertPanelZone1B";
+import { MDAAlertPanelZone1B, CohortImpactSection, DistributionalComparisonSummary } from "./MDAAlertPanelZone1B";
 import { PMMWidgetZone1C } from "./PMMWidgetZone1C";
 import { FourFrameworkZone1D } from "./FourFrameworkZone1D";
 import { CohortIndicatorsPanel } from "./CohortIndicatorsPanel";
@@ -1006,6 +1006,11 @@ export function ScenarioInstrumentCluster({
           />
         }
         zone1bCohortSection={<CohortImpactSection isCompleted={activeScenarioDetail?.status === "completed"} />}
+        distributionalSummarySlot={
+          store.distributionalSummary && store.distributionalSummary.pairs.length > 0
+            ? <DistributionalComparisonSummary summary={store.distributionalSummary} />
+            : undefined
+        }
         pmmWidget={<PMMWidgetZone1C />}
         fourFramework={
           <FourFrameworkZone1D


### PR DESCRIPTION
## Summary

- **DEMO-133 (#1462) AC-B1/B2:** `DistributionalComparisonSummary` extracted from `CohortImpactSection` sticky-bottom, exported from `MDAAlertPanelZone1B`, and wired as `distributionalSummarySlot` in `InstrumentCluster` — renders as first child of zone-1b with 160px minimum height in comparison sessions. MDA alert container gets `data-testid="mda-alert-list"`.
- **AC-B3:** Single-scenario sessions unaffected — slot is `undefined` when no distributional summary in store.
- **DEMO-131 (#1460) AC-B4:** `zone3-methodology-panel` `data-testid` added; `scrollIntoView({block:"nearest"})` fires on `panelOpen` transition; `overflowY:"auto"` added.
- **DEMO-149 AC-B5:** Governance horizon disclosure collapsed from 3 lines to 1 line (full text in `title` tooltip); `data-testid="psp-value"` added to PSP percentage span.

## AC coverage

| AC | Status |
|---|---|
| AC-B1 (distributional summary in viewport, height ≥ 160) | GREEN |
| AC-B2 (summary before mda-alert-list in DOM) | GREEN |
| AC-B3 (single-scenario: alerts first, summary absent) | GREEN |
| AC-B4 (Zone 3 panel top < 900 after toggle) | GREEN |
| AC-B5 (psp-value visible, not clipped) | GREEN |

## Pre-push gate

`cd frontend && npm run build` — PASS.

## Intent / ADR

`docs/process/intents/M18-G7-B-2026-06-29-zone1b-layout.md` · ADR-008 Amendment 2