### PR TITLE
process(m19-g2c): mark all CM advisories on record in sprint entry §2.2

### DIFF
--- a/docs/process/sprint-plans/m19-g2c-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-g2c-sprint-entry.md
@@ -107,13 +107,13 @@ For Sri Lanka (#1549), Pakistan (#1550), Turkey (#1551), Egypt (#1552), Ghana (#
 
 | Country | Issue | CM advisory on issue? | Feature PR may open? |
 |---|---|---|---|
-| Greece 2010–15 | #1547 | N/A — extends existing fixture | Yes, once EL approval recorded |
-| Argentina 2001 | #1548 | N/A — extends existing fixture | Yes, once EL approval recorded |
-| Sri Lanka 2022–23 | #1549 | Not yet — BLOCKING | No — CM advisory required first |
-| Pakistan 2022–23 | #1550 | Not yet — BLOCKING | No — CM advisory required first |
-| Turkey 2018–19 | #1551 | Not yet — BLOCKING | No — CM advisory required first |
-| Egypt 2016 | #1552 | Not yet — BLOCKING | No — CM advisory required first |
-| Ghana 2022–23 | #1554 | Not yet — BLOCKING | No — CM advisory required first |
+| Greece 2010–15 | #1547 | N/A — extends existing fixture | Yes — PR #1597 merged |
+| Argentina 2001 | #1548 | N/A — extends existing fixture | Yes — PR #1598 merged |
+| Sri Lanka 2022–23 | #1549 | Advisory on record 2026-07-03 — unblocked | Yes |
+| Pakistan 2022–23 | #1550 | Advisory on record 2026-07-03 — unblocked | Yes |
+| Turkey 2018–19 | #1551 | Advisory on record 2026-07-03 — unblocked | Yes |
+| Egypt 2016 | #1552 | Advisory on record 2026-07-03 — unblocked | Yes — MonetaryVolumeInput deserializer fix required first |
+| Ghana 2022–23 | #1554 | Advisory on record 2026-07-03 — unblocked | Yes — verify GHA entity; MonetaryVolumeInput optional (absence-of-input fallback accepted) |
 
 *Implementing agent must check the CM advisory column before opening each PR. Do not open a feature PR for a new-country scenario until the CM advisory comment is on the corresponding issue. This is an enforcement obligation, not advisory.*
 


### PR DESCRIPTION
## Summary

- Updates `docs/process/sprint-plans/m19-g2c-sprint-entry.md §2.2` pre-PR-open CM advisory table
- All five new-country CM advisories posted 2026-07-03 and are now on record
- Countries unblocked: Sri Lanka (#1549), Pakistan (#1550), Turkey (#1551), Egypt (#1552), Ghana (#1554)
- Residual gates noted per CM advisory: Egypt requires `MonetaryVolumeInput` deserializer fix; Ghana may use absence-of-input fallback

## CM advisory comment links

| Country | Issue | Comment |
|---|---|---|
| Sri Lanka | #1549 | #issuecomment-4872469004 |
| Pakistan | #1550 | #issuecomment-4872470995 |
| Turkey | #1551 | #issuecomment-4872473440 |
| Egypt | #1552 | #issuecomment-4872476659 |
| Ghana | #1554 | #issuecomment-4873838893 |

## Test plan
- [ ] No code changes — process document only
- [ ] CI lint and build gates pass (Python/TS unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)