### PR TITLE
fix(schema): add band_method, is_meaningless, suppressed_reason to api_contracts.yml §trajectory (#1632)

### DIFF
--- a/docs/schema/api_contracts.yml
+++ b/docs/schema/api_contracts.yml
@@ -691,6 +691,23 @@ endpoints:
                 is_pre_calibration:
                   type: "boolean|null"
                   description: "true throughout M18 (pre-calibration phase per ADR-007); null when composite_score is null."
+                band_method:
+                  type: "string|null"
+                  description: >
+                    BandingEngine calibration method applied to this framework point (M19-G3 #1537).
+                    Examples: "bayesian_posterior", "bootstrap", "parametric". null when
+                    composite_score is null or BandingEngine was not applied.
+                is_meaningless:
+                  type: "boolean|null"
+                  description: >
+                    ADR-007 meaninglessness threshold flag (M19-G3 #1536). true when the CI
+                    interval is too wide to be directionally informative (MDA alert suppressed).
+                    null when composite_score is null.
+                suppressed_reason:
+                  type: "string|null"
+                  description: >
+                    Human-readable explanation when CI is suppressed (e.g. "insufficient variance
+                    for bootstrap resampling"). null when CI is not suppressed.
             policy_inputs:
               type: array
               description: "Policy input events applied at this step. Source: scenario_scheduled_inputs."


### PR DESCRIPTION
## Summary

- Adds three missing fields to `docs/schema/api_contracts.yml §trajectory.steps[].frameworks.items`
- Closes #1632 — G3 delivery gap: `BandingEngine` fields shipped in PR #1537 but were absent from the schema contract, leaving the NM-086 gate open in G4

Fields added:
| Field | Type | Source |
|---|---|---|
| `band_method` | `string\|null` | BandingEngine calibration method (M19-G3 #1537) |
| `is_meaningless` | `boolean\|null` | ADR-007 meaninglessness threshold flag (M19-G3 #1536) |
| `suppressed_reason` | `string\|null` | Human-readable CI suppression reason |

## Test plan

- [ ] Schema-only change — no frontend or backend code modified
- [ ] `npm run build` passes (pre-push gate confirmed: no TypeScript files changed)
- [ ] Visual inspection: fields inserted after `is_pre_calibration` at line 691, before `policy_inputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbnQhDhZEfLBRcxEmRGo4S