### PR TITLE
feat(frontend): AC-C1–C5 — CohortImpactSection monitored-row state (M18-G7-C)

### DIFF
--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -852,22 +852,150 @@ const COHORT_SEVERITY_COLOR: Record<CohortThresholdCrossing["severity"], string>
   WATCH: "#0070a0",
 };
 
-export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boolean }) {
-  const { cohort_threshold_crossings: crossings } = useScenarioStepStore();
+const FOCAL_BADGE_COLOR = {
+  CLEAR: "#2e7d32",
+  CRITICAL: "#c62828",
+  UNKNOWN: "#888888",
+} as const;
+
+interface FocalCohortConfig {
+  indicator_key: string;
+  floor_value: number;
+  floor_label: string;
+  framework: string;
+}
+
+export function CohortImpactSection({
+  isCompleted = false,
+  monitoredFocalCohorts,
+}: {
+  isCompleted?: boolean;
+  monitoredFocalCohorts?: FocalCohortConfig[];
+}) {
+  const { cohort_threshold_crossings: crossings, current_step, trajectory } = useScenarioStepStore();
   const bp = useViewportBreakpoint();
-  const isNarrow = bp === 1024; // covers all viewports < 1280px, including 768px (#1250)
+  const isNarrow = bp === 1024;
   const headerLabel = isCompleted ? "COHORT IMPACT (HISTORICAL)" : "COHORT IMPACT";
   const emptyText = isCompleted
     ? "No cohort threshold crossings at or before this step."
     : "No cohort threshold crossings projected on current path.";
+
+  // Sort crossings: active (non-historical) first by severity, then historical (HIST) rows.
+  const activeCrossings = [...crossings]
+    .filter((c) => c.step_crossed >= current_step)
+    .sort((a, b) => {
+      const sevOrder: Record<string, number> = { CRITICAL: 0, WARNING: 1, WATCH: 2 };
+      return (sevOrder[a.severity] ?? 3) - (sevOrder[b.severity] ?? 3);
+    });
+  const historicalCrossings = crossings.filter((c) => c.step_crossed < current_step);
+  const sortedCrossings = [...activeCrossings, ...historicalCrossings];
+
+  // Build focal row states from trajectory indicators at current step.
+  const currentStepData = trajectory?.steps.find((s) => s.step_index === current_step) ?? null;
+  const focalRows = (monitoredFocalCohorts ?? []).map((focal) => {
+    const rawValue = currentStepData?.frameworks[focal.framework]?.indicators?.[focal.indicator_key] ?? null;
+    const numValue = rawValue !== null ? parseFloat(rawValue) : null;
+    const state: "CLEAR" | "CRITICAL" | "UNKNOWN" =
+      numValue === null ? "UNKNOWN" : numValue > focal.floor_value ? "CLEAR" : "CRITICAL";
+    return { focal, numValue, state };
+  });
+
+  const hasCrossings = sortedCrossings.length > 0;
+  const hasFocal = focalRows.length > 0;
+
+  function renderCrossingRow(crossing: CohortThresholdCrossing) {
+    const isHistorical = crossing.step_crossed < current_step;
+    const severityColor = COHORT_SEVERITY_COLOR[crossing.severity];
+    const borderColor = isHistorical ? "#a06000" : severityColor;
+    const isSad = !!crossing.is_synthetic && crossing.synthetic_method === "STRUCTURAL_ABSENCE";
+    const badgeText = isSad
+      ? "SAD"
+      : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_MODEL"
+        ? "T4"
+        : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_COMPARABLE"
+          ? "T3"
+          : `T${crossing.tier}`;
+    const valueDisplay = formatCohortDistance(crossing.above_floor_pct, crossing.breaches_below !== false, isSad);
+    return (
+      <div
+        key={`${crossing.quintile_key}-${crossing.indicator_key}`}
+        data-testid="cohort-impact-row"
+        data-crossing-step={crossing.step_crossed}
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 4,
+          borderLeft: `2px solid ${borderColor}`,
+          paddingLeft: 6,
+          paddingTop: 2,
+          paddingBottom: 2,
+          marginBottom: 2,
+          fontSize: isNarrow ? 11 : 10,
+        }}
+      >
+        <span
+          data-testid="severity-badge"
+          style={{
+            color: isHistorical ? "#fff" : severityColor,
+            background: isHistorical ? "#a06000" : undefined,
+            borderRadius: isHistorical ? 3 : undefined,
+            padding: isHistorical ? "1px 5px" : undefined,
+            fontWeight: 700,
+            flexShrink: 0,
+            fontSize: isNarrow ? 10 : 9,
+          }}
+        >
+          {isHistorical ? "HIST" : crossing.severity}
+        </span>
+        <span style={{ color: "#333", lineHeight: 1.3, flex: 1, minWidth: 0 }}>
+          <span style={{ fontWeight: 600, display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {crossing.cohort_label} — {crossing.indicator_label}
+          </span>
+          <span style={{ color: "#666", display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {`Threshold crossed at step ${crossing.step_crossed} · `}
+            <span data-testid={`cohort-value-${crossing.indicator_key}`}>
+              {valueDisplay}
+            </span>
+            {` · ${formatSourceId(crossing.source)}`}
+          </span>
+        </span>
+        <span
+          data-testid="confidence-tier-badge"
+          style={{ display: "inline-flex", flexDirection: "column", alignItems: "center", gap: 1, flexShrink: 0 }}
+        >
+          <span
+            data-testid={`cohort-tier-badge-${crossing.indicator_key}`}
+            style={{
+              fontSize: isNarrow ? 10 : 8,
+              fontWeight: 700,
+              color: isSad ? "#7a0000" : "#005a9e",
+              background: isSad ? "#ffe0e0" : "#e0eeff",
+              borderRadius: 2,
+              padding: "1px 3px",
+              display: "inline-block",
+            }}
+          >
+            {badgeText}
+          </span>
+          <span
+            data-testid="confidence-tier-badge-sublabel"
+            style={{ fontSize: isNarrow ? 9 : 7, color: "#6b7280", fontWeight: 400, lineHeight: 1, whiteSpace: "nowrap" }}
+          >
+            {isSad ? "No primary data" : badgeText === "T4" ? "Model est." : "Inferred"}
+          </span>
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div
       data-testid="zone-1b-cohort-impact"
       style={{ borderTop: "1px solid #e0e0e0", paddingTop: 2, flex: "1 1 0", overflowY: "auto", background: "#fff", position: "relative" }}
     >
-      <div
-        data-testid="cohort-section-header"
+      <div data-testid="cohort-impact-section">
+        <div
+          data-testid="cohort-section-header"
           style={{
             fontSize: 9,
             fontWeight: 600,
@@ -879,7 +1007,7 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
         >
           {headerLabel}
         </div>
-        {crossings.length === 0 ? (
+        {!hasCrossings && !hasFocal ? (
           <div
             data-testid="cohort-empty-state"
             style={{ fontSize: 10, color: "#aaa", fontStyle: "italic", paddingLeft: 4 }}
@@ -887,26 +1015,17 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
             {emptyText}
           </div>
         ) : (
-          crossings.map((crossing, idx) => {
-            const color = COHORT_SEVERITY_COLOR[crossing.severity];
-            const isSad = !!crossing.is_synthetic && crossing.synthetic_method === "STRUCTURAL_ABSENCE";
-            const badgeText = isSad
-              ? "SAD"
-              : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_MODEL"
-                ? "T4"
-                : crossing.is_synthetic && crossing.synthetic_method === "SYNTHETIC_COMPARABLE"
-                  ? "T3"
-                  : `T${crossing.tier}`;
-            const valueDisplay = formatCohortDistance(crossing.above_floor_pct, crossing.breaches_below !== false, isSad);
-            return (
+          <>
+            {sortedCrossings.map((crossing) => renderCrossingRow(crossing))}
+            {focalRows.map(({ focal, numValue, state }) => (
               <div
-                key={`${crossing.quintile_key}-${crossing.indicator_key}`}
-                data-testid={`cohort-row-${idx}`}
+                key={`focal-${focal.indicator_key}`}
+                data-testid="focal-cohort-row"
                 style={{
                   display: "flex",
                   alignItems: "flex-start",
                   gap: 4,
-                  borderLeft: `2px solid ${color}`,
+                  borderLeft: `2px solid ${FOCAL_BADGE_COLOR[state]}`,
                   paddingLeft: 6,
                   paddingTop: 2,
                   paddingBottom: 2,
@@ -914,50 +1033,35 @@ export function CohortImpactSection({ isCompleted = false }: { isCompleted?: boo
                   fontSize: isNarrow ? 11 : 10,
                 }}
               >
-                <span style={{ color, fontWeight: 700, flexShrink: 0, fontSize: isNarrow ? 10 : 9 }}>
-                  {crossing.severity}
+                <span
+                  data-testid="focal-badge"
+                  style={{
+                    background: FOCAL_BADGE_COLOR[state],
+                    color: "#fff",
+                    borderRadius: 3,
+                    padding: "1px 5px",
+                    fontSize: isNarrow ? 10 : 9,
+                    fontWeight: 700,
+                    flexShrink: 0,
+                  }}
+                >
+                  {state}
                 </span>
                 <span style={{ color: "#333", lineHeight: 1.3, flex: 1, minWidth: 0 }}>
                   <span style={{ fontWeight: 600, display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {crossing.cohort_label} — {crossing.indicator_label}
+                    {focal.indicator_key.replace(/_/g, " ")} — {focal.floor_label}
                   </span>
-                  <span style={{ color: "#666", display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {`Threshold crossed at step ${crossing.step_crossed} · `}
-                    <span data-testid={`cohort-value-${crossing.indicator_key}`}>
-                      {valueDisplay}
+                  {numValue !== null && (
+                    <span style={{ color: "#666", display: "block" }}>
+                      {`${numValue.toFixed(3)} / floor ${focal.floor_value.toFixed(3)}`}
                     </span>
-                    {` · ${formatSourceId(crossing.source)}`}
-                  </span>
-                </span>
-                <span
-                  data-testid="confidence-tier-badge"
-                  style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 1, flexShrink: 0 }}
-                >
-                  <span
-                    data-testid={`cohort-tier-badge-${crossing.indicator_key}`}
-                    style={{
-                      fontSize: isNarrow ? 10 : 8,
-                      fontWeight: 700,
-                      color: isSad ? "#7a0000" : "#005a9e",
-                      background: isSad ? "#ffe0e0" : "#e0eeff",
-                      borderRadius: 2,
-                      padding: "1px 3px",
-                      display: "inline-block",
-                    }}
-                  >
-                    {badgeText}
-                  </span>
-                  <span
-                    data-testid="confidence-tier-badge-sublabel"
-                    style={{ fontSize: isNarrow ? 9 : 7, color: '#6b7280', fontWeight: 400, lineHeight: 1, whiteSpace: 'nowrap' }}
-                  >
-                    {isSad ? "No primary data" : badgeText === "T4" ? "Model est." : "Inferred"}
-                  </span>
+                  )}
                 </span>
               </div>
-            );
-          })
+            ))}
+          </>
         )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -56,6 +56,8 @@ interface RawFrameworkPoint {
   ci_upper: string | null;
   confidence_tier: number;
   scoring_basis: "percentile_rank" | "normalized_absolute" | "boundary_proximity";
+  /** M18-G7-C — raw indicator values from API; parsed to string | null in parseTrajectoryResponse. */
+  indicators?: Record<string, { value: string | null } | null>;
 }
 
 interface RawTrajectoryStep {
@@ -104,6 +106,12 @@ function parseTrajectoryResponse(raw: RawTrajectoryResponse): TrajectoryResponse
             fw.scoring_basis === "boundary_proximity"
               ? "normalized_absolute"
               : fw.scoring_basis,
+          indicators: Object.fromEntries(
+            Object.entries(fw.indicators ?? {}).map(([k, v]) => [
+              k,
+              (v as { value?: string | null } | null)?.value ?? null,
+            ])
+          ),
         };
       }
       const pmm =
@@ -512,6 +520,7 @@ export function ScenarioInstrumentCluster({
                   ci_upper: null,
                   confidence_tier: (fw.confidence_tier as number) ?? 3,
                   scoring_basis: "percentile_rank",
+                  indicators: {},
                 };
               }
               return {
@@ -1005,7 +1014,12 @@ export function ScenarioInstrumentCluster({
             comparisonScenarios={loadedComparisonScenarios}
           />
         }
-        zone1bCohortSection={<CohortImpactSection isCompleted={activeScenarioDetail?.status === "completed"} />}
+        zone1bCohortSection={
+          <CohortImpactSection
+            isCompleted={activeScenarioDetail?.status === "completed"}
+            monitoredFocalCohorts={activeScenarioDetail?.configuration?.monitored_focal_cohorts}
+          />
+        }
         distributionalSummarySlot={
           store.distributionalSummary && store.distributionalSummary.pairs.length > 0
             ? <DistributionalComparisonSummary summary={store.distributionalSummary} />

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -16,6 +16,8 @@ export interface TrajectoryFrameworkPoint {
   ci_upper: number | null;
   confidence_tier: number;
   scoring_basis: "percentile_rank" | "normalized_absolute";
+  /** M18-G7-C — indicator values keyed by indicator_key. Populated by parseTrajectoryResponse. */
+  indicators?: Record<string, string | null>;
 }
 
 export interface TrajectoryStep {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -82,6 +82,13 @@ export interface ScenarioConfigSchema {
       conditionality_type?: "standard" | "strict" | "relaxed";
     };
   };
+  /** M18-G7-C — monitored focal cohorts for CohortImpactSection (ADR-010 Amendment 2). */
+  monitored_focal_cohorts?: Array<{
+    indicator_key: string;
+    floor_value: number;
+    floor_label: string;
+    framework: string;
+  }>;
 }
 
 // ADR-016 Component 1 — Data quality preview response


### PR DESCRIPTION
## Summary

- **AC-C1**: `[data-testid="focal-cohort-row"]` renders when `monitored_focal_cohorts` is in scenario configuration
- **AC-C2**: CLEAR badge (green `#2e7d32`) when indicator value > floor; CRITICAL badge (red `#c62828`) when ≤ floor
- **AC-C3**: Historical threshold crossings (`step_crossed < current_step`) show amber `#a06000` HIST badge with `data-testid="severity-badge"` and `data-crossing-step` attribute; `data-testid="cohort-impact-section"` inner wrapper added (outer `zone-1b-cohort-impact` preserved for m16 tests)
- **AC-C4**: Active CRITICAL crossing rows render before CLEAR focal rows (severity-aware ordering)
- **AC-C5**: No `focal-cohort-row` when scenario has no `monitored_focal_cohorts`

## Files changed

- `types.ts` — `monitored_focal_cohorts` added to `ScenarioConfigSchema`
- `scenarioStepStore.ts` — optional `indicators?: Record<string, string | null>` on `TrajectoryFrameworkPoint`
- `ScenarioInstrumentCluster.tsx` — `RawFrameworkPoint.indicators` preserved through `parseTrajectoryResponse`; `monitoredFocalCohorts` wired to `CohortImpactSection`
- `MDAAlertPanelZone1B.tsx` — `CohortImpactSection` overhauled per ADR-010 Amendment 2

## Test plan

- [ ] Pre-push build gate passed (tsc-b + vite)
- [ ] `[data-testid="focal-cohort-row"]` visible with `monitored_focal_cohorts` configured (AC-C1)
- [ ] CLEAR badge green `rgb(46, 125, 50)` when value > floor (AC-C2)
- [ ] HIST badge amber `rgb(160, 96, 0)` for historical crossings (AC-C3)
- [ ] CRITICAL row precedes CLEAR focal row in DOM (AC-C4)
- [ ] No focal row with no `monitored_focal_cohorts` (AC-C5)
- [ ] m16-g10-predemo-polish E2E tests unaffected (outer `zone-1b-cohort-impact` wrapper preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)