### PR TITLE
docs(intents): file M19-G5 Phase C intent documents — #1522 and #1524

### DIFF
--- a/docs/process/intents/M19-G5-2026-07-03-view-model-retrofit.md
+++ b/docs/process/intents/M19-G5-2026-07-03-view-model-retrofit.md
@@ -1,0 +1,144 @@
+---
+name: M19-G5-view-model-retrofit
+type: implementation-intent
+adr: "N/A — code architecture refactor; no user-visible design decision; no ADR required"
+issues: "#1522"
+status: Filed
+authored-by: PM Agent
+authored-date: 2026-07-03
+implementing-agent: Frontend Architect Agent
+sprint-entry: docs/process/sprint-plans/m19-g5-sprint-entry.md
+---
+
+# Implementation Intent: G5 — View Model Layer Retrofit (Zone 1 Extraction) (#1522)
+
+## 1. Source Issue and Architecture Authority
+
+**Issue:** #1522 — View model layer retrofit — extract composition logic from Zone 1 instrument
+components
+**ADR prerequisite:** None — code architecture refactor; no UX contract change; no ADR required.
+**Authored by:** PM Agent
+**Date:** 2026-07-03
+**Implementing agent:** Frontend Architect Agent
+
+**Background (G5 scheduling rationale):**
+#1522 was originally M20+. It is pulled into G5 because #1524 (trackwheel zoom) requires
+`visibleStepRange` plumbing that is cleaner to build with extracted pure functions in a
+dedicated module. Without the extraction, `visibleStepRange` would thread through a 1338-line
+component with no co-located ownership. The G5 scope is a focused extraction — not the full
+`buildTrajectoryRenderModel` architectural vision — deliberately sized to unblock #1524 without
+introducing refactor risk ahead of Demo 8.
+
+**G5 scope (focused extraction only):**
+1. Create `frontend/src/components/trajectoryViewModel.ts` — the new home for pure functions
+   currently in `TrajectoryView.tsx`
+2. `TrajectoryView.tsx` re-exports all moved functions — existing test imports unchanged
+3. `mergeTrajectories` gains optional `visibleStepRange?: [number, number]` param to slice
+   steps before merging — the bridge that #1524 uses for zoom state
+4. New pure utility `sliceToStepRange` for post-merge filtering in `CompositeChartSVG`
+
+**Explicitly deferred (not G5):**
+- `buildTrajectoryRenderModel()` full typed render model
+- `ciRibbonModel.ts` CI band geometry extraction
+- Secondary components (MDAAlertPanelZone1B, PMMWidgetZone1C, FourFrameworkZone1D)
+
+---
+
+## 2. Scope — Single Deliverable
+
+**What changes:**
+
+| File | Change |
+|---|---|
+| `frontend/src/components/trajectoryViewModel.ts` | NEW — exports `computeYDomain`, `computeDivergenceFill`, `getConfidenceBadgeVisible`, `mergeTrajectories`, `sliceToStepRange`, and their dependent types (`MergedStepDatum`) |
+| `frontend/src/components/TrajectoryView.tsx` | MODIFIED — imports above from `trajectoryViewModel.ts`; re-exports them under the same names; passes optional `visibleStepRange` to `mergeTrajectories` in `mergedData` useMemo |
+
+**What does NOT change:**
+- Any exported function signature (except `mergeTrajectories` which gains an optional third param
+  — backward compatible; all existing call sites omit the param and continue to work)
+- Any test file (existing tests import from `TrajectoryView` via re-export; no import path change)
+- Any backend code
+- `CompositeChartSVG` internal step-index logic (receives `visibleStepRange` prop in G5 only as
+  a pass-through for #1524; does not use it internally until #1524 lands)
+
+---
+
+## 3. Acceptance Criteria
+
+**AC-1 — trajectoryViewModel.ts exists with correct exports**
+`frontend/src/components/trajectoryViewModel.ts` exists and exports:
+- `computeYDomain(values: number[]): [number, number]`
+- `computeDivergenceFill(active: number | null, baseline: number | null): boolean`
+- `getConfidenceBadgeVisible(confidenceTier: number): boolean`
+- `mergeTrajectories(active, baseline, visibleStepRange?): MergedStepDatum[]`
+- `sliceToStepRange(data: MergedStepDatum[], range: [number, number]): MergedStepDatum[]`
+- `MergedStepDatum` type (re-exported for consumers)
+
+**Observable state:** `import { computeYDomain } from "../trajectoryViewModel"` resolves
+without TypeScript error.
+
+**AC-2 — TrajectoryView.tsx re-exports are present**
+`TrajectoryView.tsx` still exports `computeYDomain`, `computeDivergenceFill`,
+`getConfidenceBadgeVisible`, `mergeTrajectories` by name (via re-export from
+`trajectoryViewModel.ts`). Existing test import `from "../TrajectoryView"` still resolves.
+
+**Observable state:** `TrajectoryView.test.ts` passes without any import path change.
+
+**AC-3 — All existing pure-function unit tests pass unchanged**
+`TrajectoryView.test.ts` tests for `computeDivergenceFill`, `getConfidenceBadgeVisible`,
+`computeYDomain`, `FRAMEWORKS`, `CONNECT_NULLS` all pass. No test modification required.
+
+**Observable state:** `npm run test` exits 0; `TrajectoryView.test.ts` shows all green.
+
+**AC-4 — mergeTrajectories visibleStepRange filtering**
+When `visibleStepRange: [3, 7]` is passed as the third argument to `mergeTrajectories`,
+the returned `MergedStepDatum[]` contains only steps with `step_index` in [3, 7] inclusive.
+When `visibleStepRange` is undefined (or null), all steps are returned (existing behavior).
+
+**Observable state:** Unit test in `trajectoryViewModel.test.ts`:
+```
+mergeTrajectories(trajectory10steps, null, [3, 7]).map(d => d.step_index) === [3, 4, 5, 6, 7]
+mergeTrajectories(trajectory10steps, null, undefined).length === 10
+```
+
+**AC-5 — sliceToStepRange pure function**
+`sliceToStepRange(data, [3, 7])` returns only items where `step_index >= 3 && step_index <= 7`.
+Empty array input returns empty array. Range `[0, Infinity]` returns all items.
+
+**Observable state:** Unit test in `trajectoryViewModel.test.ts`.
+
+**AC-6 — No behavior regression in TrajectoryView**
+Recharts path and composite SVG path render identically before and after the extraction
+(no visual change). `yDomain` continues to rescale from `mergedData`.
+
+**Observable state:** Existing E2E tests that observe Zone 1A pass without change.
+
+---
+
+## 4. File-Level Change Plan
+
+| File | Change type | Detail |
+|---|---|---|
+| `frontend/src/components/trajectoryViewModel.ts` | NEW | All pure functions + `MergedStepDatum` type |
+| `frontend/src/components/TrajectoryView.tsx` | MODIFIED — imports + re-exports | Remove function bodies; add `export { ... } from "./trajectoryViewModel"`; update `mergedData` useMemo to pass `visibleStepRange` |
+| `frontend/src/components/__tests__/trajectoryViewModel.test.ts` | NEW | AC-4 and AC-5 unit tests; verifies extraction did not alter function behavior |
+
+---
+
+## 5. QA Notes (NM-086 compliance)
+
+No new API mock routes introduced. No `api_contracts.yml` verification required.
+
+`trajectoryViewModel.test.ts` covers AC-4 and AC-5 with pure-function unit tests (no React
+component mounting required). Existing `TrajectoryView.test.ts` covers AC-3 via re-export.
+
+**NM-086 check:** No new E2E mock routes. No api_contracts.yml cross-check needed.
+
+---
+
+## 6. Implementation Sequence Note
+
+#1522 must merge before any #1524 implementation PR opens. The `visibleStepRange` parameter
+added to `mergeTrajectories` in AC-4 is the interface that #1524 uses. If both issues are
+implemented in the same session, the implementing agent must verify #1522 is green on CI
+before opening the #1524 PR.

--- a/docs/process/intents/M19-G5-2026-07-03-zone1a-trackwheel-zoom.md
+++ b/docs/process/intents/M19-G5-2026-07-03-zone1a-trackwheel-zoom.md
@@ -1,0 +1,182 @@
+---
+name: M19-G5-zone1a-trackwheel-zoom
+type: implementation-intent
+adr: "N/A — interaction gesture within existing Zone 1A viewport contract; no ADR required (confirmed: NM-086 E2E mock check — no new routes)"
+issues: "#1524"
+status: Filed
+authored-by: PM Agent
+authored-date: 2026-07-03
+implementing-agent: Frontend Architect Agent
+sprint-entry: docs/process/sprint-plans/m19-g5-sprint-entry.md
+prerequisite: "#1522 must be merged before this PR opens"
+---
+
+# Implementation Intent: G5 — Zone 1A Trackwheel Zoom (Desktop, Reduced Scope) (#1524)
+
+## 1. Source Issue and Architecture Authority
+
+**Issue:** #1524 — Zone 1A TrajectoryView: pinch-zoom, thumbwheel zoom, and pan on trajectory plot
+**ADR prerequisite:** None — interaction gesture within existing Zone 1A viewport contract;
+no new rendering contract; no ADR required.
+**Authored by:** PM Agent
+**Date:** 2026-07-03
+**Implementing agent:** Frontend Architect Agent
+
+**G5 scope (reduced from original issue):**
+Desktop mouse trackwheel (scroll wheel) zoom in/out on Zone 1A trajectory step axis only.
+Mobile pinch-zoom, mobile pan, and click-drag pan are deferred (EL decision 2026-07-03 comment
+on #1524). Sparse tick strategy at high zoom is deferred — ticks may crowd at maximum zoom;
+acceptable for G5.
+
+**Why this matters:**
+When trajectory composite scores cluster in a narrow band (e.g., ZMB financial 0.51–0.56,
+governance ~0.51), a 20-step full-range view shows scores as a near-flat line. Trackwheel zoom
+lets an analyst narrow to steps 3–8 where divergence is visible and defensible at a negotiating
+table. This is the core Demo 8 / Mode 3 analyst workflow when inspecting the per-step delta.
+
+**Prerequisite:** #1522 must be merged first. The `visibleStepRange` state slot in
+`TrajectoryView` and the `mergeTrajectories(active, baseline, visibleStepRange)` interface
+are provided by #1522.
+
+**Browser technical note:**
+React's synthetic `onWheel` fires passively in modern browsers (Chrome 51+) — `preventDefault()`
+inside it does not stop page scroll. A non-passive native `addEventListener('wheel', handler,
+{ passive: false })` on the container ref is required. This is a known constraint; the pattern
+is safe and does not require a third-party library.
+
+---
+
+## 2. Scope — Single Deliverable
+
+**What changes:**
+
+| File | Change |
+|---|---|
+| `frontend/src/components/TrajectoryView.tsx` | MODIFIED — adds `visibleStepRange` state, non-passive wheel listener via `useEffect`, double-click reset handler; passes `visibleStepRange` to `mergeTrajectories` (recharts path) and to `CompositeChartSVG` as new optional prop |
+| `frontend/src/components/TrajectoryView.tsx` (`CompositeChartSVG`) | MODIFIED — accepts optional `visibleStepRange?: [number, number] \| null` prop; when non-null, filters `stepIndices` and trajectory steps to the visible range before building path geometry |
+
+**What does NOT change:**
+- `computeYDomain` — rescales automatically because `mergedData` is already sliced via #1522
+- Any backend code or API contract
+- Touch event handling (zero touch events registered)
+- `FourFrameworkZone1D`, `PMMWidgetZone1C`, `MDAAlertPanelZone1B` — not in scope
+
+---
+
+## 3. Acceptance Criteria
+
+**AC-1 — Scroll wheel zooms the step axis**
+When the mouse cursor is positioned over Zone 1A and the user scrolls the mouse wheel downward
+(wheel `deltaY > 0`), the visible step range narrows by approximately 20% per scroll event,
+centered on the midpoint of the current visible range. The y-axis rescales to composite scores
+visible in the new step slice. Curves that were previously overlapping (< 5px separation)
+become visually separated.
+
+**Observable state:** `data-testid="zone-1a-trajectory"` container receives `data-visible-step-min`
+and `data-visible-step-max` attributes reflecting the current visible range. After one downward
+scroll starting from full 20-step range, the range narrows (e.g., steps [3, 17] instead of
+[1, 20]).
+
+**AC-2 — Scroll wheel zoom out restores range**
+When the cursor is over Zone 1A and the user scrolls upward (`deltaY < 0`), the visible range
+widens up to the full trajectory range. Scrolling beyond full range is a no-op (clamped).
+
+**Observable state:** After scrolling fully out, `data-visible-step-min` and
+`data-visible-step-max` match the full trajectory `[minStep, maxStep]`.
+
+**AC-3 — Page does not scroll while hovering Zone 1A**
+The `wheel` event listener on the Zone 1A container calls `event.preventDefault()` on every
+wheel event that occurs while the cursor is over the Zone 1A container. The outer page scroll
+position does not change while the user is scrolling within Zone 1A.
+
+**Observable state:** A Playwright test that scrolls the wheel over `[data-testid="zone-1a-trajectory"]`
+observes `window.scrollY` unchanged. The listener is registered with `{ passive: false }`.
+
+**AC-4 — Double-click resets to full range**
+When the user double-clicks anywhere within Zone 1A, `visibleStepRange` resets to `null` and
+the full trajectory range is restored.
+
+**Observable state:** After zooming in, a double-click on `[data-testid="zone-1a-trajectory"]`
+results in `data-visible-step-min` and `data-visible-step-max` returning to the full range.
+
+**AC-5 — No touch events registered**
+`TrajectoryView` registers no `touchstart`, `touchmove`, `touchend`, or `pointerdown` handlers.
+Mobile browsers scrolling over Zone 1A are unaffected — the page scrolls normally.
+
+**Observable state:** Static check — `frontend/tests/e2e/m19-g5-zone1a-trackwheel-zoom.spec.ts`
+uses `page.evaluate` to verify no touch event listener is registered on the Zone 1A container.
+
+**AC-6 — CompositeChartSVG respects visibleStepRange**
+When `visibleStepRange` is non-null, `CompositeChartSVG` filters `stepIndices` to the visible
+range. Terminal labels, MDA floor line, and comparison scenario curves all reflect the zoomed
+step window. The y-domain recomputes from the visible step scores only.
+
+**Observable state:** In comparison mode with `visibleStepRange: [3, 8]`, the SVG contains
+path geometry only for steps 3–8. Terminal labels appear at step 8 (not step 20).
+
+---
+
+## 4. File-Level Change Plan
+
+| File | Change type | Detail |
+|---|---|---|
+| `frontend/src/components/TrajectoryView.tsx` | MODIFIED | `useState<[number, number] \| null>(null)` for `visibleStepRange`; `useRef` for container; `useEffect` with non-passive wheel listener + dblclick reset; pass `visibleStepRange` to `mergeTrajectories` and `CompositeChartSVG` |
+| `frontend/src/components/TrajectoryView.tsx` (`CompositeChartSVG`) | MODIFIED | New `visibleStepRange?: [number, number] \| null` prop; filter `stepIndices` when non-null; recompute y-domain from filtered composite scores |
+| `frontend/tests/e2e/m19-g5-zone1a-trackwheel-zoom.spec.ts` | NEW | E2E tests covering AC-1 through AC-5; guard pattern if backend unavailable |
+
+---
+
+## 5. Zoom Geometry Specification
+
+The zoom computation on each wheel event:
+
+```
+const ZOOM_FACTOR = 0.20;  // 20% range reduction per tick (downward scroll)
+const [lo, hi] = current visibleStepRange ?? [minStep, maxStep]
+const center = Math.round((lo + hi) / 2)
+const halfRange = Math.round((hi - lo) / 2)
+
+if (deltaY > 0) {  // zoom in
+  const newHalf = Math.max(1, Math.round(halfRange * (1 - ZOOM_FACTOR)))
+  setVisibleStepRange([
+    Math.max(minStep, center - newHalf),
+    Math.min(maxStep, center + newHalf),
+  ])
+} else {  // zoom out
+  const newHalf = Math.round(halfRange / (1 - ZOOM_FACTOR))
+  const newLo = Math.max(minStep, center - newHalf)
+  const newHi = Math.min(maxStep, center + newHalf)
+  if (newLo === minStep && newHi === maxStep) {
+    setVisibleStepRange(null)  // fully zoomed out → reset
+  } else {
+    setVisibleStepRange([newLo, newHi])
+  }
+}
+```
+
+Center is the midpoint of the current range (not the cursor position). Cursor-centered zoom
+is deferred — it requires mapping pixel position to step index, which increases complexity.
+Midpoint-centered zoom is correct and sufficient for G5.
+
+---
+
+## 6. QA Notes (NM-086 compliance)
+
+No new API mock routes introduced. No `api_contracts.yml` verification required.
+
+The E2E test file uses the guard pattern: if `__worldsim_setMode` or the trajectory window
+seam is unavailable (backend offline), tests return early without failing assertions. This
+matches the pattern established in `m19-g5-zmb-yaxis-tight-scoping.spec.ts`.
+
+**NM-086 check:** No new E2E mock routes. No api_contracts.yml cross-check needed.
+
+---
+
+## 7. data-attribute contract (testid observability)
+
+`TrajectoryView`'s outer `div` gains two new `data-` attributes when `visibleStepRange` is non-null:
+- `data-visible-step-min="{lo}"` — current visible range lower bound (step index)
+- `data-visible-step-max="{hi}"` — current visible range upper bound (step index)
+
+When `visibleStepRange` is null (full range), these attributes are absent. AC-1 and AC-2 use
+these attributes to assert zoom state without inspecting internal React state.


### PR DESCRIPTION
## Summary

Files two intent documents for G5 Phase C:

- `docs/process/intents/M19-G5-2026-07-03-view-model-retrofit.md` — #1522 (focused extraction: `trajectoryViewModel.ts`, `visibleStepRange` param in `mergeTrajectories`, `sliceToStepRange` utility)
- `docs/process/intents/M19-G5-2026-07-03-zone1a-trackwheel-zoom.md` — #1524 (reduced scope: desktop trackwheel zoom only; mobile deferred per EL decision 2026-07-03)

**Scope change recorded:** #1524 original scope (pinch-zoom + pan) reduced to desktop mouse trackwheel zoom only. EL decision comment posted on #1524.

**NM-086 compliance:** No new E2E mock routes in either deliverable. No `api_contracts.yml` cross-check needed.

**Prerequisite ordering:** #1522 must merge before #1524 implementation PR opens. Sprint journal #1660 and issues updated.

## Test plan

- [ ] Both intent files exist in `docs/process/intents/`
- [ ] Both follow the same format as `M19-G5-2026-07-03-zmb-yaxis-tight-scoping.md`
- [ ] #1524 intent correctly documents reduced scope and prerequisite on #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbnQhDhZEfLBRcxEmRGo4S