### PR TITLE
feat(banding): M19 G3 #1536 — meaninglessness threshold suppression in compute_band()

### DIFF
--- a/backend/app/simulation/banding_engine.py
+++ b/backend/app/simulation/banding_engine.py
@@ -144,6 +144,31 @@ def compute_band(
     clipped_lower = ci_lower > raw_lower
     clipped_upper = ci_upper < raw_upper
 
+    # ADR-007 §6 Implementation Clause (Amendment 1): meaninglessness threshold.
+    # When the CI equals the full natural range at step >= 7, suppress. Use
+    # equality on the clipped values rather than the clipped_* flags because
+    # raw_upper can equal natural_upper exactly (e.g. score=0.4 × 2.5 = 1.0),
+    # which leaves clipped_upper=False while the CI still spans [0, 1].
+    if (
+        step_index >= 7
+        and ci_lower == natural_lower
+        and ci_upper == natural_upper
+    ):
+        return BandResult(
+            ci_lower=None,
+            ci_upper=None,
+            ci_coverage=None,
+            is_pre_calibration=None,
+            clipped_lower=True,
+            clipped_upper=True,
+            band_method="SUPPRESSED_MEANINGLESS",
+            is_meaningless=True,
+            suppressed_reason=(
+                f"CI spans full natural range [{natural_lower}, {natural_upper}]"
+                f" at step {step_index} T{confidence_tier} — directionally meaningless"
+            ),
+        )
+
     # Quantize to 4 decimal places (consistent with composite_score precision)
     quantizer = Decimal("0.0001")
     ci_lower_str = str(ci_lower.quantize(quantizer, rounding=ROUND_HALF_UP))


### PR DESCRIPTION
Closes #1536
Depends on: #1612 (BandResult visible fields — must merge first)

## Summary

Implements ADR-007 Amendment 1 §6: when a computed CI spans the entire natural framework range at `step_index >= 7`, the band is suppressed as directionally meaningless.

**Suppression condition:** `ci_lower == natural_lower AND ci_upper == natural_upper AND step_index >= 7`

Uses equality on clipped values (not `clipped_*` flags) because `raw_upper` can equal `natural_upper` exactly — e.g. score=0.4 at T5: `0.4 × 2.5 = 1.0`, leaving `clipped_upper=False` while the CI still spans [0, 1].

**Suppressed `BandResult`:** `ci_lower=None`, `ci_upper=None`, `ci_coverage=None`, `is_pre_calibration=None`, `band_method="SUPPRESSED_MEANINGLESS"`, `is_meaningless=True`, `suppressed_reason` includes natural bounds and step/tier context.

**Firing table (financial/HD [0,1]):**
- T5 step ≥ 7: suppresses for scores in [0.4, 0.8] and beyond ✓
- T3 step 7: does NOT suppress (half_width=0.75, CI=[0.125, 0.875]) ✓
- T5 step 6: does NOT suppress (step < 7 guard) ✓
- Single-clip (score near 0 or 1): does NOT suppress ✓

## Test plan

- [x] `test_m19_g3_meaninglessness_threshold.py` — 22/22 pass (AC-01 through AC-06)
- [x] `test_m19_g3_bandresult_visible_fields.py` — 13/13 pass
- [x] `test_m18_g1_ci_bands.py` — 40/40 unit tests pass; 2 pre-existing integration failures unrelated to this PR
- [x] ruff + mypy: PASS