### PR TITLE
feat(m19-g5): view model layer retrofit — extract pure functions to trajectoryViewModel.ts (#1522)

### DIFF
--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -5,6 +5,10 @@
  * Implements: ADR-010 Decisions 1–10, FA brief §TrajectoryView.
  * Design decisions: DD-012 (Zustand atom), DD-013 (divergence fill), DD-014 (step annotation).
  * Framework colors: frameworkColors.ts (UX Designer ruling, MV-001 closed 2026-05-23).
+ *
+ * Pure view-model functions (computeYDomain, computeDivergenceFill, getConfidenceBadgeVisible,
+ * mergeTrajectories, sliceToStepRange, MergedStepDatum) live in trajectoryViewModel.ts (#1522).
+ * Re-exported below for backward compatibility with existing import sites.
  */
 import React, { useMemo, useLayoutEffect, useRef } from "react";
 import {
@@ -26,9 +30,24 @@ import {
   type TrajectoryResponse,
   type MDAFloor,
 } from "../store/scenarioStepStore";
+import {
+  computeYDomain,
+  computeDivergenceFill,
+  getConfidenceBadgeVisible,
+  mergeTrajectories,
+  type MergedStepDatum,
+} from "./trajectoryViewModel";
+
+export {
+  computeYDomain,
+  computeDivergenceFill,
+  getConfidenceBadgeVisible,
+  mergeTrajectories,
+  type MergedStepDatum,
+};
 
 // ---------------------------------------------------------------------------
-// Exported constants and pure functions (tested by TrajectoryView.test.ts)
+// Exported constants (tested by TrajectoryView.test.ts)
 // ---------------------------------------------------------------------------
 
 /** All four framework keys in display-priority order. */
@@ -46,48 +65,6 @@ export const CONNECT_NULLS = false as const;
 export const CI_BAND_OPACITY = 0.12;
 /** Reduced opacity when showBaseline=true — divergence fill + CI ribbon coexist (M18-G1 #1254). */
 export const CI_BAND_OPACITY_MODE3 = 0.05;
-
-/**
- * Returns true when |active - baseline| > 0.01 and both values are non-null.
- * The 0.01 threshold prevents fill noise from floating-point rounding near convergence.
- * AC-010 tests the boundary exactly.
- */
-export function computeDivergenceFill(
-  active: number | null,
-  baseline: number | null,
-): boolean {
-  if (active === null || baseline === null) return false;
-  // Round to 4 decimal places to eliminate floating-point artifacts.
-  // 0.76 - 0.75 in IEEE 754 = 0.010000000000000009; rounded = 0.01 → not above threshold → false.
-  const delta = parseFloat(Math.abs(active - baseline).toFixed(4));
-  return delta > 0.01;
-}
-
-/**
- * Returns true when the confidence tier warrants the "(exp)" curve-face badge.
- * Badge appears at Tier 4 and 5 only. AC-013 tests the boundary at tier 3/4.
- */
-export function getConfidenceBadgeVisible(confidenceTier: number): boolean {
-  return confidenceTier >= 4;
-}
-
-/**
- * Compute adaptive y-axis domain from a set of composite score values.
- * Padding = max(0.05, 10% of range); result clamped to [0, 1].
- * Used by both the recharts path and CompositeChartSVG to ensure curve separation
- * is visible when scores cluster in a narrow band (e.g. FIN ~0.51–0.56, GOV ~0.51).
- */
-export function computeYDomain(values: number[]): [number, number] {
-  if (values.length === 0) return [0, 1];
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const range = max - min;
-  const padding = Math.max(0.05, range * 0.1);
-  return [
-    Math.max(0, parseFloat((min - padding).toFixed(2))),
-    Math.min(1, parseFloat((max + padding).toFixed(2))),
-  ];
-}
 
 // ---------------------------------------------------------------------------
 // Phase 4 — composite encoding constants and helpers (ADR-017 §Decision table)
@@ -172,106 +149,8 @@ export function computeCompositeCIBounds(step: TrajectoryStep): { lower: number 
   };
 }
 
-// ---------------------------------------------------------------------------
-// Internal types
-// ---------------------------------------------------------------------------
-
-export interface MergedStepDatum {
-  step_index: number;
-  effective_from: string;
-  step_event_label: string | null;
-  step_significance: "SIGNIFICANT" | "ROUTINE";
-  financial_active: number | null;
-  financial_baseline: number | null;
-  human_development_active: number | null;
-  human_development_baseline: number | null;
-  ecological_active: number | null;
-  ecological_baseline: number | null;
-  governance_active: number | null;
-  governance_baseline: number | null;
-  financial_confidence_tier: number;
-  human_development_confidence_tier: number;
-  ecological_confidence_tier: number;
-  governance_confidence_tier: number;
-  financial_scoring_basis: string;
-  human_development_scoring_basis: string;
-  financial_ci_lower: number | null;
-  financial_ci_upper: number | null;
-  human_development_ci_lower: number | null;
-  human_development_ci_upper: number | null;
-  ecological_ci_lower: number | null;
-  ecological_ci_upper: number | null;
-  governance_ci_lower: number | null;
-  governance_ci_upper: number | null;
-  /** M19-G3 (#1537) / G4 (#1529): BandingEngine calibration state for CI display. */
-  financial_band_method: string | null;
-}
-
-// ---------------------------------------------------------------------------
-// Data merging
-// ---------------------------------------------------------------------------
-
-export function mergeTrajectories(
-  active: TrajectoryResponse,
-  baseline: TrajectoryResponse | null,
-): MergedStepDatum[] {
-  const baselineByStep = new Map<number, TrajectoryStep>();
-  if (baseline) {
-    for (const step of baseline.steps) {
-      baselineByStep.set(step.step_index, step);
-    }
-  }
-
-  return active.steps.map((step) => {
-    const bStep = baselineByStep.get(step.step_index) ?? null;
-
-    const get = (
-      source: TrajectoryStep | null,
-      fw: string,
-    ): number | null => source?.frameworks[fw]?.composite_score ?? null;
-
-    const tier = (fw: string): number =>
-      step.frameworks[fw]?.confidence_tier ?? 1;
-
-    const basis = (fw: string): string =>
-      step.frameworks[fw]?.scoring_basis ?? "percentile_rank";
-
-    const ci = (fw: string, bound: "ci_lower" | "ci_upper"): number | null => {
-      const raw = step.frameworks[fw]?.[bound] ?? null;
-      return raw !== null ? parseFloat(raw as unknown as string) : null;
-    };
-
-    return {
-      step_index: step.step_index,
-      effective_from: step.effective_from,
-      step_event_label: step.step_event_label,
-      step_significance: step.step_significance,
-      financial_active: get(step, "financial"),
-      financial_baseline: get(bStep, "financial"),
-      human_development_active: get(step, "human_development"),
-      human_development_baseline: get(bStep, "human_development"),
-      ecological_active: get(step, "ecological"),
-      ecological_baseline: get(bStep, "ecological"),
-      governance_active: get(step, "governance"),
-      governance_baseline: get(bStep, "governance"),
-      financial_confidence_tier: tier("financial"),
-      human_development_confidence_tier: tier("human_development"),
-      ecological_confidence_tier: tier("ecological"),
-      governance_confidence_tier: tier("governance"),
-      financial_scoring_basis: basis("financial"),
-      human_development_scoring_basis: basis("human_development"),
-      financial_ci_lower: ci("financial", "ci_lower"),
-      financial_ci_upper: ci("financial", "ci_upper"),
-      human_development_ci_lower: ci("human_development", "ci_lower"),
-      human_development_ci_upper: ci("human_development", "ci_upper"),
-      ecological_ci_lower: ci("ecological", "ci_lower"),
-      ecological_ci_upper: ci("ecological", "ci_upper"),
-      governance_ci_lower: ci("governance", "ci_lower"),
-      governance_ci_upper: ci("governance", "ci_upper"),
-      financial_band_method: step.frameworks["financial"]?.band_method ?? null,
-    };
-  });
-}
+// MergedStepDatum and mergeTrajectories live in trajectoryViewModel.ts (#1522).
+// Re-exported above for backward compatibility.
 
 // ---------------------------------------------------------------------------
 // Custom XAxis tick — Mode 1 step annotation (FA-C5, UD-R2)

--- a/frontend/src/components/trajectoryViewModel.ts
+++ b/frontend/src/components/trajectoryViewModel.ts
@@ -1,52 +1,178 @@
 /**
- * trajectoryViewModel — view model layer for Zone 1 trajectory instruments.
+ * trajectoryViewModel — pure view-model functions for Zone 1 trajectory instruments.
  *
- * RED STUB: This file is a placeholder that satisfies TypeScript imports until
- * #1522 (view model layer retrofit) is implemented. Function signatures are
- * correct; implementations are stubs that make AC-4 and AC-5 tests FAIL.
+ * Extracted from TrajectoryView.tsx by M19-G5 #1522 (view model layer retrofit).
+ * TrajectoryView.tsx re-exports all symbols below for backward compatibility.
  *
- * After #1522 lands:
- *   - computeYDomain, computeDivergenceFill, getConfidenceBadgeVisible are moved
- *     here from TrajectoryView.tsx (TrajectoryView re-exports them).
- *   - mergeTrajectories gains visibleStepRange filtering.
- *   - sliceToStepRange is implemented.
- *   - This comment block is removed.
- *
- * M19-G5 Phase C (#1522) — implement before opening #1524 implementation PR.
+ * Hosting pure functions here:
+ *   - Makes them testable without mounting a React component
+ *   - Provides a clean `visibleStepRange` parameter seam for #1524 trackwheel zoom
+ *   - Satisfies the platform principle: new scenario types add logic here, not in a renderer
  */
-import type { TrajectoryResponse } from "../store/scenarioStepStore";
-export type { MergedStepDatum } from "./TrajectoryView";
+import type { TrajectoryResponse, TrajectoryStep } from "../store/scenarioStepStore";
 
-// Re-export pure functions that exist today — behavior preserved (AC-3 GREEN).
-export {
-  computeYDomain,
-  computeDivergenceFill,
-  getConfidenceBadgeVisible,
-} from "./TrajectoryView";
+// ---------------------------------------------------------------------------
+// MergedStepDatum — output type of mergeTrajectories
+// ---------------------------------------------------------------------------
 
-// Stub for internal import resolution.
-import type { MergedStepDatum } from "./TrajectoryView";
+export interface MergedStepDatum {
+  step_index: number;
+  effective_from: string;
+  step_event_label: string | null;
+  step_significance: "SIGNIFICANT" | "ROUTINE";
+  financial_active: number | null;
+  financial_baseline: number | null;
+  human_development_active: number | null;
+  human_development_baseline: number | null;
+  ecological_active: number | null;
+  ecological_baseline: number | null;
+  governance_active: number | null;
+  governance_baseline: number | null;
+  financial_confidence_tier: number;
+  human_development_confidence_tier: number;
+  ecological_confidence_tier: number;
+  governance_confidence_tier: number;
+  financial_scoring_basis: string;
+  human_development_scoring_basis: string;
+  financial_ci_lower: number | null;
+  financial_ci_upper: number | null;
+  human_development_ci_lower: number | null;
+  human_development_ci_upper: number | null;
+  ecological_ci_lower: number | null;
+  ecological_ci_upper: number | null;
+  governance_ci_lower: number | null;
+  governance_ci_upper: number | null;
+  /** M19-G3 (#1537) / G4 (#1529): BandingEngine calibration state for CI display. */
+  financial_band_method: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
 
 /**
- * RED STUB — always returns empty array; ignores all parameters.
- * AC-4 tests will FAIL (mergeTrajectories returns [] instead of filtered steps).
- * Replaced by #1522 with real merge + visibleStepRange filtering logic.
+ * Returns true when |active - baseline| > 0.01 and both values are non-null.
+ * The 0.01 threshold prevents fill noise from floating-point rounding near convergence.
+ * AC-010 tests the boundary exactly.
  */
-export function mergeTrajectories(
-  _active: TrajectoryResponse,
-  _baseline: TrajectoryResponse | null,
-  _visibleStepRange?: [number, number] | null,
-): MergedStepDatum[] {
-  return []; // RED: replaced by #1522
+export function computeDivergenceFill(
+  active: number | null,
+  baseline: number | null,
+): boolean {
+  if (active === null || baseline === null) return false;
+  // Round to 4 decimal places to eliminate floating-point artifacts.
+  // 0.76 - 0.75 in IEEE 754 = 0.010000000000000009; rounded = 0.01 → not above threshold → false.
+  const delta = parseFloat(Math.abs(active - baseline).toFixed(4));
+  return delta > 0.01;
 }
 
 /**
- * RED STUB — always returns empty array.
- * AC-5 tests will FAIL until #1522 replaces this with the real implementation.
+ * Returns true when the confidence tier warrants the "(exp)" curve-face badge.
+ * Badge appears at Tier 4 and 5 only. AC-013 tests the boundary at tier 3/4.
+ */
+export function getConfidenceBadgeVisible(confidenceTier: number): boolean {
+  return confidenceTier >= 4;
+}
+
+/**
+ * Compute adaptive y-axis domain from a set of composite score values.
+ * Padding = max(0.05, 10% of range); result clamped to [0, 1].
+ * Used by both the recharts path and CompositeChartSVG to ensure curve separation
+ * is visible when scores cluster in a narrow band (e.g. FIN ~0.51–0.56, GOV ~0.51).
+ */
+export function computeYDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [0, 1];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  const padding = Math.max(0.05, range * 0.1);
+  return [
+    Math.max(0, parseFloat((min - padding).toFixed(2))),
+    Math.min(1, parseFloat((max + padding).toFixed(2))),
+  ];
+}
+
+/**
+ * Merge active and baseline trajectory responses into a flat array of step datums.
+ * Optional `visibleStepRange` slices to [lo, hi] inclusive before returning —
+ * the seam used by #1524 trackwheel zoom to scope the recharts data window.
+ */
+export function mergeTrajectories(
+  active: TrajectoryResponse,
+  baseline: TrajectoryResponse | null,
+  visibleStepRange?: [number, number] | null,
+): MergedStepDatum[] {
+  const baselineByStep = new Map<number, TrajectoryStep>();
+  if (baseline) {
+    for (const step of baseline.steps) {
+      baselineByStep.set(step.step_index, step);
+    }
+  }
+
+  const steps = visibleStepRange
+    ? active.steps.filter(
+        (s) => s.step_index >= visibleStepRange[0] && s.step_index <= visibleStepRange[1],
+      )
+    : active.steps;
+
+  return steps.map((step) => {
+    const bStep = baselineByStep.get(step.step_index) ?? null;
+
+    const get = (
+      source: TrajectoryStep | null,
+      fw: string,
+    ): number | null => source?.frameworks[fw]?.composite_score ?? null;
+
+    const tier = (fw: string): number =>
+      step.frameworks[fw]?.confidence_tier ?? 1;
+
+    const basis = (fw: string): string =>
+      step.frameworks[fw]?.scoring_basis ?? "percentile_rank";
+
+    const ci = (fw: string, bound: "ci_lower" | "ci_upper"): number | null => {
+      const raw = step.frameworks[fw]?.[bound] ?? null;
+      return raw !== null ? parseFloat(raw as unknown as string) : null;
+    };
+
+    return {
+      step_index: step.step_index,
+      effective_from: step.effective_from,
+      step_event_label: step.step_event_label,
+      step_significance: step.step_significance,
+      financial_active: get(step, "financial"),
+      financial_baseline: get(bStep, "financial"),
+      human_development_active: get(step, "human_development"),
+      human_development_baseline: get(bStep, "human_development"),
+      ecological_active: get(step, "ecological"),
+      ecological_baseline: get(bStep, "ecological"),
+      governance_active: get(step, "governance"),
+      governance_baseline: get(bStep, "governance"),
+      financial_confidence_tier: tier("financial"),
+      human_development_confidence_tier: tier("human_development"),
+      ecological_confidence_tier: tier("ecological"),
+      governance_confidence_tier: tier("governance"),
+      financial_scoring_basis: basis("financial"),
+      human_development_scoring_basis: basis("human_development"),
+      financial_ci_lower: ci("financial", "ci_lower"),
+      financial_ci_upper: ci("financial", "ci_upper"),
+      human_development_ci_lower: ci("human_development", "ci_lower"),
+      human_development_ci_upper: ci("human_development", "ci_upper"),
+      ecological_ci_lower: ci("ecological", "ci_lower"),
+      ecological_ci_upper: ci("ecological", "ci_upper"),
+      governance_ci_lower: ci("governance", "ci_lower"),
+      governance_ci_upper: ci("governance", "ci_upper"),
+      financial_band_method: step.frameworks["financial"]?.band_method ?? null,
+    };
+  });
+}
+
+/**
+ * Filter a pre-merged MergedStepDatum array to a visible step range [lo, hi] inclusive.
+ * Used by CompositeChartSVG to scope the SVG rendering window (#1524 trackwheel zoom).
  */
 export function sliceToStepRange(
-  _data: MergedStepDatum[],
-  _range: [number, number],
+  data: MergedStepDatum[],
+  range: [number, number],
 ): MergedStepDatum[] {
-  return []; // RED: replaced by #1522
+  return data.filter((d) => d.step_index >= range[0] && d.step_index <= range[1]);
 }


### PR DESCRIPTION
## Summary

- Creates `frontend/src/components/trajectoryViewModel.ts` with all pure view-model functions extracted from `TrajectoryView.tsx`:
  - `MergedStepDatum` interface
  - `computeDivergenceFill`, `getConfidenceBadgeVisible`, `computeYDomain`
  - `mergeTrajectories` — now accepts optional `visibleStepRange?: [number, number] | null` (seam for #1524)
  - `sliceToStepRange` — new pure function filtering merged data to a step range
- `TrajectoryView.tsx` imports from the new module and re-exports all symbols for backward compatibility with existing import sites
- Pre-push build gate: PASS; all 33 unit tests GREEN

## Intent

`docs/process/intents/M19-G5-2026-07-03-view-model-retrofit.md`

## Acceptance criteria satisfied

- AC-1: `trajectoryViewModel.ts` exports all five named symbols ✓
- AC-3: `computeYDomain`, `computeDivergenceFill`, `getConfidenceBadgeVisible` behavior preserved ✓
- AC-4: `mergeTrajectories(trajectory, null, [3,7])` returns 5 steps ✓
- AC-5: `sliceToStepRange(data, [3,7])` returns 5 items ✓

## Test plan

- [x] `npx vitest run src/components/__tests__/trajectoryViewModel.test.ts` — 33/33 PASS
- [x] `npm run build` — PASS (pre-push gate)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbnQhDhZEfLBRcxEmRGo4S