### PR TITLE
docs(ux): address UX Designer Concerns 1–3 from ADR-021 sign-off

### DIFF
--- a/docs/adr/ADR-021-constraint-floor-search.md
+++ b/docs/adr/ADR-021-constraint-floor-search.md
@@ -564,17 +564,18 @@ fields below are required — a checkbox without the structured attestation is n
   control plane colors — blue `#0284c7`, orange `#ea580c`, and teal `#0d9488` — under
   deuteranopia and protanopia simulation. Blue-vs-teal distinguishability under
   deuteranopia must be confirmed with a simulation tool (Sim Daltonism, Coblis, or
-  equivalent). If not empirically distinguishable, a teal value with greater luminance
-  separation from blue must be selected and the ADR updated. The validation result must
-  be documented in the G1 sprint PR description. This is a hard gate per
-  `information-hierarchy.md §CVD Color Specification`.
+  equivalent). Blue/teal luminance contrast ratio is ~1.14:1, insufficient for luminance-
+  only discrimination; empirical hue simulation is required. If not empirically
+  distinguishable, a teal replacement is documented with candidates in
+  `information-hierarchy.md §CVD Color Specification` — update this ADR §D-1 with the
+  replacement hex value. Tracked: #1564.
 
 - **[Concern 2 — UX-1]** A new CI assertion (`AC-016`) must be added confirming that
   the Form 3 section header (`data-testid="constraint-search-section"`) is visible
   within the 280px column at 1280×800 with Forms 1 and 2 in minimum state (no history
   entries). At 1024×768, the assertion must verify Form 3 is reachable within one
   column-internal scroll from column top. This assertion must be in the same PR as the
-  Form 3 implementation — not filed as a follow-up.
+  Form 3 implementation — not filed as a follow-up. Tracked: #1563.
 
 ---
 

--- a/docs/ux/information-hierarchy.md
+++ b/docs/ux/information-hierarchy.md
@@ -668,24 +668,53 @@ trajectory = 1260px total, within the 1280px minimum viewport width.
 
 ### CVD (Colour Vision Deficiency) Color Specification
 
-The blue/orange distinction is an epistemic requirement. It must hold for users with
+The blue/orange/teal distinction is an epistemic requirement. It must hold for users with
 deuteranopia (red-green CVD, the most common form) and protanopia.
 
-| Role | Hex | Name | Use |
-|---|---|---|---|
-| Policy (blue) | `#0284c7` | Sky-700 | Policy form header, border, Apply button, trajectory inflection markers |
-| Shock (orange) | `#ea580c` | Orange-600 | Shock form header, border, Inject button, trajectory shock markers |
+| Role | Hex | Name | Relative luminance | Use |
+|---|---|---|---|---|
+| Policy (blue) | `#0284c7` | Sky-700 | 0.204 | Policy form header, border, Apply button, trajectory inflection markers |
+| Shock (orange) | `#ea580c` | Orange-600 | 0.247 | Shock form header, border, Inject button, trajectory shock markers |
+| Constraint search (teal) | `#0d9488` | Teal-600 | 0.232 | Form 3 (CONSTRAINT SEARCH) header, border, search button (ADR-021, M19+) |
 
-These two values are safe under deuteranopia and protanopia simulations: they differ
+The blue/orange pair is safe under deuteranopia and protanopia simulations: they differ
 in hue (blue vs. orange/yellow region) and in luminance (sky-700 is darker than
 orange-600 at 100% opacity), providing both hue and luminance discrimination channels.
 
+**Blue/teal requires empirical CVD validation before Form 3 ships (MV-001 extension).**
+Teal `#0d9488` (luminance 0.232) and blue `#0284c7` (luminance 0.204) have a luminance
+contrast ratio of approximately 1.14:1 — insufficient for luminance-only discrimination.
+Under deuteranopia simulation, both teal and blue shift into a similar blue-spectrum
+appearance, and hue discrimination between them may be impaired. They also share spatial
+proximity in the 280px column (Form 3 is directly below Forms 1 and 2), reducing the
+spatial discrimination channel available for orange.
+
+The UX Designer must run blue vs. teal through a CVD simulation tool (Sim Daltonism,
+Coblis, or equivalent) under deuteranopia and protanopia before Form 3 ships. If blue
+and teal are not empirically distinguishable under deuteranopia simulation, a replacement
+must be selected from the following candidate alternatives (mathematical analysis only —
+empirical verification still required):
+
+| Candidate | Hex | Relative luminance | Notes |
+|---|---|---|---|
+| Teal-500 (lighter) | `#14b8a6` | ~0.380 | Greater luminance contrast from blue (1.86:1); may be too light for column header context |
+| Cyan-700 | `#0e7490` | ~0.159 | Darker than blue; hue is further from blue-green mid-range |
+| Emerald-700 | `#047857` | ~0.079 | High luminance contrast from blue (2.59:1); hue clearly green — distinguishable under deuteranopia |
+
+If the empirical result confirms teal `#0d9488` passes CVD validation, no change to the ADR
+is required. If it fails, the UX Designer selects the replacement value and updates ADR-021 §D-1
+before the G1 sprint branch opens. The updated value cascades to all Form 3 styling tokens.
+
+Non-color disambiguation for Form 3: label text (CONSTRAINT SEARCH), position (below
+Forms 1 and 2), and icon (if implemented) provide supplementary discrimination channels
+that reduce — but do not eliminate — the CVD risk if teal and blue are indistinguishable.
+
 **MV-001 validation is a hard gate.** Manual CVD validation using a simulation tool
 (e.g., Sim Daltonism, Coblis) must be completed and documented before any Mode 3
-control plane component ships. The validation must confirm that both section headers
-and their respective form elements are distinguishable from each other under
-deuteranopia and protanopia simulation at all supported viewports. The MV-001 gate
-applies to both trajectory markers and alert panel treatment as well.
+control plane component ships. From M19 onward, the validation covers all three colors:
+blue vs. orange, orange vs. teal, and blue vs. teal. Each pair must be confirmed as
+distinguishable under deuteranopia and protanopia simulation at all supported viewports.
+The MV-001 gate applies to both trajectory markers and alert panel treatment as well.
 
 **Purple is deprecated for control plane elements.** The current `#8b5cf6` purple
 in `ControlPlane.tsx` does not satisfy the blue/orange requirement and must be

--- a/docs/ux/user-journeys.md
+++ b/docs/ux/user-journeys.md
@@ -388,10 +388,54 @@ is a strong argument; a Tier 5 breach requires an epistemic caveat.
 
 **Step 6 — Compare: build the counter-proposal evidence**
 
+*Step 6 has two sub-steps: 6a (boundary search, Mode 3) and 6b (comparison view, Mode 2).
+Sub-step 6a is available from M19 onward (ADR-021). Before M19, skip to 6b.*
+
+---
+
+**Step 6a — Boundary search: find the parameter floor before constructing the counter-proposal**
+*(ADR-021 — available M19+)*
+
+Before constructing the counter-proposal scenario, Eleni uses Mode 3
+constraint-floor search to establish the parameter value at which the focal
+cohort crosses its threshold. This replaces trial-and-error scenario
+construction: she finds the boundary first, then builds the scenario around it.
+
+From Mode 2 (after completing Steps 3–5), she clicks "Enter Active Control"
+to switch to Mode 3. Because she has not applied any Form 1 (policy
+instrument) or Form 2 (scenario shock) inputs in this Mode 3 session, the
+"reset active branch" caution in the transition dialog does not apply — there
+is no active branch to reset.
+
+In Form 3 (CONSTRAINT SEARCH), she selects the focal cohort indicator with the
+shallowest floor from Step 4 (e.g., "Primary education enrolment rate, floor ≥
+0.85") and clicks "Find safe boundary." The backend binary search runs
+approximately 8–9 engine evaluations against that floor. The result appears:
+"fiscal multiplier ≥ 1.18 (±0.01) | 9 evaluations | [0.1, 3.0] searched".
+
+She notes the boundary value, then clicks "Return to Mode 2." The transition
+resets the Mode 3 branch state. No inputs were applied, so nothing is lost.
+
+The boundary value (1.18) now informs her parameter choices for the counter-
+proposal scenario she builds in Step 6b.
+
+*Critical constraint:* The boundary search result must display before the
+30-second HTTP timeout fires. The result must be readable and copyable for
+manual entry into the counter-proposal scenario's parameter inputs.
+
+*Exit from Step 6a:* She knows the minimum parameter value that avoids the
+focal cohort threshold crossing under the scenario conditions she has been
+analyzing.
+
+---
+
+**Step 6b — Comparison view: validate the counter-proposal**
+
 She creates a second scenario modeling an alternative path — the same fiscal
 outcome but with softer conditionality on the terms most likely to cross
 thresholds (e.g., a more gradual consolidation in year 2, or protection of
-a specific social expenditure floor).
+a specific social expenditure floor). The boundary value from Step 6a anchors
+her parameter choices.
 
 She uses compare mode (COMPARE_VIEW with DeltaChoropleth) to visualize the
 divergence between the two scenarios geographically, then opens the entity
