### PR TITLE
fix(zone1b): guard against missing scenarioId in comparison scenario map (#1456)

### DIFF
--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -1118,6 +1118,7 @@ export function MDAAlertPanelZone1B({
       {comparisonScenarios.length > 0 && (
         <div style={{ padding: "4px 6px" }}>
           {comparisonScenarios.map((sc) => {
+            if (!sc.scenarioId) return null;
             const slug = sc.scenarioId.replace(/^[a-z]{3}-/, "");
             const palette = SCENARIO_COMPARISON_PALETTE[sc.paletteIndex];
             const crossings = sc.thresholdCrossings ?? [];


### PR DESCRIPTION
## Summary

- Adds `if (!sc.scenarioId) return null` guard at the top of the `comparisonScenarios.map()` in `MDAAlertPanelZone1B.tsx` before the `.replace()` call
- Prevents `TypeError: Cannot read properties of undefined (reading 'replace')` when a `ScenarioComparisonConfig` entry is missing `scenarioId` (e.g., raw API objects passed with snake_case `scenario_id`)
- The TypeScript type already enforces the contract at compile time; this guard provides a runtime backstop so a malformed entry degrades to `null` rather than tearing down the Zone 1B panel

## Closes

Fixes #1456

## Pre-wave classification

Pre-wave fix — scope < one PR, no sprint entry required (per `docs/process/sprint-plans/m19-sprint-plan.md §Pre-wave`).

## Test plan

- [x] Frontend build gate passes (`npm run build` ✓)
- [ ] Existing E2E tests: `m18-g7-cohort-section.spec.ts`, `demo-narrated.spec.ts` — no Zone 1B regression (CI will run these)
- [ ] Manual: confirm that passing a well-formed `ScenarioComparisonConfig[]` via `__worldsim_setComparisonScenarios` still renders comparison scenarios correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)