### PR TITLE
fix(e2e): hotfix 4 CI failures on sprint/m18-g7

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -396,6 +396,7 @@ class ScenarioConfigSchema(BaseModel):
     commodity_price_shocks: list[CommodityShockConfig] = []
     projection_steps: int | None = Field(default=None, ge=1, le=100)
     ecological_shock_coefficient: float = Field(default=0.0, ge=0.0, le=1.0)
+    monitored_focal_cohorts: list[dict[str, Any]] = []
 
 
 class ScheduledInputSchema(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -209,7 +209,16 @@ export default function App() {
     // (URL-loaded scenarios with status != "completed" stay at currentStep=null → 0).
     (window as unknown as Record<string, unknown>).__worldsim_setCurrentStep = (step: number) =>
       setCurrentStep(step);
-  }, [setSelectedEntityId, setAttributeName]);
+    // M18-G7-B — load a comparison scenario alongside the URL-loaded reference scenario.
+    // Reads the reference scenario ID from the current URL (?scenario=) so no stale closure.
+    (window as unknown as Record<string, unknown>).__worldsim_loadComparisonScenario = (id: string) => {
+      const refId = new URLSearchParams(window.location.search).get("scenario") ?? "";
+      setComparisonScenarios([
+        { scenarioId: refId, label: "A", paletteIndex: 0 },
+        { scenarioId: id, label: "B", paletteIndex: 1 },
+      ]);
+    };
+  }, [setSelectedEntityId, setAttributeName, setComparisonScenarios]);
 
   // When a scenario is selected: fast-forward currentStep if already completed,
   // and extract the primary entity for the identity header + choropleth highlight (#744).

--- a/frontend/src/components/InstrumentCluster.tsx
+++ b/frontend/src/components/InstrumentCluster.tsx
@@ -152,7 +152,7 @@ export function InstrumentCluster({
             </div>
           )}
           {/* Sub-zone A — MDA alert panel; permanent 80px floor (ADR-018) */}
-          <div data-testid="mda-alert-list" style={{ flex: "1 1 80px", minHeight: 80, overflow: "hidden" }}>
+          <div data-testid="zone-1b-mda-panel-wrapper" style={{ flex: "1 1 80px", minHeight: 80, overflow: "hidden" }}>
             {mdaPanel ?? (
               <div style={{ color: "#bbb", fontSize: 12, padding: 8 }}>
                 MDA Alert Panel (Zone 1B)

--- a/frontend/tests/e2e/m18-g7-zone1b-layout.spec.ts
+++ b/frontend/tests/e2e/m18-g7-zone1b-layout.spec.ts
@@ -247,6 +247,31 @@ test("AC-B1: distributional-comparison-summary in viewport at 1440×900 in compa
   await page.route(`**/api/v1/scenarios/${cmpId}/trajectory**`, (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(cmpMock) }),
   );
+  // M18-G7-B hotfix: mock distributional-differential so DistributionalComparisonSummary renders
+  // regardless of whether the backend has cohort data for these test scenarios.
+  await page.route("**/api/v1/scenarios/comparison/distributional-differential**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        entity_id: "ZMB",
+        reference_scenario_id: cmpId,
+        terminal_step: 3,
+        tier: "T3",
+        methodology_summary: "Q1 headcount differential (mock)",
+        pairs: [
+          {
+            scenario_id: cmpId,
+            steps: [
+              { step: 1, headcount_differential: -5000, ci_lower: -8000, ci_upper: -2000, direction_stable: true },
+              { step: 2, headcount_differential: -8000, ci_lower: -12000, ci_upper: -4000, direction_stable: true },
+              { step: 3, headcount_differential: -12000, ci_lower: -16000, ci_upper: -8000, direction_stable: true },
+            ],
+          },
+        ],
+      }),
+    }),
+  );
 
   await page.goto(`/?scenario=${refId}`);
   await waitForAppReady(page);
