### PR TITLE
feat(frontend): M18-G7-D — data pipeline fixes (PSP driver, HCL, ecological)

### DIFF
--- a/frontend/src/components/FourFrameworkZone1D.tsx
+++ b/frontend/src/components/FourFrameworkZone1D.tsx
@@ -219,7 +219,7 @@ interface FourFrameworkZone1DProps {
   pspDominantDriver?: string | null;
 }
 
-const DRIVER_LABELS: Record<string, string> = {
+export const DRIVER_LABELS: Record<string, string> = {
   fiscal_sustainability: "fiscal sustainability",
   external_balance: "external balance",
   governance: "governance",
@@ -453,13 +453,15 @@ export function FourFrameworkZone1D({
               data-testid={`framework-score-${key}`}
               className={scoreClass}
               style={{
-                fontSize: 13,
+                fontSize: key === "ecological" && isNull && point?.note != null ? 10 : 13,
                 fontWeight: 700,
                 color: isNull ? "#aaa" : color,
                 fontVariantNumeric: "tabular-nums",
               }}
             >
-              {formatScore(score)}
+              {key === "ecological" && isNull && point?.note != null
+                ? "Not modelled"
+                : formatScore(score)}
             </span>
           </div>
         );

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -58,6 +58,10 @@ interface RawFrameworkPoint {
   scoring_basis: "percentile_rank" | "normalized_absolute" | "boundary_proximity";
   /** M18-G7-C — raw indicator values from API; parsed to string | null in parseTrajectoryResponse. */
   indicators?: Record<string, { value: string | null } | null>;
+  /** M18-G7-D — dominant driver of PSP change (political_economy only). */
+  psp_dominant_driver?: string | null;
+  /** M18-G7-D — note from API (e.g. "Ecological disabled for SEN Demo 7 Act 1"). */
+  note?: string | null;
 }
 
 interface RawTrajectoryStep {
@@ -112,6 +116,8 @@ function parseTrajectoryResponse(raw: RawTrajectoryResponse): TrajectoryResponse
               (v as { value?: string | null } | null)?.value ?? null,
             ])
           ),
+          psp_dominant_driver: fw.psp_dominant_driver ?? null,
+          note: fw.note ?? null,
         };
       }
       const pmm =
@@ -443,6 +449,20 @@ export function ScenarioInstrumentCluster({
       store.setPmmState(step.pmm.value, step.pmm.direction);
     } else {
       store.setPmmState(null, null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
+  }, [currentStep, store.trajectory]);
+
+  // M18-G7-D: sync pspDominantDriver from trajectory when trajectory or step changes.
+  // Supplements the measurement-output extraction path so the driver renders in
+  // mocked demo sessions where measurement-output is not intercepted.
+  useEffect(() => {
+    const traj = store.trajectory;
+    if (!traj || currentStep === 0) return;
+    const step = traj.steps.find((s) => s.step_index === currentStep);
+    const driverFromTraj = step?.frameworks["political_economy"]?.psp_dominant_driver ?? null;
+    if (driverFromTraj !== null) {
+      setPspDominantDriver(driverFromTraj);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a Zustand singleton, stable reference
   }, [currentStep, store.trajectory]);

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -18,6 +18,10 @@ export interface TrajectoryFrameworkPoint {
   scoring_basis: "percentile_rank" | "normalized_absolute";
   /** M18-G7-C — indicator values keyed by indicator_key. Populated by parseTrajectoryResponse. */
   indicators?: Record<string, string | null>;
+  /** M18-G7-D — dominant driver of PSP change at this step (political_economy only). */
+  psp_dominant_driver?: string | null;
+  /** M18-G7-D — note from API (e.g. "Ecological disabled for SEN Demo 7 Act 1"). */
+  note?: string | null;
 }
 
 export interface TrajectoryStep {

--- a/frontend/tests/e2e/demo-narrated.spec.ts
+++ b/frontend/tests/e2e/demo-narrated.spec.ts
@@ -203,7 +203,15 @@ function makeAct1BaselineMock(scenarioId: string): object {
           ci_lower: null,
           ci_upper: null,
           scoring_basis: "percentile_rank",
-          indicators: {},
+          indicators: {
+            // M18-G7-D AC-D3: bottom quintile HCL indicator for Zone 1B focal cohort display.
+            bottom_quintile_informal_workers_poverty_headcount: {
+              value: "0.450",
+              unit: "ratio",
+              variable_type: "STOCK",
+              confidence_tier: 3,
+            },
+          },
           mda_alerts: [],
           has_below_floor_indicator: false,
           note: null,
@@ -235,6 +243,8 @@ function makeAct1BaselineMock(scenarioId: string): object {
               confidence_tier: 3,
             },
           },
+          // M18-G7-D AC-D1: psp_dominant_driver at steps >= BRANCH_FROM_STEP.
+          ...(i + 1 >= BRANCH_FROM_STEP ? { psp_dominant_driver: "fiscal_sustainability" } : {}),
           mda_alerts: [],
           has_below_floor_indicator: false,
           note: null,
@@ -326,6 +336,8 @@ function makeAct1BranchMock(): object {
                 confidence_tier: 3,
               },
             },
+            // M18-G7-D AC-D1: psp_dominant_driver at steps >= BRANCH_FROM_STEP.
+            ...(isBranched ? { psp_dominant_driver: "fiscal_sustainability" } : {}),
             mda_alerts: [],
             has_below_floor_indicator: false,
             note: null,


### PR DESCRIPTION
## Cluster D — Data Pipeline Fixes

Targets `sprint/m18-g7`. Closes DEMO-132, DEMO-143, DEMO-150.

### Changes

**AC-D2 — Export `DRIVER_LABELS`**
- `FourFrameworkZone1D.tsx`: `const DRIVER_LABELS` → `export const DRIVER_LABELS`
- All 5 AC-D2 unit tests now green

**AC-D1 — `psp_dominant_driver` in trajectory mock + extraction path**
- `RawFrameworkPoint` and `TrajectoryFrameworkPoint` extended with `psp_dominant_driver?: string | null`
- `parseTrajectoryResponse` preserves the field
- New trajectory-side sync `useEffect` in `ScenarioInstrumentCluster` reads `psp_dominant_driver` from the political_economy trajectory framework at `currentStep` — supplements the measurement-output path so the driver row renders in mocked demo sessions
- `makeAct1BranchMock`: adds `psp_dominant_driver: "fiscal_sustainability"` at steps >= `BRANCH_FROM_STEP`
- `makeAct1BaselineMock`: same at steps >= `BRANCH_FROM_STEP`

**AC-D3 — HCL bottom quintile indicator in mock**
- `makeAct1BaselineMock`: `human_development.indicators` now includes `bottom_quintile_informal_workers_poverty_headcount: { value: "0.450", ... }` at every step

**AC-D4 — Ecological "Not modelled" display**
- `RawFrameworkPoint` and `TrajectoryFrameworkPoint` extended with `note?: string | null`
- `parseTrajectoryResponse` preserves the field
- `FourFrameworkZone1D`: ecological score cell renders `"Not modelled"` (font-size 10) instead of `"—"` when `composite_score === null && note != null`

### Test results

```
AC-D1: PASS (playwright static)
AC-D2: PASS (vitest — 5/5)
AC-D3: PASS (playwright static)
AC-D4: PASS (playwright static)
Build gate: PASS (tsc -b && vite build)
Backend lint: PASS (ruff + mypy)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)