### PR TITLE
feat(m19-g2c): Turkey 2018–19 Backside of Power Curve fixture + Type B tests (#1551)

### DIFF
--- a/backend/tests/backtesting/test_m19_g2c_scenario_runs.py
+++ b/backend/tests/backtesting/test_m19_g2c_scenario_runs.py
@@ -919,13 +919,139 @@ class TestPakistanTypeB:
             await asgi_client.delete(f"/api/v1/scenarios/{cf_id}")
 
 
-# Turkey (#1551) — TestTurkeyTypeB
-# ----------------------------------------
-# ACs: AC-1..5, AC-9, AC-10, AC-NC-2 (advisory), AC-NC-3, AC-TUR-1..3
-# Run: Type B
-# Primary indicator: fin_composite
-# Advisory: direction_verdict COUNTER_FACTUAL_BETTER
-# Add in: feat/m19-g2c-turkey-backside (after CM advisory on #1551)
+@pytest.mark.backtesting
+@pytest.mark.asyncio(loop_scope="session")
+class TestTurkeyTypeB:
+    """AC-1..5, AC-9, AC-10, AC-NC-2 (advisory), AC-NC-3, AC-TUR-1..3.
+
+    Type B: CB independence (rate hold) vs actual rate-cut path.
+    Backside of Power Curve canonical case. Skips without DATABASE_URL.
+    """
+
+    @pytest_asyncio.fixture(loop_scope="session")
+    async def asgi_client(self) -> AsyncGenerator[httpx.AsyncClient, None]:
+        if not _DATABASE_URL:
+            pytest.skip("DATABASE_URL not set — skipping Turkey Type B tests")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            yield client
+
+    async def test_construction(self, asgi_client: httpx.AsyncClient) -> None:
+        """AC-1, AC-2, AC-NC-3, AC-TUR-1: importable; entity=TUR; CF has no step-3/4 cuts."""
+        from tests.fixtures.turkey_2018_scenario import (
+            build_turkey_counterfactual_scenario,
+            build_turkey_scenario,
+        )
+
+        baseline = build_turkey_scenario()
+        cf = build_turkey_counterfactual_scenario()
+
+        assert baseline.configuration.entities[0] == "TUR"
+        assert cf.configuration.entities[0] == "TUR"
+        assert baseline.configuration.n_steps == 4
+        assert cf.configuration.n_steps == 4
+
+        # AC-TUR-1: counter-factual has no rate-cut inputs at Steps 3 and 4
+        cf_step3_cuts = [
+            s for s in (cf.scheduled_inputs or [])
+            if s.step in (3, 4) and s.input_type == "MonetaryRateInput"
+            and float(s.input_data.get("value", "0")) < 0
+        ]
+        assert not cf_step3_cuts, (
+            "AC-TUR-1 FAIL: counter-factual should have NO negative MonetaryRateInput "
+            f"at steps 3 or 4 (found {cf_step3_cuts!r}). "
+            "The CB independence path holds the rate at 24%."
+        )
+
+    async def test_type_b_run(self, asgi_client: httpx.AsyncClient) -> None:
+        """AC-3, AC-4, AC-5, AC-9, AC-10, AC-TUR-2/3: full Type B run."""
+        from tests.fixtures.turkey_2018_scenario import (
+            build_turkey_counterfactual_scenario,
+            build_turkey_scenario,
+        )
+
+        b_resp = await asgi_client.post(
+            "/api/v1/scenarios",
+            json=build_turkey_scenario().model_dump(mode="json"),
+        )
+        assert b_resp.status_code == 201, f"AC-3 FAIL: {b_resp.status_code}"
+        baseline_id: str = b_resp.json()["scenario_id"]
+
+        cf_resp = await asgi_client.post(
+            "/api/v1/scenarios",
+            json=build_turkey_counterfactual_scenario().model_dump(mode="json"),
+        )
+        assert cf_resp.status_code == 201, f"AC-3 FAIL: {cf_resp.status_code}"
+        cf_id: str = cf_resp.json()["scenario_id"]
+
+        try:
+            result = await run_harness(
+                scenario_id=cf_id,
+                steps=4,
+                run_type=RunType.TYPE_B,
+                control_inputs=[{} for _ in range(4)],
+                baseline_run_id=baseline_id,
+                primary_indicator="fin_composite",
+                http_client=asgi_client,
+            )
+
+            assert len(result.per_step_records) == 4
+            assert "direction_verdict" in result.summary
+            verdict = result.summary["direction_verdict"]
+            valid_verdicts = {
+                DirectionVerdict.COUNTER_FACTUAL_BETTER,
+                DirectionVerdict.BASELINE_BETTER,
+                DirectionVerdict.INDISTINGUISHABLE,
+            }
+            assert verdict in valid_verdicts or str(verdict) in {
+                str(v) for v in valid_verdicts
+            }
+
+            per_step_diff = result.summary.get("per_step_diff", [])
+            assert isinstance(per_step_diff, list) and len(per_step_diff) == 4
+
+            known = result.summary.get("known_limitations", [])
+            assert isinstance(known, list) and len(known) >= 1, "AC-5 FAIL"
+
+            tier3_found = any(
+                term in str(e)
+                for e in known
+                for term in ("Tier 3", "INFERRED_STRUCTURAL", "hypothetical")
+            )
+            if not tier3_found:
+                warnings.warn(
+                    "AC-9 advisory (TUR): no Tier 3 disclosure in known_limitations.",
+                    UserWarning, stacklevel=1,
+                )
+
+            # AC-TUR-2: direction advisory (expected CF_BETTER — rate hold better for FX)
+            _assert_direction_advisory(
+                actual=verdict,
+                expected=DirectionVerdict.COUNTER_FACTUAL_BETTER,
+                country="TUR",
+                indicator="fin_composite",
+            )
+
+            # AC-TUR-3: per_step_diff should diverge at step 3 (first cut)
+            if len(per_step_diff) >= 3:
+                step3_diff = per_step_diff[2]
+                step2_diff = per_step_diff[1]
+                if step3_diff is not None and step2_diff is not None:
+                    try:
+                        diverged = abs(float(step3_diff)) > abs(float(step2_diff))
+                    except (TypeError, ValueError):
+                        diverged = False
+                    if not diverged:
+                        warnings.warn(
+                            "AC-TUR-3 advisory (TUR): per_step_diff did not diverge "
+                            "at Step 3 (first rate cut). Expected step3 diff > step2 diff.",
+                            UserWarning, stacklevel=1,
+                        )
+        finally:
+            await asgi_client.delete(f"/api/v1/scenarios/{baseline_id}")
+            await asgi_client.delete(f"/api/v1/scenarios/{cf_id}")
 
 
 # Egypt (#1552) — TestEgyptTypeB

--- a/backend/tests/fixtures/turkey_2018_scenario.py
+++ b/backend/tests/fixtures/turkey_2018_scenario.py
@@ -1,0 +1,287 @@
+"""Turkey 2018–19 lira crisis — Backside of the Power Curve scenario fixture.
+
+Historical context:
+  Turkey 2018–19 is the cleanest available real-world example of the
+  Backside of the Power Curve failure mode in monetary policy.
+
+  Timeline modeled (4 quarterly steps):
+    2018 Q4 (Step 1): CBRT emergency rate hike to 24% (from 17.75%).
+      The hike was 625 basis points in one step (September 2018) following
+      the August 2018 currency crisis (TRY hit 7.24/USD). The hike initially
+      stabilised the lira but left Turkey on the wrong side of the power curve:
+      the rate was unsustainably high given the economy's structural inflation
+      and the political context.
+
+    2019 Q1 (Step 2): Hold. CBRT maintains 24% despite political pressure.
+      President Erdoğan publicly demanded rate cuts throughout Q1 2019,
+      calling for "logical rates". CBRT held through Q1 under Governor Çetinkaya.
+
+    2019 Q3 (Step 3): First rate cut −425 bps (24% → 19.75%).
+      Governor Çetinkaya was fired in July 2019 (first central bank governor
+      dismissed mid-term in modern Turkey). New governor Murat Uysal immediately
+      cut rates. This fired the Backside of the Power Curve and Hypoxia modes.
+
+    2019 Q4 (Step 4): Second rate cut −425 bps (19.75% → 14%).
+      Inflation remained above 8% throughout this period (12.3% in December 2019).
+      Rate cuts with sticky inflation deepened the TRY depreciation trajectory.
+
+Failure modes:
+  - Backside of the Power Curve: standard monetary transmission inverted —
+    rate cuts intended to stimulate growth instead accelerated TRY depreciation
+    and imported inflation, shrinking the real economy
+  - Hypoxia: CB independence compromised by executive pressure, impairing
+    the institution's capacity to make rate decisions on monetary grounds
+
+Counter-factual: maintain 24% rate (CB independence path).
+  Steps 3–4: no rate cuts. GovernanceModule institutional_capacity_index
+  is not degraded by the Hypoxia trigger since CB remains independent.
+
+Simulation structure:
+  build_turkey_scenario(): n_steps=4, quarterly. Actual rate-cut path.
+  build_turkey_counterfactual_scenario(): n_steps=4, quarterly. Rate hold path.
+
+Initial state sources (mid-2018, pre-crisis):
+  gdp_growth         — IMF WEO April 2018 (TUR 2018 est: 4.2%)
+  unemployment_rate  — TUIK Household Labour Force Survey H1 2018 (10.2%)
+  sovereign_risk_premium — JP Morgan EMBI+ TUR August 2018 pre-hike (~320 bps)
+  fdi_stock_pct_gdp  — UNCTAD WIR 2018 (TUR: ~18.8%)
+  portfolio_flow_velocity — CBRT BOP 2018 H1 (outflow ~-0.04)
+  credit_rating_score — Fitch BB- end-2018. 21-notch linear: BB- = 26.
+  reserve_coverage_months — CBRT 2018 H1: ~4.5 months
+  inflation_rate     — TUIK CPI August 2018: 17.9%
+
+References: Issue #1551; CM advisory 2026-07-03.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from app.schemas import (
+    QuantitySchema,
+    ScenarioConfigSchema,
+    ScenarioCreateRequest,
+    ScheduledInputSchema,
+)
+
+
+def build_turkey_scenario() -> ScenarioCreateRequest:
+    """Build Turkey 2018–19 actual rate-cut baseline (Backside of Power Curve).
+
+    Returns a ScenarioCreateRequest ready to POST to /api/v1/scenarios.
+    4 quarterly steps: 2018 Q4 → 2019 Q1 → 2019 Q3 → 2019 Q4.
+    Step 1: emergency hike +6.25pp to 24%. Steps 3–4: rate cuts under pressure.
+    """
+    initial_gdp_growth = QuantitySchema(
+        value="0.042",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2018, 4, 1),
+        source_registry_id="IMF_WEO_APR2018_TUR",
+        measurement_framework="financial",
+    )
+
+    initial_unemployment_rate = QuantitySchema(
+        value="0.102",
+        unit="ratio",
+        variable_type="ratio",
+        confidence_tier=2,
+        observation_date=date(2018, 6, 30),
+        source_registry_id="TUIK_HLFS_TUR_2018H1",
+        measurement_framework="human_development",
+    )
+
+    # CBRT: reserve coverage mid-2018 ~4.5 months (gross)
+    initial_reserve_coverage_months = QuantitySchema(
+        value="4.5",
+        unit="months",
+        variable_type="stock",
+        attribute_type="stock",
+        confidence_tier=2,
+        observation_date=date(2018, 6, 30),
+        source_registry_id="CBRT_RESERVES_TUR_2018H1",
+        measurement_framework="financial",
+    )
+
+    # JP Morgan EMBI+ TUR August 2018 pre-emergency-hike: ~320 bps
+    initial_sovereign_risk_premium = QuantitySchema(
+        value="0.032",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="rate",
+        confidence_tier=2,
+        observation_date=date(2018, 8, 31),
+        source_registry_id="JPMORGAN_EMBI_TUR_2018Q3",
+        measurement_framework="financial",
+    )
+
+    # UNCTAD WIR 2018 — TUR inward FDI stock / GDP: ~18.8%
+    initial_fdi_stock_pct_gdp = QuantitySchema(
+        value="0.188",
+        unit="ratio",
+        variable_type="stock",
+        attribute_type="stock",
+        confidence_tier=2,
+        observation_date=date(2018, 1, 1),
+        source_registry_id="UNCTAD_WIR_TUR_2018",
+        measurement_framework="financial",
+    )
+
+    # CBRT BOP 2018 H1: significant portfolio outflow (~-4% GDP)
+    initial_portfolio_flow_velocity = QuantitySchema(
+        value="-0.040",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="flow",
+        confidence_tier=2,
+        observation_date=date(2018, 6, 30),
+        source_registry_id="CBRT_BOP_TUR_2018H1",
+        measurement_framework="financial",
+    )
+
+    # Fitch BB- end-2018 (downgraded from BB in August 2018). 21-notch scale: BB- = 26.
+    initial_credit_rating_score = QuantitySchema(
+        value="26.0",
+        unit="index_0_100",
+        variable_type="stock",
+        attribute_type="structural_index",
+        confidence_tier=1,
+        observation_date=date(2018, 12, 31),
+        source_registry_id="FITCH_SOVEREIGN_RATINGS_TUR_2018",
+        measurement_framework="financial",
+    )
+
+    # TUIK CPI August 2018: 17.9% YoY (peaked at this point)
+    initial_inflation_rate = QuantitySchema(
+        value="0.179",
+        unit="ratio",
+        variable_type="ratio",
+        attribute_type="rate",
+        confidence_tier=1,
+        observation_date=date(2018, 8, 31),
+        source_registry_id="TUIK_CPI_TUR_AUG2018",
+        measurement_framework="financial",
+    )
+
+    return ScenarioCreateRequest(
+        name="Turkey 2018-19 Lira Crisis — Backside of Power Curve Baseline",
+        description=(
+            "Backtesting fixture for Issue #1551. "
+            "Turkey 2018–19: emergency rate hike to 24% (Step 1) → hold (Step 2) "
+            "→ rate cuts under political pressure after CB governor fired (Steps 3–4). "
+            "Backside of Power Curve: rate cuts with 8–12% inflation deepen TRY depreciation. "
+            "Hypoxia: institutional_capacity_index degraded by CB independence compromise. "
+            "Type B primary indicator: fin_composite. "
+            "Initial state: IMF WEO April 2018 + TUIK HLFS 2018H1 + CBRT data."
+        ),
+        configuration=ScenarioConfigSchema(
+            entities=["TUR"],
+            n_steps=4,
+            timestep_label="quarterly",
+            start_date=date(2018, 9, 1),
+            step_metadata={
+                "1": {"significance": "SIGNIFICANT", "label": "Emergency hike to 24%"},
+                "2": {"significance": "SIGNIFICANT", "label": "Hold under pressure"},
+                "3": {"significance": "SIGNIFICANT", "label": "First cut / governor fired"},
+                "4": {"significance": "SIGNIFICANT", "label": "Second cut / Hypoxia deepens"},
+            },
+            initial_attributes={
+                "TUR": {
+                    "gdp_growth": initial_gdp_growth,
+                    "unemployment_rate": initial_unemployment_rate,
+                    "reserve_coverage_months": initial_reserve_coverage_months,
+                    "sovereign_risk_premium": initial_sovereign_risk_premium,
+                    "fdi_stock_pct_gdp": initial_fdi_stock_pct_gdp,
+                    "portfolio_flow_velocity": initial_portfolio_flow_velocity,
+                    "credit_rating_score": initial_credit_rating_score,
+                    "inflation_rate": initial_inflation_rate,
+                },
+            },
+        ),
+        scheduled_inputs=[
+            # Step 1 (2018 Q4): Emergency CBRT hike +625 bps from 17.75% → 24%.
+            ScheduledInputSchema(
+                step=1,
+                input_type="MonetaryRateInput",
+                input_data={
+                    "instrument": "policy_rate",
+                    "target_entity": "TUR",
+                    "value": "0.0625",
+                    "duration_periods": 2,
+                },
+            ),
+
+            # Step 2 (2019 Q1): Hold. No new inputs — CBRT maintains 24%.
+
+            # Step 3 (2019 Q3): First rate cut −425 bps (24% → 19.75%).
+            # Governor Çetinkaya fired; new governor Uysal immediately cuts.
+            ScheduledInputSchema(
+                step=3,
+                input_type="MonetaryRateInput",
+                input_data={
+                    "instrument": "policy_rate",
+                    "target_entity": "TUR",
+                    "value": "-0.0425",
+                    "duration_periods": 1,
+                },
+            ),
+
+            # Step 4 (2019 Q4): Second cut −425 bps (19.75% → 14%).
+            ScheduledInputSchema(
+                step=4,
+                input_type="MonetaryRateInput",
+                input_data={
+                    "instrument": "policy_rate",
+                    "target_entity": "TUR",
+                    "value": "-0.0425",
+                    "duration_periods": 1,
+                },
+            ),
+        ],
+    )
+
+
+def build_turkey_counterfactual_scenario() -> ScenarioCreateRequest:
+    """Build Turkey counter-factual: CB independence path (rate hold at 24%).
+
+    Counter-factual question: does maintaining the 24% rate (CB independence
+    path) produce meaningfully better exchange rate stability and reserve
+    protection than the actual rate-cut sequence?
+
+    At what step does the rate-cut path enter regime-dependent deterioration?
+
+    Structural differences from baseline:
+    - Steps 3–4: NO rate cuts (hold at 24%)
+    - GovernanceModule: no CB governor removal; institutional_capacity_index
+      not degraded (no Hypoxia trigger in counter-factual)
+
+    AC-TUR-1: Steps 3 and 4 have no MonetaryRateInput scheduled inputs.
+    """
+    base = build_turkey_scenario()
+
+    return base.model_copy(update={
+        "name": "Turkey 2018-19 Counter-Factual — CB Independence Path (Rate Hold at 24%)",
+        "description": (
+            "Counter-factual for Issue #1551. "
+            "CBRT holds 24% rate through Steps 3–4 (CB independence maintained). "
+            "No Hypoxia trigger: institutional_capacity_index not degraded. "
+            "Type B primary indicator: fin_composite. "
+            "Direction advisory: COUNTER_FACTUAL_BETTER on reserve protection. "
+            "Known limitation: INFERRED_STRUCTURAL (Tier 3)."
+        ),
+        "scheduled_inputs": [
+            # Step 1: same emergency hike to 24%
+            ScheduledInputSchema(
+                step=1,
+                input_type="MonetaryRateInput",
+                input_data={
+                    "instrument": "policy_rate",
+                    "target_entity": "TUR",
+                    "value": "0.0625",
+                    "duration_periods": 4,
+                },
+            ),
+            # Steps 2–4: hold — no rate cut inputs. Counter-factual ends here.
+            # The CB independence path means no step 3 or step 4 rate change inputs.
+        ],
+    })


### PR DESCRIPTION
## Summary

- New `build_turkey_scenario()` and `build_turkey_counterfactual_scenario()` in `backend/tests/fixtures/turkey_2018_scenario.py`
- Baseline: emergency hike to 24% (Step 1) → hold (Step 2) → rate cuts after governor fired (Steps 3–4, Backside of Power Curve + Hypoxia)
- Counter-factual: hold at 24% (CB independence, no Hypoxia trigger)
- `TestTurkeyTypeB` class (2 methods), CM advisory on record: #issuecomment-4872473440

## Acceptance criteria

- [x] AC-TUR-1: counter-factual has no negative `MonetaryRateInput` at Steps 3–4
- [x] AC-5: `known_limitations` non-empty via TYPE_B Tier 3 disclosure
- [x] 13 tests SKIP without `DATABASE_URL` (NM-056 compliant)

Closes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)