@@ -385,7 +410,7 @@ test("AC-B2: distributional-comparison-summary renders BEFORE mda-alert-list in 
   await page.waitForTimeout(2_000);
 
   const summary = page.locator('[data-testid="distributional-comparison-summary"]');
-  const alertList = page.locator('[data-testid="mda-alert-list"]');
+  const alertList = page.locator('[data-testid="zone-1b-mda-panel-wrapper"]');
 
   const summaryVisible = await summary.isVisible({ timeout: 5_000 }).catch(() => false);
   const alertListVisible = await alertList.isVisible({ timeout: 5_000 }).catch(() => false);
@@ -398,7 +423,7 @@ test("AC-B2: distributional-comparison-summary renders BEFORE mda-alert-list in 
   // compareDocumentPosition: DOCUMENT_POSITION_FOLLOWING = 4 means summary appears before alerts
   const position = await page.evaluate(() => {
     const s = document.querySelector('[data-testid="distributional-comparison-summary"]');
-    const a = document.querySelector('[data-testid="mda-alert-list"]');
+    const a = document.querySelector('[data-testid="zone-1b-mda-panel-wrapper"]');
     if (!s || !a) return null;
     return s.compareDocumentPosition(a);
   });
@@ -461,8 +486,8 @@ test("AC-B3: single-scenario — mda-alert-list first, distributional-comparison
     "See ADR-008 Amendment 2 §Zone 1B DOM ordering — regression guard.",
   ).toBe(false);
 
-  // mda-alert-list should be visible (alerts-first ordering preserved)
-  const alertListPresent = await page.locator('[data-testid="mda-alert-list"]').isVisible({ timeout: 3_000 }).catch(() => false);
+  // zone-1b-mda-panel-wrapper should be visible (alerts-first ordering preserved)
+  const alertListPresent = await page.locator('[data-testid="zone-1b-mda-panel-wrapper"]').isVisible({ timeout: 3_000 }).catch(() => false);
   if (alertListPresent) {
     // In single-scenario, alert-list must appear at the top of Zone 1B
     // (distributional-comparison-summary is absent, so no reordering needed)
@@ -585,10 +610,19 @@ test("AC-B5: psp-value visible at 1440×900 (not clipped by governance disclosur
   await waitForAppReady(page);
   await page.waitForTimeout(2_000);
 
+  // Advance one step so measurement-output fires and psp-value renders.
+  // At step 0 the measurement-output fetch is skipped (early return).
+  const advBtn = page.locator('[data-testid="advance-step-btn"]');
+  const advVisible = await advBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+  if (advVisible) {
+    await advBtn.click();
+    await page.waitForTimeout(2_000);
+  }
+
   const pspValue = page.locator('[data-testid="psp-value"]')
     .or(page.locator('[data-testid="psp-probability-value"]'))
     .first();
-  const pspVisible = await pspValue.isVisible({ timeout: 3_000 }).catch(() => false);
+  const pspVisible = await pspValue.isVisible({ timeout: 5_000 }).catch(() => false);
 
   if (!pspVisible) {
     console.warn("AC-B5: psp-value element not visible — may be hidden by governance disclosure. Noting as expected RED state.");


### PR DESCRIPTION
## Summary

Hotfix for 4 failing E2E tests on `sprint/m18-g7` after Cluster D merge (PR #1506).

- **m17-g3 (AC-A2)**: Cluster B renamed `zone-1b-mda-panel-wrapper` → `mda-alert-list` in `InstrumentCluster.tsx`, breaking m17-g3 tests that expect the original testid. Restored to `zone-1b-mda-panel-wrapper`; updated 3 locators in `m18-g7-zone1b-layout.spec.ts` to match.
- **AC-C1**: `ScenarioConfigSchema` (Pydantic) was silently dropping `monitored_focal_cohorts` from POST payloads — Pydantic v2 discards unknown fields by default. Added the field with default `[]`.
- **AC-B1**: `__worldsim_loadComparisonScenario` E2E test seam was absent from `App.tsx`. Added it — reads `?scenario=` from URL for the reference ID, sets `comparisonScenarios` with 2 entries (triggering distributional-differential fetch). Also added a route mock for the distributional-differential endpoint so `DistributionalComparisonSummary` renders without real cohort data in the test scenarios.
- **AC-B5**: `psp-value` never renders at step 0 (measurement-output fetch has early return for `currentStep === 0`). Test now clicks `advance-step-btn` before checking PSP visibility.

## Test plan
- [ ] CI green on `sprint/m18-g7` after merge
- [ ] m17-g3 AC-A2 passes (zone-1b-mda-panel-wrapper testid present)
- [ ] AC-C1 passes (monitored_focal_cohorts persisted through backend)
- [ ] AC-B1 passes (distributional-comparison-summary visible in comparison session)
- [ ] AC-B5 passes (psp-value visible after step advance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)