@@ -404,7 +448,8 @@ for the primary scenario (it is, per ui-state-machine.md).
 
 *Exit from this step:* She has two scenarios — the original proposal and her
 counter-proposal — with documented threshold crossings in the former and
-fewer/later crossings in the latter.
+fewer/later crossings in the latter. The counter-proposal parameters are
+anchored to the constraint-floor boundary, not arbitrary intuition.
 
 ---
 
@@ -1417,7 +1462,8 @@ Phase 3 inputs for the DIC architectural review.
 | A — Preparation Step 3b | Mode 2 | SCENARIO_RUNNING | Trajectory view + MDA alert panel | EL Decision 2 viewport |
 | A — Preparation Step 4 | Mode 2 | SCENARIO_RUNNING / COMPLETE | MDA alert panel | ADR-006 Decision 5 composite alert |
 | A — Preparation Step 5 | Mode 2 | DRAWER_DATA | FrameworkPanel + cohort breakdown | ADR-006 Decision 4 sibling fields |
-| A — Preparation Step 6 | Mode 2 | COMPARE_VIEW (single-entity) | Divergence timeline | EL Decision 3 |
+| A — Preparation Step 6a | Mode 3 | MODE_3_ACTIVE | ControlPlaneColumn Form 3 (constraint search) | ADR-021 D-1, D-2, D-3 (M19+) |
+| A — Preparation Step 6b | Mode 2 | COMPARE_VIEW (single-entity) | Divergence timeline | EL Decision 3 |
 | B — Negotiation Step 2 | Mode 3 | SCENARIO_PRELOADED | Instrument cluster (instant load) | currentStep ?? fallback |
 | B — Negotiation Step 3 | Mode 3 | DRAWER_DATA | MDA alert panel | ADR-006 Decision 5 alert_source |
 | B — Negotiation Step 4 | Mode 3 | DRAWER_DATA | ia1_disclosure text | ADR-006 Decision 13 canonical phrase |


### PR DESCRIPTION
## Summary

Resolves the three UX Designer concerns filed against ADR-021 before the EL acceptance vote proceeds.

## Concern 3 (pre-implementation — resolved) ✓

**Was:** `user-journeys.md §Journey A Step 6` did not document the Mode 2→Mode 3→Form 3→Mode 2 boundary-establishment sub-workflow. UX-7 "closes Journey A Step 6" was ungrounded.

**Resolution:**
- Step 6 restructured into Step 6a (boundary search, Mode 3, ADR-021 M19+) and Step 6b (comparison view, Mode 2)
- Step 6a documents the Preparatory-state sub-workflow; clarifies "reset active branch" caution does not apply when no Form 1/2 inputs have been made
- Journey Dependency Map: new row for Step 6a with `ADR-021 D-1, D-2, D-3` dependency

## Concern 1 (pre-ship — formally tracked) #1564

**Was:** MV-001 gate only covered blue/orange. Teal `#0d9488` vs blue `#0284c7` never validated. Luminance contrast ratio ~1.14:1 — insufficient for luminance-only discrimination.

**Resolution:**
- `information-hierarchy.md §CVD Color Specification` updated: luminance analysis for all three colors, candidate replacement teals documented (Teal-500 `#14b8a6`, Cyan-700 `#0e7490`, Emerald-700 `#047857`), MV-001 gate explicitly extended to all three pairs
- The question of whether `#0d9488` passes empirical deuteranopia simulation is still open — the table + analysis is in place so the G1 implementing agent knows exactly what to validate and what to do if it fails
- ADR-021 pre-ship condition updated with #1564 reference

## Concern 2 (pre-ship — formally tracked) #1563

**Was:** No tracked AC-016 assertion requirement.

**Resolution:**
- GitHub issue #1563 filed with precise acceptance criteria (viewport sizes, scroll conditions, same-PR requirement)
- ADR-021 pre-ship condition updated with #1563 reference

## What remains for EL before acceptance vote

After this PR merges:
- **Concern 3 is closed** — Journey A Step 6 governing document is updated
- **Concerns 1 and 2 are tracked** — both have GitHub issues the G1 agent must satisfy pre-ship

The UX Designer sign-off permits the acceptance vote to proceed. These concerns do not block acceptance — they block G1 shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)