### PR TITLE
docs(adr): EL accepts ADR-007 Amendment 1 — ARCH-016 cleared

### DIFF
--- a/docs/adr/ADR-007-synthetic-data-framework.md
+++ b/docs/adr/ADR-007-synthetic-data-framework.md
@@ -16,7 +16,7 @@ Accepted
 
 **Standards Version:** 2026-05-23 (Amendment 1: 2026-07-02)
 **Valid Until:** Milestone 13 — Methodology Publication and Public Launch; Amendment 1 reviewed at M20 or on MAGNITUDE_MATCH trigger (whichever is first)
-**License Status:** ACCEPTED — 2026-05-23; Amendment 1: PROPOSED — 2026-07-02; panel conditions incorporated 2026-07-02 — pending EL acceptance
+**License Status:** ACCEPTED — 2026-05-23; Amendment 1: ACCEPTED — 2026-07-03 (EL acceptance; panel conditions incorporated 2026-07-02)
 
 **M12 exit review:** 2026-06-10 (SCAN-026). No renewal triggers fired during Milestone 12. The synthetic data framework was not implemented in M12 — ADR-007 `Quantity` schema fields (`is_synthetic`, `synthetic_method`, `comparison_group_id`, `holdout_validated`) remain unimplemented (Issue #22, now deferred to M13). No sixth method proposed, holdout validation gate unchanged, confidence tier max() arithmetic unchanged, meaninglessness threshold unchanged, anomaly detection governance constraints unchanged. Implementation pressure now carries to M13 as a first-order obligation: M13's methodology publication scope makes the synthetic data framework a pre-publication requirement — undocumented synthetic fields block the methodology transparency commitment. License renewed to Milestone 13.
 
@@ -836,12 +836,12 @@ uncertainty, but grounding it in evidence.
 | Reviewer | Role | Status |
 |---|---|---|
 | Architect Agent | R — author | Complete ✓ (2026-07-02) |
-| Chief Methodologist (DIC) | C — posterior calibration method and coverage measurement protocol | Pending |
-| Computation Engine Agent | C — implementation of _classify_fidelity() gate and BandResult field additions | Pending |
-| UX Designer Agent | C — display contract for is_pre_calibration and band_method (#1537) | Pending |
-| Engineering Lead | A — final acceptance authority | Pending |
+| Chief Methodologist (DIC) | C — posterior calibration method and coverage measurement protocol | VALIDATE ✓ (2026-07-02) — conditions incorporated |
+| Computation Engine Agent | C — implementation of _classify_fidelity() gate and BandResult field additions | VALIDATE ✓ (2026-07-02) — CE Condition A gated on #1543 intent doc |
+| UX Designer Agent | C — display contract for is_pre_calibration and band_method (#1537) | CONSULT — no objection ✓ (2026-07-02) — Concerns 1+2 incorporated; Concern 3 gated on #1537 intent doc |
+| Engineering Lead | A — final acceptance authority | **ACCEPTED ✓ (2026-07-03)** |
 
-*Panel review artifact: `docs/adr/reviews/ADR-007-amendment-1-panel-review.md` (to be filed)*
+*Panel review artifact: `docs/adr/reviews/ADR-007-amendment-1-panel-review.md`*
 
 ---
 

--- a/docs/adr/reviews/ADR-007-amendment-1-panel-review.md
+++ b/docs/adr/reviews/ADR-007-amendment-1-panel-review.md
@@ -4,7 +4,7 @@ type: adr-panel-review
 adr: ADR-007 Amendment 1
 amendment: 1
 milestone: M19 — Constraint Search and Empirical Calibration
-status: In progress
+status: Accepted — 2026-07-03
 authored-date: 2026-07-02
 ---
 
@@ -90,7 +90,16 @@ Concerns 1+2 are INCORPORATE items. Concern 3 is a flag for #1537 intent doc. **
 
 ## Engineering Lead — Acceptance
 
-*[EL acceptance to be recorded here]*
+**Date:** 2026-07-03
+**Reviewing agent:** Engineering Lead (@PublicEnemage)
+
+All panel conditions are incorporated. CM Conditions A and B are in the amendment text (§8.4: C_mag floor `max(C_mag_t, 0.05)`, EVIDENCE_INSUFFICIENT guard, `affected_indicators_excluded` field, indicator-scoped evidence requirement). CE Condition B is in the amendment text (§8.4: CalibrationStore pattern, `_CALIBRATION_MULTIPLIERS` module-level dict, `set_calibration_multipliers()` override). CE Condition A and UX Concern 3 are gated on the #1543 and #1537 intent documents respectively — those intent documents cannot be filed until this acceptance is on record. UX Concerns 1 and 2 are in the amendment text (§8.7 enum stability clause; §8.8 suppressed CI slot placeholder "Data range too wide for confidence interval").
+
+**ARCH-016 accepted. Amendment 1 to ADR-007 is ACCEPTED as of 2026-07-03.**
+
+G3 BLOCKED_ADR is cleared. PI Agent to post gate comment on sprint journal #1587.
+
+— @PublicEnemage (Engineering Lead, 2026-07-03)
 
 ---
 
@@ -102,4 +111,4 @@ Concerns 1+2 are INCORPORATE items. Concern 3 is a flag for #1537 intent doc. **
 | Chief Methodologist | VALIDATE (conditional) | 2026-07-02 | Conditions A + B — INCORPORATE |
 | Computation Engine Agent | VALIDATE (conditional) | 2026-07-02 | Conditions A + B — scope gaps in #1543 intent doc |
 | UX Designer Agent | CONSULT — no objection | 2026-07-02 | Concerns 1+2 INCORPORATE; Concern 3 in #1537 intent doc |
-| Engineering Lead | Pending | — | — |
+| Engineering Lead | **ACCEPTED** | 2026-07-03 | All conditions incorporated or gated on intent docs |


### PR DESCRIPTION
## Summary

EL acceptance of ADR-007 Amendment 1 (ARCH-016) recorded 2026-07-03.

**Changes:**
- `docs/adr/ADR-007-synthetic-data-framework.md`: Amendment 1 License Status `PROPOSED → ACCEPTED`; panel sign-offs table filled with all verdicts
- `docs/adr/reviews/ADR-007-amendment-1-panel-review.md`: EL Acceptance section populated; vote summary `Pending → ACCEPTED`; frontmatter status updated

**What this unblocks:**
- G3 BLOCKED_ADR cleared — PI Agent to post gate comment on sprint journal #1587
- G3 intent documents (#1543, #1536, #1537) may now be filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)