### PR TITLE
fix(frontend): M18-G7 hotfix2 — AC-B1/B5/C2/P1 four CI failures

### DIFF
--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -739,6 +739,7 @@ export function DistributionalComparisonSummary({ summary }: { summary: Distribu
         padding: "6px 8px",
         background: "#fff",
         zIndex: 1,
+        minHeight: 160,
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 2 }}>
@@ -903,7 +904,7 @@ export function CohortImpactSection({
   const hasCrossings = sortedCrossings.length > 0;
   const hasFocal = focalRows.length > 0;
 
-  function renderCrossingRow(crossing: CohortThresholdCrossing) {
+  function renderCrossingRow(crossing: CohortThresholdCrossing, rowIndex: number) {
     const isHistorical = crossing.step_crossed < current_step;
     const severityColor = COHORT_SEVERITY_COLOR[crossing.severity];
     const borderColor = isHistorical ? "#a06000" : severityColor;
@@ -919,7 +920,7 @@ export function CohortImpactSection({
     return (
       <div
         key={`${crossing.quintile_key}-${crossing.indicator_key}`}
-        data-testid="cohort-impact-row"
+        data-testid={`cohort-row-${rowIndex}`}
         data-crossing-step={crossing.step_crossed}
         style={{
           display: "flex",
@@ -1016,7 +1017,7 @@ export function CohortImpactSection({
           </div>
         ) : (
           <>
-            {sortedCrossings.map((crossing) => renderCrossingRow(crossing))}
+            {sortedCrossings.map((crossing, idx) => renderCrossingRow(crossing, idx))}
             {focalRows.map(({ focal, numValue, state }) => (
               <div
                 key={`focal-${focal.indicator_key}`}

--- a/frontend/tests/e2e/m18-g7-cohort-section.spec.ts
+++ b/frontend/tests/e2e/m18-g7-cohort-section.spec.ts
@@ -305,6 +305,17 @@ test("AC-C2: focal-cohort-row shows CLEAR badge with green background when value
     }),
   );
 
+  // Mock advance so current_step increments reliably without real backend latency.
+  // Returns step_executed: 1 for all clicks — trajectory step 1 has value 0.450 > floor 0.400.
+  await page.route(`**/api/v1/scenarios/${scenId}/advance**`, (route) => {
+    if (route.request().method() !== "POST") { route.continue(); return; }
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ step_executed: 1, is_complete: false }),
+    });
+  });
+
   await page.goto(`/?scenario=${scenId}`);
   await waitForAppReady(page);
 
@@ -526,7 +537,7 @@ test("AC-C4: CRITICAL breach row appears before CLEAR focal row in DOM", async (
   await page.waitForTimeout(1_000);
 
   const focalRow = page.locator('[data-testid="focal-cohort-row"]');
-  const criticalRow = page.locator('[data-testid="cohort-impact-row"]').first();
+  const criticalRow = page.locator('[data-testid="cohort-row-0"]');
 
   const bothVisible = await Promise.all([
     focalRow.isVisible({ timeout: 3_000 }).catch(() => false),
@@ -540,7 +551,7 @@ test("AC-C4: CRITICAL breach row appears before CLEAR focal row in DOM", async (
 
   // CRITICAL row must appear before CLEAR focal row in DOM
   const position = await page.evaluate(() => {
-    const critical = document.querySelector('[data-testid="cohort-impact-row"]');
+    const critical = document.querySelector('[data-testid^="cohort-row-"]');
     const focal = document.querySelector('[data-testid="focal-cohort-row"]');
     if (!critical || !focal) return null;
     return critical.compareDocumentPosition(focal);

--- a/frontend/tests/e2e/m18-g7-zone1b-layout.spec.ts
+++ b/frontend/tests/e2e/m18-g7-zone1b-layout.spec.ts
@@ -606,6 +606,38 @@ test("AC-B5: psp-value visible at 1440×900 (not clipped by governance disclosur
 
   if (!scenId) { console.warn("AC-B5: backend not available — skipping"); return; }
 
+  // Mock advance and measurement-output so psp-value renders from step 1
+  // without depending on real SEN political_economy backend output.
+  await page.route(`**/api/v1/scenarios/${scenId}/advance**`, (route) => {
+    if (route.request().method() !== "POST") { route.continue(); return; }
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ step_executed: 1, is_complete: false }),
+    });
+  });
+  await page.route(`**/api/v1/scenarios/${scenId}/measurement-output**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        entity_id: "SEN", scenario_id: scenId, step_index: 1,
+        outputs: {
+          political_economy: {
+            framework: "political_economy", composite_score: null,
+            indicators: {
+              programme_survival_probability: {
+                value: "0.67", unit: "probability",
+                variable_type: "STOCK", confidence_tier: 3 },
+            },
+            mda_alerts: [], has_below_floor_indicator: false, note: null,
+          },
+        },
+        ia1_disclosure: "pre-cal",
+      }),
+    }),
+  );
+
   await page.goto(`/?scenario=${scenId}`);
   await waitForAppReady(page);
   await page.waitForTimeout(2_000);


### PR DESCRIPTION
## Summary

- **AC-B1**: Add `minHeight: 160` to `distributional-comparison-summary` div in `MDAAlertPanelZone1B.tsx`. The `InstrumentCluster` wrapper already had `minHeight: 160` but the bounding-box test measures the inner component div directly — it was rendering at 91px.
- **AC-P1**: Restore `data-testid={`cohort-row-${idx}`}` on crossing rows. Cluster C (`e6a655f`) changed the testid from the indexed `cohort-row-N` pattern (M17-G3 contract) to a flat `cohort-impact-row`. Updated AC-C4 in `m18-g7-cohort-section.spec.ts` to use `cohort-row-0` / prefix selector accordingly.
- **AC-B5**: Mock `/advance` and `/measurement-output` in AC-B5 so `psp-value` renders at step 1 without depending on real SEN backend returning PSP data.
- **AC-C2**: Mock `/advance` in AC-C2 so `current_step` increments reliably to 1; trajectory mock has `value: "0.450" > floor 0.400` at step 1 → CLEAR badge.

## Test plan

- [ ] CI E2E suite green on `sprint/m18-g7` after merge
- [ ] `m18-g7-zone1b-layout.spec.ts` AC-B1 and AC-B5 pass
- [ ] `m18-g7-cohort-section.spec.ts` AC-C2 and AC-C4 pass
- [ ] `m17-g3-zone-1b-allocation.spec.ts` AC-P1 passes (indexed testid restored)
- [ ] No regression on AC-C3 (`data-crossing-step` attribute retained) or AC-C5

🤖 Generated with [Claude Code](https://claude.com/claude-code)