### PR TITLE
feat(frontend): DEMO-158 — generic choropleth centering DEV seams

### DIFF
--- a/frontend/src/components/ChoroplethMap.tsx
+++ b/frontend/src/components/ChoroplethMap.tsx
@@ -81,6 +81,7 @@ function computeSteps(features: GeoJSONFeatureCollection["features"]): number[] 
 export default function ChoroplethMap({ attributeName, title, scenarioId, currentStep, onEntityClick, activeEntityIds = [] }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
+  const dataRef = useRef<GeoJSONFeatureCollection | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
   const onEntityClickRef = useRef(onEntityClick);
   const [error, setError] = useState<string | null>(null);
@@ -132,6 +133,7 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
       }
 
       const data: GeoJSONFeatureCollection = await res.json();
+      dataRef.current = data;
       const steps = computeSteps(data.features);
 
       const applyData = () => {
@@ -257,6 +259,44 @@ export default function ChoroplethMap({ attributeName, title, scenarioId, curren
         : ["==", ["get", "entity_id"], ""],
     );
   }, [activeEntityIds]);
+
+  // DEV seams — choropleth entity centering and map-center query for E2E demo walkthrough.
+  // centerOnEntity: looks up entity polygon from the fetched GeoJSON and calls fitBounds —
+  //   generic across any ISO alpha-3 entity with polygon data in the choropleth source.
+  // getMapCenter: returns current map center {lat, lon} for AC-E4 soft assertion.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const win = window as unknown as Record<string, unknown>;
+    win.__worldsim_centerOnEntity = (entityId: string) => {
+      const map = mapRef.current;
+      const fc = dataRef.current;
+      if (!map || !fc) return;
+      const feature = fc.features.find((f) => f.properties.entity_id === entityId);
+      if (!feature || !feature.geometry) return;
+      const geom = feature.geometry as unknown as { type: string; coordinates: unknown };
+      let points: number[][];
+      if (geom.type === "Polygon") {
+        points = (geom.coordinates as number[][][]).flat(1) as number[][];
+      } else if (geom.type === "MultiPolygon") {
+        points = (geom.coordinates as number[][][][]).flat(2) as number[][];
+      } else {
+        return;
+      }
+      if (!points.length) return;
+      const lngs = points.map((p) => p[0]);
+      const lats = points.map((p) => p[1]);
+      map.fitBounds(
+        [[Math.min(...lngs), Math.min(...lats)], [Math.max(...lngs), Math.max(...lats)]],
+        { padding: 40, maxZoom: 6, duration: 0 },
+      );
+    };
+    win.__worldsim_getMapCenter = () => {
+      const map = mapRef.current;
+      if (!map) return null;
+      const c = map.getCenter();
+      return { lat: c.lat, lon: c.lng };
+    };
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Adds `__worldsim_centerOnEntity(entityId)` DEV seam to `ChoroplethMap.tsx`
- Adds `__worldsim_getMapCenter()` DEV seam for AC-E4 soft assertion
- Caches fetched GeoJSON in `dataRef` so the seam has access to polygon geometry at call time

## Mechanism

The solution is generic — no hardcoded coordinates. `centerOnEntity` looks up the entity's polygon feature from the already-fetched GeoJSON via `entity_id` (ISO alpha-3), computes the bounding box from the coordinate array, and calls `map.fitBounds`. Works for any country in the choropleth source. Handles both `Polygon` and `MultiPolygon` geometry types. Both seams are guarded by `import.meta.env.DEV` and stripped from production builds.

## Acceptance criteria

- AC-E4 soft assertion (lat < −8 and lat > −20 for ZMB center) will now fire and pass
- `__worldsim_centerOnEntity('ZMB')` called before Frame D in the demo walkthrough
- Pre-push build gate: PASS (TypeScript clean, 0 errors)

## Related

Resolves DEMO-158 (HIGH finding from IR-M18-002). EL-approved after investigation confirmed a generic solution exists (GeoJSON polygon geometry already in frontend, no hardcoded coordinates). IR review: `docs/demo/m18/reviews/2026-07-01-v0.18.0-ir-review.md`.

Sprint journal: #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)