### PR TITLE
fix(zone1a/zone1b): CI label precision — ci-calibration-status + declared interval (#1529)

### DIFF
--- a/frontend/src/components/MDAAlertPanelZone1B.tsx
+++ b/frontend/src/components/MDAAlertPanelZone1B.tsx
@@ -798,7 +798,13 @@ export function DistributionalComparisonSummary({ summary }: { summary: Distribu
               </span>
             </div>
             <div style={{ fontSize: 11, color: "#6b7280" }}>
-              {`${_formatK(ciLow)} – ${_formatK(ciHigh)}  95% CI`}
+              {`${_formatK(ciLow)} – ${_formatK(ciHigh)}  `}
+              <span
+                data-testid="distributional-ci-label"
+                title="Structural uncertainty model — BandingEngine step-based schedule; not a frequentist confidence interval. See methodology panel for details."
+              >
+                declared interval
+              </span>
             </div>
           </div>
         );

--- a/frontend/src/components/ScenarioInstrumentCluster.tsx
+++ b/frontend/src/components/ScenarioInstrumentCluster.tsx
@@ -62,6 +62,8 @@ interface RawFrameworkPoint {
   psp_dominant_driver?: string | null;
   /** M18-G7-D — note from API (e.g. "Ecological disabled for SEN Demo 7 Act 1"). */
   note?: string | null;
+  /** M19-G3 (#1537) / G4 (#1529): BandingEngine calibration state for CI display. */
+  band_method?: string | null;
 }
 
 interface RawTrajectoryStep {
@@ -118,6 +120,7 @@ function parseTrajectoryResponse(raw: RawTrajectoryResponse): TrajectoryResponse
           ),
           psp_dominant_driver: fw.psp_dominant_driver ?? null,
           note: fw.note ?? null,
+          band_method: fw.band_method ?? null,
         };
       }
       const pmm =

--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -203,6 +203,8 @@ export interface MergedStepDatum {
   ecological_ci_upper: number | null;
   governance_ci_lower: number | null;
   governance_ci_upper: number | null;
+  /** M19-G3 (#1537) / G4 (#1529): BandingEngine calibration state for CI display. */
+  financial_band_method: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +268,7 @@ export function mergeTrajectories(
       ecological_ci_upper: ci("ecological", "ci_upper"),
       governance_ci_lower: ci("governance", "ci_lower"),
       governance_ci_upper: ci("governance", "ci_upper"),
+      financial_band_method: step.frameworks["financial"]?.band_method ?? null,
     };
   });
 }
@@ -1300,6 +1303,35 @@ export const TrajectoryView = React.memo(function TrajectoryView({
           comparison is not valid.
         </div>
       )}
+
+      {/* M19-G3 (#1537) / G4 (#1529): CI calibration status disclosure (ADR-007 Amendment 1 §8.7).
+          Absent when band_method is SUPPRESSED_MEANINGLESS (CI bounds hidden per G3 §4). */}
+      {(() => {
+        const lastStep = mergedData[mergedData.length - 1];
+        const bandMethod = lastStep?.financial_band_method ?? null;
+        if (!bandMethod || bandMethod === "SUPPRESSED_MEANINGLESS") return null;
+        const STATUS_TEXT: Record<string, string> = {
+          PRE_CALIBRATION_STRUCTURAL_PRIOR: "structural prior — not yet empirically calibrated",
+          PRE_CALIBRATION_PROVISIONAL_DIRECTIONAL: "provisional — directional calibration only",
+          BAYESIAN_POSTERIOR_CALIBRATED: "empirically calibrated interval",
+        };
+        const text = STATUS_TEXT[bandMethod];
+        if (!text) return null;
+        return (
+          <div
+            data-testid="ci-calibration-status"
+            style={{
+              fontSize: 9,
+              color: "#888",
+              marginTop: 2,
+              padding: "2px 8px",
+              fontStyle: "italic",
+            }}
+          >
+            {text}
+          </div>
+        );
+      })()}
 
     </div>
   );

--- a/frontend/src/store/scenarioStepStore.ts
+++ b/frontend/src/store/scenarioStepStore.ts
@@ -22,6 +22,8 @@ export interface TrajectoryFrameworkPoint {
   psp_dominant_driver?: string | null;
   /** M18-G7-D — note from API (e.g. "Ecological disabled for SEN Demo 7 Act 1"). */
   note?: string | null;
+  /** M19-G3 (#1537) / G4 (#1529): BandingEngine calibration state for this framework point. */
+  band_method?: string | null;
 }
 
 export interface TrajectoryStep {


### PR DESCRIPTION
## Summary

Implements G4 #1529 — two display-contract fixes for ADR-007 Amendment 1 §8.7 (DEMO-163 resolution).

**Deliverable A — `ci-calibration-status` text (Demo 8 gate):**
TrajectoryView now renders `data-testid="ci-calibration-status"` with calibration state text derived from `financial_band_method` at the last step:

| `band_method` | Status text |
|---|---|
| `PRE_CALIBRATION_STRUCTURAL_PRIOR` | `"structural prior — not yet empirically calibrated"` |
| `PRE_CALIBRATION_PROVISIONAL_DIRECTIONAL` | `"provisional — directional calibration only"` |
| `BAYESIAN_POSTERIOR_CALIBRATED` | `"empirically calibrated interval"` |
| `SUPPRESSED_MEANINGLESS` | element absent |

**Deliverable B — "95% CI" → "declared interval":**
`MDAAlertPanelZone1B.tsx` line 801: `"95% CI"` replaced with `"declared interval"` + tooltip. `data-testid="distributional-ci-label"` wired. Tooltip: "Structural uncertainty model — BandingEngine step-based schedule; not a frequentist confidence interval. See methodology panel for details."

**Type chain:**
`band_method` added to `TrajectoryFrameworkPoint`, `RawFrameworkPoint`, `MergedStepDatum`, and extracted in `parseTrajectoryResponse()`. Backend wire-up completes the G3 #1537 backend gap once issue #1632 (api_contracts.yml) is resolved in G5.

## Acceptance criteria covered

AC-1 through AC-9 as per `frontend/tests/e2e/m19-g4-ci-label-precision.spec.ts`

## Test plan

- [ ] Frontend build gate: PASS (pre-push confirmed)
- [ ] `npm run build` on `sprint/m19-g4` post-merge: clean
- [ ] E2E: `m19-g4-ci-label-precision.spec.ts` — all 9 ACs

## References

- Issue: #1529
- Intent doc: `docs/process/intents/M19-G4-2026-07-03-ci-label-precision.md`
- Sprint entry: `docs/process/sprint-plans/m19-g4-sprint-entry.md` (EL Approved 2026-07-03)
- Demo 8 gate: `ci-calibration-status` must be present for `PRE_CALIBRATION_PROVISIONAL_DIRECTIONAL` at Act 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcXyxbrdytpbqgxuMG968m