### PR TITLE
docs(m18-exit): fix stale SCAN-028 pending refs and README milestone markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,11 +294,11 @@ See GitHub Releases for full delivery history.
 
 **Milestone 18 — Full Argument and Demo 7 (Complete)**
 
-Delivered: CI bands on Zone 1A trajectories (ADR-007 full implementation, #1254), PSP driver decomposition (#1255), counter-scenario comparison with distributional differential and CI bounds (#1349), control plane column Mode 2+3 (ADR-019, #1354), Zone 3 auditability panel (#1422), Mode 3 render optimization (#1217), 24 Demo 7 DEMO-NNN findings remediated across G6/G7. Demo 7 simulated stakeholder session: north star PASS (unconditional). SCAN-028 pending (EL-gated).
+Delivered: CI bands on Zone 1A trajectories (ADR-007 full implementation, #1254), PSP driver decomposition (#1255), counter-scenario comparison with distributional differential and CI bounds (#1349), control plane column Mode 2+3 (ADR-019, #1354), Zone 3 auditability panel (#1422), Mode 3 render optimization (#1217), 24 Demo 7 DEMO-NNN findings remediated across G6/G7. Demo 7 simulated stakeholder session: north star PASS (unconditional). SCAN-028 complete (Clean, 2026-07-02).
 
 **Milestone 19 — Constraint Search and Empirical Calibration (Current)**
 
-Core deliverable: Mode 3 constraint-floor capability (instrument finds configurations that avoid a human cost threshold, rather than requiring one-at-a-time manual search); SEN and ZMB backtesting; empirically grounded CI intervals (ADR-007 Bayesian posterior layer); PSP driver arc across programme window and in-viewport auditability panel (DEMO-165, #1528).
+Core deliverable: Mode 3 constraint-floor capability (instrument finds configurations that avoid a human cost threshold, rather than requiring one-at-a-time manual search); SEN and ZMB backtesting; empirically grounded CI intervals (ADR-007 Bayesian posterior layer); PSP driver arc across programme window and in-viewport auditability panel (DEMO-165, #1528); CI label precision (#1529); scenarioId guard Zone 1B (#1456); ADR-007 meaninglessness threshold (#1536); BandResult visible fields (#1537); focal cohort floor validation (#1538).
 
 Demo 8 at M19 close.
 
@@ -314,10 +314,10 @@ M0–M18 complete (v0.1.0–v0.18.0). M19 current. See GitHub Releases for full 
 The full roadmap covering M19 and beyond — milestone deliverables, demo anchors, canonical users served, and the long-term resolution spectrum direction — is maintained at `docs/roadmap/worldsim-roadmap.md`. That document is the canonical reference. The summary below reflects current and next milestone only.
 
 **Milestone 18 — Full Argument and Demo 7 (Complete)**
-Delivered: CI bands ADR-007 (#1254); PSP driver decomposition (#1255); counter-scenario comparison with distributional differential (#1349); control plane column ADR-019 (#1354); Zone 3 auditability panel (#1422); 24 DEMO-NNN findings remediated (G6/G7). Demo 7 north star PASS (unconditional, 2026-07-02). SCAN-028 pending.
+Delivered: CI bands ADR-007 (#1254); PSP driver decomposition (#1255); counter-scenario comparison with distributional differential (#1349); control plane column ADR-019 (#1354); Zone 3 auditability panel (#1422); 24 DEMO-NNN findings remediated (G6/G7). Demo 7 north star PASS (unconditional, 2026-07-02). SCAN-028 complete (Clean, 2026-07-02).
 
 **Milestone 19 — Constraint Search and Empirical Calibration (Current)**
-Core deliverable: Mode 3 constraint-floor search capability; SEN/ZMB backtesting; empirically grounded CI intervals; PSP driver arc and auditability panel (DEMO-165/#1528). Demo 8 at M19 close.
+Core deliverable: Mode 3 constraint-floor search capability; SEN/ZMB backtesting; empirically grounded CI intervals; PSP driver arc and auditability panel (DEMO-165/#1528); CI label precision (#1529); scenarioId guard Zone 1B (#1456); ADR-007 meaninglessness threshold (#1536); BandResult visible fields (#1537); focal cohort floor validation (#1538). Demo 8 at M19 close.
 
 Full roadmap: `docs/roadmap/worldsim-roadmap.md`
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,16 @@ governance); Mode 3 Active Control enables counter-scenario branching for
 negotiation support.
 
 **This tool is in active pre-release development.** The working software
-described below reflects Milestone 15 (ADR-017 Zone 1A Information Architecture;
-Layer 3 self-interpreting outputs in Zone 1B and Zone 1D; Path 1 approved source
-network; cohort disaggregation and political risk designs; grounding strip date
-accuracy; accessibility validated on 8GB/4-core target hardware). M16 is in
-active development.
+described below reflects Milestone 18 (CI bands on Zone 1A trajectories; PSP
+driver decomposition; counter-scenario comparison with distributional differential
+and CI bounds; control plane column Mode 2+3; Zone 3 auditability panel; Demo 7
+north star PASS unconditional, 2026-07-02). M19 is in active development.
 
 ---
 
 ## What's Built
 
-The working system at Milestone 15 (core components — not exhaustive):
+The working system at Milestone 18 (core components — not exhaustive):
 
 - **Simulation engine** — Event-driven graph in Python. The `Quantity` type
   system tracks `value: Decimal`, unit, variable type (STOCK/FLOW/RATIO/


### PR DESCRIPTION
## Summary

- **CLAUDE.md §What We Are Building First:** `SCAN-028 pending (EL-gated)` → `SCAN-028 complete (Clean, 2026-07-02)`
- **CLAUDE.md §Milestone Roadmap:** `SCAN-028 pending` → `SCAN-028 complete (Clean, 2026-07-02)`
- **CLAUDE.md M19 scope (both sections):** Added carry-forward issues from Socratic Agent TEST session: CI label precision (#1529), scenarioId guard (#1456), ADR-007 meaninglessness threshold (#1536), BandResult visible fields (#1537), focal cohort floor validation (#1538)
- **README.md §What It Is:** Stale "reflects Milestone 15 … M16 is in active development" → Milestone 18 / M19
- **README.md §What's Built:** "The working system at Milestone 15" → Milestone 18

## Why

SCAN-028 was filed and confirmed clean on 2026-07-02 as part of the M18 exit ceremony. The "pending" markers were accurate when written but the PR was opened before the scan completed. The README milestone markers were three milestones stale (M15 → M18).

## Test plan

- [ ] Verify no remaining "pending" references to SCAN-028 in CLAUDE.md
- [ ] Verify README §What It Is and §What's Built both reference M18
- [ ] Verify M19 scope lists in both CLAUDE.md sections include all five carry-forward issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)