### PR TITLE
fix(schema): add FocalCohortConfig model — enforce floor_value range on monitored_focal_cohorts (#1538)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -344,6 +344,24 @@ class CommodityShockConfig(BaseModel):
         return str(v)
 
 
+class FocalCohortConfig(BaseModel):
+    """Schema-validated focal cohort entry for CLEAR badge floor comparison (#1538).
+
+    `indicator_key` must reference a known indicator in the scenario context.
+    `floor_value` is a ratio in (0, 1] — the threshold below which the cohort
+    is considered to have fallen below the CM-endorsed recovery floor.
+    `recovery_horizon_years` defaults to the CM-reviewed value of 10 years.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    indicator_key: str
+    floor_value: float = Field(gt=0, le=1)
+    floor_label: str = ""
+    framework: str = "human_development"
+    recovery_horizon_years: int = Field(default=10, ge=1, le=50)
+
+
 class ScenarioConfigSchema(BaseModel):
     """Scenario configuration payload.
 
@@ -396,7 +414,7 @@ class ScenarioConfigSchema(BaseModel):
     commodity_price_shocks: list[CommodityShockConfig] = []
     projection_steps: int | None = Field(default=None, ge=1, le=100)
     ecological_shock_coefficient: float = Field(default=0.0, ge=0.0, le=1.0)
-    monitored_focal_cohorts: list[dict[str, Any]] = []
+    monitored_focal_cohorts: list[FocalCohortConfig] = []
 
 
 class ScheduledInputSchema(BaseModel):


### PR DESCRIPTION
## Summary

- Defines `FocalCohortConfig(BaseModel)` in `backend/app/schemas.py` to replace the unvalidated `list[dict[str, Any]]` in `ScenarioConfigSchema.monitored_focal_cohorts`
- Enforces `floor_value in (0, 1]` — prevents out-of-range floor values from reaching the CLEAR badge comparison in Mode 3
- `recovery_horizon_years` validated in `[1, 50]`, default 10 (the CM-reviewed value hardcoded in `HumanCapitalTrajectoryPanel.tsx:23`)
- `floor_label` and `framework` are optional with defaults for full backwards compatibility with existing E2E fixture payloads
- `floor_value` serializes as `float` (not `Decimal` string) to match the frontend's `floor_value: number` type — `focal.floor_value.toFixed(3)` continues to work

## Deliberation note: float vs Decimal

The issue spec says `floor_value: Decimal`. However, Pydantic v2.9 serializes `Decimal` as a string in JSON mode, and the frontend component (`CohortImpactSection`) calls `.toFixed(3)` on `focal.floor_value` (a `number` method). Using `float` is consistent with `fiscal_multiplier: float` and `ecological_shock_coefficient: float` in the same schema class. The range validation `gt=0, le=1` works identically on `float`.

## Closes

Fixes #1538

## Pre-wave classification

Pre-wave fix — prerequisite for #1540 (Mode 3 constraint-floor search, G1 Wave 1), per `docs/process/sprint-plans/m19-sprint-plan.md §Pre-wave`.

## Test plan

- [x] `ruff check` + `mypy app/` clean
- [x] Manual validation: `floor_value=0` rejected, `floor_value=1.5` rejected, `floor_value=1.0` accepted, JSON serializes as `float 0.4`
- [x] `ScenarioConfigSchema` coerces existing E2E fixture dicts to `FocalCohortConfig` instances correctly
- [ ] CI: existing E2E tests (`m18-g7-cohort-section.spec.ts`, `demo-narrated.spec.ts`) pass (no change to the API payload shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)