### PR TITLE
chore(m19): record EL sprint plan approval — G1 sprint entries open

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > Historical state lives in `docs/process/session-archives/`.
 > Authority: `docs/process/sprint-group-isolation.md §SESSION_STATE.md Cockpit Card Protocol`.
 
-**Last updated:** 2026-07-02 (M19 creation ceremony complete — release/m19 cut, sprint plan updated to 22-issue roster; EL sign-off on sprint plan pending before G1 sprint entries open)
+**Last updated:** 2026-07-02 (M19 sprint plan EL-approved; pre-wave + G1 sprint entries open; ADR decision on constraint-floor search required before G1 sprint entry filed)
 **Current milestone:** M19 — Constraint Search and Empirical Calibration
 
 ---
@@ -19,8 +19,8 @@
 | GitHub Milestone | #21 — created 2026-07-02 |
 | Exit checklist issue | #1535 (M19 Exit Checklist — blocks milestone closure) |
 | Release branch | `release/m19` — cut from `main` 2026-07-02 at 1bf1ecc |
-| Sprint plan | `docs/process/sprint-plans/m19-sprint-plan.md` — filed 2026-07-02; EL approval pending |
-| Active wave | None — M19 kickoff; EL sprint plan approval required before G1 opens |
+| Sprint plan | `docs/process/sprint-plans/m19-sprint-plan.md` — EL-approved 2026-07-02 |
+| Active wave | Pre-wave — #1456, #1538, #1532 in progress |
 | Active sprint groups | None |
 | Active sprint journal issues | None |
 
@@ -30,9 +30,7 @@
 
 | Decision | Status |
 |---|---|
-| M19 sprint plan approval | Pending EL — required before G1 sprint entries open |
-| ADR decision: constraint-floor search — new ADR-020 or ADR-019 amendment? | Pending Architect + EL — required before G1 sprint entry |
-| Close #1340 (M18 Exit Checklist) | Pending EL — all exit conditions now satisfied |
+| ADR decision: constraint-floor search — new ADR-020 or ADR-019 amendment? | Pending Architect + EL — required before G1 sprint entry is filed |
 
 ---
 

--- a/docs/process/sprint-plans/m19-sprint-plan.md
+++ b/docs/process/sprint-plans/m19-sprint-plan.md
@@ -2,10 +2,10 @@
 name: m19-sprint-plan
 type: sprint-plan
 milestone: M19 — Constraint Search and Empirical Calibration
-status: filed 2026-07-02; EL approval pending
+status: EL-approved 2026-07-02; pre-wave and G1 sprint entries open
 authored-by: PM Agent
 authored-date: 2026-07-02
-el-approved: pending
+el-approved: 2026-07-02
 consulted-agents:
   - Business Product Owner (Demo 8 value prioritization; constraint-floor capability as Act 1 anchor; backtesting scope)
   - Computation Engine Agent (Bayesian posterior dependency chain; backtesting fixture sequencing; constraint-floor search algorithm)
@@ -17,7 +17,7 @@ sop-reference: docs/process/sprint-planning-sop.md
 
 # M19 Sprint Plan — Constraint Search and Empirical Calibration
 
-**Status:** Filed 2026-07-02 — EL approval required before G1 sprint entries open
+**Status:** EL-approved 2026-07-02 (#1535 comment) — pre-wave and G1 sprint entries open
 **Release branch:** `release/m19` — cut from `main` 2026-07-02 at commit 1bf1ecc (after doc corrections PR #1539)
 **Exit checklist issue:** #1535 (M19 Exit Checklist — blocks milestone closure)
 **GitHub Milestone:** #21


### PR DESCRIPTION
## Summary

Records EL approval of the M19 sprint plan.

- Sprint plan frontmatter: `el-approved: 2026-07-02`; status → EL-approved
- SESSION_STATE.md: sprint plan status updated; active wave → Pre-wave; open decisions reduced to ADR decision on constraint-floor search
- EL approval on record: #1535 comment

## What this unlocks

Pre-wave work (#1456 crash fix, #1538 floor schema, #1532 capital controls scope) and G1 sprint entries may now be filed. G1 sprint entry requires ADR decision on constraint-floor search (ADR-020 vs ADR-019 amendment) before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)