### PR TITLE
feat(banding): M19 G3 #1537 — BandResult visible fields (band_method, is_meaningless, suppressed_reason)

### DIFF
--- a/backend/app/simulation/banding_engine.py
+++ b/backend/app/simulation/banding_engine.py
@@ -77,12 +77,16 @@ def _tier_multiplier(confidence_tier: int) -> Decimal:
 class BandResult:
     """Output of compute_band for a single framework point."""
 
-    ci_lower: str | None            # Decimal-as-string; None when composite_score is None
-    ci_upper: str | None            # Decimal-as-string; None when composite_score is None
+    ci_lower: str | None            # Decimal-as-string; None when suppressed or null score
+    ci_upper: str | None            # Decimal-as-string; None when suppressed or null score
     ci_coverage: float | None       # 0.80 or None
-    is_pre_calibration: bool | None # True or None
-    clipped_lower: bool                # True if max(natural_lower, raw_lower) fired
-    clipped_upper: bool                # True if min(natural_upper, raw_upper) fired
+    is_pre_calibration: bool | None # True or None (None when suppressed)
+    clipped_lower: bool             # True if max(natural_lower, raw_lower) fired
+    clipped_upper: bool             # True if min(natural_upper, raw_upper) fired
+    # Visible fields added M19 G3 #1537 — all defaulted for backwards compatibility
+    band_method: str | None = None  # frozen enum; None only on null-score path
+    is_meaningless: bool = False    # True when CI suppressed (full natural range)
+    suppressed_reason: str | None = None  # human-readable suppression reason
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +113,7 @@ def compute_band(
             is_pre_calibration=None,
             clipped_lower=False,
             clipped_upper=False,
+            band_method=None,
         )
 
     if framework not in _FRAMEWORK_BOUNDS:
@@ -121,6 +126,7 @@ def compute_band(
             is_pre_calibration=None,
             clipped_lower=False,
             clipped_upper=False,
+            band_method=None,
         )
 
     natural_lower, natural_upper = _FRAMEWORK_BOUNDS[framework]
@@ -150,4 +156,5 @@ def compute_band(
         is_pre_calibration=True,
         clipped_lower=clipped_lower,
         clipped_upper=clipped_upper,
+        band_method="PRE_CALIBRATION_STRUCTURAL_PRIOR",
     )


### PR DESCRIPTION
Closes #1537

## Summary

- Adds three new fields to `BandResult` dataclass in `backend/app/simulation/banding_engine.py`, all with defaults for backwards compatibility:
  - `band_method: str | None = None` — frozen enum string per ADR-007 §8.7
  - `is_meaningless: bool = False` — True when CI suppressed to full natural range
  - `suppressed_reason: str | None = None` — human-readable suppression message
- `compute_band()` normal return now sets `band_method="PRE_CALIBRATION_STRUCTURAL_PRIOR"`
- Null-score and unknown-framework paths set `band_method=None` explicitly
- Frozen enum values (locked from this PR forward — G4 #1529 depends on these strings): `"PRE_CALIBRATION_STRUCTURAL_PRIOR"`, `"PRE_CALIBRATION_PROVISIONAL_DIRECTIONAL"`, `"BAYESIAN_POSTERIOR_CALIBRATED"`, `"SUPPRESSED_MEANINGLESS"`

## Test plan

- [x] `test_m19_g3_bandresult_visible_fields.py` — 13/13 pass (all AC-01, AC-02, AC-08 assertions)
- [x] `test_m18_g1_ci_bands.py` — 40/40 unit tests pass; 2 pre-existing integration failures unrelated to this PR (mock `side_effect` exhausted by `_fetch_active_boundary_constants` added after fixture was written — KI on record)
- [x] ruff + mypy: PASS