### PR TITLE
process(m19): file NM-086; correct NM-084 reference in SESSION_STATE.md

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -86,7 +86,8 @@
 - **sprint-branch-ci-gate Ruleset:** Node ID `RRS_lACqUmVwb3NpdG9yecc5IKi2kzgEV92A`. Requires `changes`, `lint`, `test-backend`, `compliance-scan`. (playwright-e2e not required — NM-076 context.)
 - **NM-075:** git worktrees must be allocated per sprint group (`git worktree add /tmp/<name> <branch>`) to prevent branch switches overwriting in-progress work.
 - **NM-076:** Before any testid rename, grep the full E2E corpus for the old testid; update E2E tests in the same PR. Rule in CODING_STANDARDS.md (PR #1439).
-- **NM-084:** E2E mock routes must be verified against `api_contracts.yml` before the implementation PR opens. Filed 2026-07-03. Process: QA Lead FA-confirmation open items are now blocking conditions on intent approval gate.
+- **NM-084/NM-085:** CM sign-off ordering gap + co-dependent fixture CI sequencing (G2B). SOP improvements filed: §Pre-Merge CM Review Gate + §Co-Dependent Fixture Sprint Entry Requirements.
+- **NM-086:** E2E mock routes must be verified against `api_contracts.yml` before the implementation PR opens (G1, filed 2026-07-03). Process: QA Lead mock-helper verification is a blocking checklist item on intent authorship.
 - **M18 complete (v0.18.0, 2026-07-02):** G1–G7 delivered; Demo 7 PASS (unconditional); release/m18 → main via PR #1534. Archive: `docs/process/session-archives/session-state-pre-m19.md`.
 - **Demo 7 north star (2026-07-02):** Aicha presents Zambia +342K cohort effect with CI bounds and sourcing to IMF restructuring table. Next available DEMO-167.
 - **Socratic TEST gaps (M19 scope):** #1536 (meaninglessness threshold), #1537 (BandResult visible fields), #1538 (focal cohort floor validation) — all filed 2026-07-02, assigned M19.

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -4255,6 +4255,37 @@ Codify the documentation requirement in `docs/process/sprint-planning-sop.md §C
 
 ---
 
+## NM-086 — E2E Mock Route Not Verified Against `api_contracts.yml`; CI Caught Contract Mismatch That Pre-Push Gate Missed (Reactive)
+
+**Date:** 2026-07-03
+**Milestone:** M19 — Constraint Search and Empirical Calibration
+**Detected by:** G1 E2E CI failure (PR #1574); `mode3-constraint-floor.spec.ts` mock helpers used incorrect route shape not matching `api_contracts.yml`
+**Severity:** Medium — E2E tests failed in CI rather than silently passing with a wrong mock; no incorrect analytical output reached users. Pre-push gate (`npm run build`) passed because the build does not exercise E2E mocks.
+
+### What happened
+
+The G1 E2E spec (`frontend/tests/e2e/m19-g1-constraint-floor-search.spec.ts`) was authored with mock helpers that did not match the actual API contract for the constraint-floor search endpoint. The discrepancy was caught when E2E tests ran in CI on PR #1574. A follow-up fix PR (#1579) corrected the mock helpers against `api_contracts.yml`.
+
+The implementing agent did not read `api_contracts.yml` before authoring the E2E mock helpers, despite the schema registry rule in CLAUDE.md requiring this for any agent calling or implementing an API endpoint.
+
+### What was at risk
+
+If E2E tests had been authored to soft-skip or if the CI E2E job had been non-required at the time, the incorrect mock helpers would have merged and future test authors would have copied them — propagating a contract mismatch that silently passes while testing the wrong behaviour.
+
+### What caught it
+
+CI (E2E job on PR #1574). The pre-push hook (`npm run build`) passed because TypeScript compilation does not catch runtime mock shape mismatches. Local E2E execution would have caught it, but was not run before push.
+
+### Process improvement
+
+**QA Lead obligation at intent authorship:** When authoring E2E test files for endpoints that have entries in `api_contracts.yml`, the QA Lead must include a checklist item in the intent document confirming that mock helper shapes were verified against `api_contracts.yml` before the test file is filed. The checklist item is: "Mock helpers verified against `docs/schema/api_contracts.yml §[endpoint name]`? [yes/no]". A test file filed without this confirmation is flagged as incomplete by the PI Agent at sprint entry.
+
+**Implementing agent obligation:** Before opening any PR that adds or modifies E2E mock helpers, the implementing agent must grep `docs/schema/api_contracts.yml` for the relevant endpoint and confirm the mock shape matches. This is an extension of the existing schema registry rule in CLAUDE.md §Standards and Conventions.
+
+Codified in `docs/CODING_STANDARDS.md §E2E Mock Helper Authorship` as part of the G2C sprint entry, or earlier if a frontend-touching sprint opens first.
+
+---
+
 ## NM-NNN — [Short descriptive title]
 
 **Date:** YYYY-MM-DD (or approximate milestone era)


### PR DESCRIPTION
## NM numbering correction

NM-084 was already assigned to the CM sign-off ordering gap (G2B, filed in PR #1578).
The EL's SESSION_STATE.md carry-forward referenced "NM-084" for the E2E mock routes
finding (G1), using an already-taken number.

**Changes:**
- `docs/process/near-miss-registry.md` — NM-086 filed (E2E mock routes not verified against api_contracts.yml before implementation PR; caught by CI on PR #1574; fix in PR #1579)
- `SESSION_STATE.md` — carry-forward corrected: NM-084/NM-085 summary added, NM-086 reference replaces incorrect "NM-084" for the E2E mock routes finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)