### PR TITLE
feat(m19-g5): Zone 1A trackwheel zoom — desktop scroll wheel step-axis zoom (#1524)

### DIFF
--- a/frontend/src/components/TrajectoryView.tsx
+++ b/frontend/src/components/TrajectoryView.tsx
@@ -10,7 +10,7 @@
  * mergeTrajectories, sliceToStepRange, MergedStepDatum) live in trajectoryViewModel.ts (#1522).
  * Re-exported below for backward compatibility with existing import sites.
  */
-import React, { useMemo, useLayoutEffect, useRef } from "react";
+import React, { useMemo, useLayoutEffect, useRef, useState, useEffect } from "react";
 import {
   ComposedChart,
   Line,
@@ -263,6 +263,7 @@ interface CompositeChartSVGProps {
   width: number;
   height: number;
   comparisonScenarios?: ScenarioComparisonConfig[];
+  visibleStepRange?: [number, number] | null;
 }
 
 function CompositeChartSVG({
@@ -273,6 +274,7 @@ function CompositeChartSVG({
   width,
   height,
   comparisonScenarios = [],
+  visibleStepRange = null,
 }: CompositeChartSVGProps) {
   const MARGIN = { top: 16, right: 60, bottom: 48, left: 44 };
   const chartW = width - MARGIN.left - MARGIN.right;
@@ -280,7 +282,15 @@ function CompositeChartSVG({
 
   const refCode = entityCodes.find((c) => activeTrajectories[c]);
   const refSteps = refCode ? activeTrajectories[refCode].steps : [];
-  const stepIndices = refSteps.map((s) => s.step_index);
+  const allStepIndices = refSteps.map((s) => s.step_index);
+  const stepIndices = visibleStepRange
+    ? allStepIndices.filter((i) => i >= visibleStepRange[0] && i <= visibleStepRange[1])
+    : allStepIndices;
+
+  const filterSteps = (steps: TrajectoryStep[]): TrajectoryStep[] =>
+    visibleStepRange
+      ? steps.filter((s) => s.step_index >= visibleStepRange![0] && s.step_index <= visibleStepRange![1])
+      : steps;
 
   const xScale = (idx: number): number => {
     if (stepIndices.length <= 1) return MARGIN.left + chartW / 2;
@@ -293,10 +303,14 @@ function CompositeChartSVG({
   // scenario curves are not collapsed by a floor that anchors the scale far below the data.
   // comparisonDataMin tracks the raw data minimum (pre-padding) for floor suppression (AC-2/#1629).
   const [yMin, yMax, comparisonDataMin] = useMemo(() => {
+    const inRange = (step: TrajectoryStep) =>
+      !visibleStepRange ||
+      (step.step_index >= visibleStepRange[0] && step.step_index <= visibleStepRange[1]);
     const values: number[] = [];
     const inComparisonMode = comparisonScenarios.length > 0;
     for (const traj of [...Object.values(activeTrajectories), ...Object.values(baselineTrajectories)]) {
       for (const step of traj.steps) {
+        if (!inRange(step)) continue;
         const s = computeEntityCompositeScore(step);
         if (s !== null) values.push(s);
       }
@@ -309,6 +323,7 @@ function CompositeChartSVG({
     for (const sc of comparisonScenarios) {
       if (!sc.trajectory) continue;
       for (const step of sc.trajectory.steps) {
+        if (!inRange(step)) continue;
         const s = computeEntityCompositeScore(step);
         if (s !== null) {
           values.push(s);
@@ -318,7 +333,7 @@ function CompositeChartSVG({
       // Floor excluded from values in comparison mode (see comment above)
     }
     return [...computeYDomain(values), compDataMin] as [number, number, number | null];
-  }, [activeTrajectories, baselineTrajectories, comparisonScenarios]);
+  }, [activeTrajectories, baselineTrajectories, comparisonScenarios, visibleStepRange]);
 
   const yScale = (score: number): number => {
     const clamped = Math.min(yMax, Math.max(yMin, score));
@@ -417,7 +432,7 @@ function CompositeChartSVG({
       {comparisonScenarios.length === 0 && entityCodes.map((code, i) => {
         const active = activeTrajectories[code];
         if (!active) return null;
-        const ribbonD = buildCIRibbonPath(active.steps);
+        const ribbonD = buildCIRibbonPath(filterSteps(active.steps));
         if (!ribbonD) return null;
         const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
         return (
@@ -433,7 +448,7 @@ function CompositeChartSVG({
       })}
       {comparisonScenarios.length > 0 && comparisonScenarios.map((sc) => {
         if (!sc.trajectory) return null;
-        const ribbonD = buildCIRibbonPath(sc.trajectory.steps);
+        const ribbonD = buildCIRibbonPath(filterSteps(sc.trajectory.steps));
         if (!ribbonD) return null;
         const palette = SCENARIO_COMPARISON_PALETTE[sc.paletteIndex];
         const slug = sc.scenarioId.replace(/^[a-z]{3}-/, "");
@@ -549,7 +564,7 @@ function CompositeChartSVG({
         entityCodes.map((code, i) => {
           const baseline = baselineTrajectories[code];
           if (!baseline) return null;
-          const pathD = buildPathD(baseline.steps);
+          const pathD = buildPathD(filterSteps(baseline.steps));
           if (!pathD) return null;
           const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
           return (
@@ -569,7 +584,7 @@ function CompositeChartSVG({
       {comparisonScenarios.length === 0 && entityCodes.map((code, i) => {
         const active = activeTrajectories[code];
         if (!active) return null;
-        const pathD = buildPathD(active.steps);
+        const pathD = buildPathD(filterSteps(active.steps));
         if (!pathD) return null;
         const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
         return (
@@ -587,7 +602,7 @@ function CompositeChartSVG({
       {/* Scenario comparison curves — N palette-colored paths */}
       {comparisonScenarios.length > 0 && comparisonScenarios.map((sc) => {
         if (!sc.trajectory) return null;
-        const pathD = buildPathD(sc.trajectory.steps);
+        const pathD = buildPathD(filterSteps(sc.trajectory.steps));
         if (!pathD) return null;
         const palette = SCENARIO_COMPARISON_PALETTE[sc.paletteIndex];
         const slug = sc.scenarioId.replace(/^[a-z]{3}-/, "");
@@ -608,7 +623,9 @@ function CompositeChartSVG({
       {entityCodes.map((code, i) => {
         const active = activeTrajectories[code];
         if (!active || active.steps.length === 0) return null;
-        const lastStep = active.steps[active.steps.length - 1];
+        const visibleSteps = filterSteps(active.steps);
+        if (visibleSteps.length === 0) return null;
+        const lastStep = visibleSteps[visibleSteps.length - 1];
         const lastScore = computeEntityCompositeScore(lastStep);
         if (lastScore === null) return null;
         const tier = getEntityWorstTier(lastStep);
@@ -635,7 +652,9 @@ function CompositeChartSVG({
       {comparisonScenarios.length === 0 && entityCodes.map((code, i) => {
         const active = activeTrajectories[code];
         if (!active || active.steps.length === 0) return null;
-        const lastStep = active.steps[active.steps.length - 1];
+        const visibleSteps = filterSteps(active.steps);
+        if (visibleSteps.length === 0) return null;
+        const lastStep = visibleSteps[visibleSteps.length - 1];
         const lastScore = computeEntityCompositeScore(lastStep);
         if (lastScore === null) return null;
         const color = ENTITY_PALETTE[i % ENTITY_PALETTE.length];
@@ -660,7 +679,9 @@ function CompositeChartSVG({
       {/* Scenario comparison terminal labels */}
       {comparisonScenarios.length > 0 && comparisonScenarios.map((sc) => {
         if (!sc.trajectory || sc.trajectory.steps.length === 0) return null;
-        const lastStep = sc.trajectory.steps[sc.trajectory.steps.length - 1];
+        const visibleSteps = filterSteps(sc.trajectory.steps);
+        if (visibleSteps.length === 0) return null;
+        const lastStep = visibleSteps[visibleSteps.length - 1];
         const lastScore = computeEntityCompositeScore(lastStep);
         if (lastScore === null) return null;
         const palette = SCENARIO_COMPARISON_PALETTE[sc.paletteIndex];
@@ -732,10 +753,61 @@ export const TrajectoryView = React.memo(function TrajectoryView({
   const { trajectory, baseline_trajectory, current_step, mode } =
     useScenarioStepStore();
 
+  // ---------------------------------------------------------------------------
+  // Trackwheel zoom state (#1524)
+  // ---------------------------------------------------------------------------
+  const [visibleStepRange, setVisibleStepRange] = useState<[number, number] | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const minStep = trajectory ? Math.min(...trajectory.steps.map((s) => s.step_index)) : 1;
+  const maxStep = trajectory ? Math.max(...trajectory.steps.map((s) => s.step_index)) : 1;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const ZOOM_FACTOR = 0.20;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      if (!trajectory) return;
+      const [lo, hi] = visibleStepRange ?? [minStep, maxStep];
+      const center = Math.round((lo + hi) / 2);
+      const halfRange = Math.round((hi - lo) / 2);
+
+      if (e.deltaY > 0) {
+        const newHalf = Math.max(1, Math.round(halfRange * (1 - ZOOM_FACTOR)));
+        setVisibleStepRange([
+          Math.max(minStep, center - newHalf),
+          Math.min(maxStep, center + newHalf),
+        ]);
+      } else {
+        const newHalf = Math.round(halfRange / (1 - ZOOM_FACTOR));
+        const newLo = Math.max(minStep, center - newHalf);
+        const newHi = Math.min(maxStep, center + newHalf);
+        if (newLo === minStep && newHi === maxStep) {
+          setVisibleStepRange(null);
+        } else {
+          setVisibleStepRange([newLo, newHi]);
+        }
+      }
+    };
+
+    const onDblClick = () => setVisibleStepRange(null);
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    el.addEventListener("dblclick", onDblClick);
+
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("dblclick", onDblClick);
+    };
+  }, [trajectory, visibleStepRange, minStep, maxStep]);
+
   const mergedData = useMemo<MergedStepDatum[]>(() => {
     if (!trajectory) return [];
-    return mergeTrajectories(trajectory, baseline_trajectory);
-  }, [trajectory, baseline_trajectory]);
+    return mergeTrajectories(trajectory, baseline_trajectory, visibleStepRange);
+  }, [trajectory, baseline_trajectory, visibleStepRange]);
 
   const showBaseline = (mode === "MODE_2" || mode === "MODE_3") && baseline_trajectory !== null;
 
@@ -829,14 +901,20 @@ export const TrajectoryView = React.memo(function TrajectoryView({
       </div>
     ) : null;
 
+  const zoomAttrs = visibleStepRange
+    ? { "data-visible-step-min": String(visibleStepRange[0]), "data-visible-step-max": String(visibleStepRange[1]) }
+    : {};
+
   // ---------------------------------------------------------------------------
   // Legibility-limit notice (N > 4)
   // ---------------------------------------------------------------------------
   if (isLegibilityLimit) {
     return (
       <div
+        ref={containerRef}
         data-testid={dataTestId}
         data-current-step={current_step}
+        {...zoomAttrs}
         style={{ width: width ?? 480, position: "relative" }}
       >
         <div
@@ -870,8 +948,10 @@ export const TrajectoryView = React.memo(function TrajectoryView({
   if (!trajectory && !hasCompositeData) {
     return (
       <div
+        ref={containerRef}
         data-testid={dataTestId}
         data-current-step={current_step}
+        {...zoomAttrs}
         style={{ width: width ?? 480, position: "relative" }}
       >
         <div
@@ -900,8 +980,10 @@ export const TrajectoryView = React.memo(function TrajectoryView({
     const entityCodes = entityIds ?? Object.keys(effectiveActiveTrajectories);
     return (
       <div
+        ref={containerRef}
         data-testid={dataTestId}
         data-current-step={current_step}
+        {...zoomAttrs}
         style={{ width: width ?? 480, position: "relative" }}
       >
         {/* AC-G4-C trajectory presence indicators (ADR-019 D-10, #1217) */}
@@ -927,6 +1009,7 @@ export const TrajectoryView = React.memo(function TrajectoryView({
           width={width ?? 480}
           height={height}
           comparisonScenarios={comparisonScenarios ?? []}
+          visibleStepRange={visibleStepRange}
         />
         {entityLabelsOverlay}
       </div>
@@ -938,8 +1021,10 @@ export const TrajectoryView = React.memo(function TrajectoryView({
   // ---------------------------------------------------------------------------
   return (
     <div
+      ref={containerRef}
       data-testid={dataTestId}
       data-current-step={current_step}
+      {...zoomAttrs}
       style={{ width: width ?? 480, position: "relative" }}
     >
       {/* AC-G4-C trajectory presence indicators (ADR-019 D-10, #1217) */}


### PR DESCRIPTION
## Summary

- Adds `visibleStepRange` state + non-passive `wheel` event listener to `TrajectoryView` via `useEffect`
- Zoom geometry: `ZOOM_FACTOR=0.20`, midpoint-centered, clamped to `[minStep, maxStep]` from trajectory data
- Double-click resets to full range; no touch events registered (AC-5)
- Container div gains `data-visible-step-min` / `data-visible-step-max` when range is non-null
- `CompositeChartSVG`: new `visibleStepRange` prop; `filterSteps` helper applies to all path/label/badge renders and y-domain computation
- Prerequisite #1522 merged at fb55ad2

## Intent

`docs/process/intents/M19-G5-2026-07-03-zone1a-trackwheel-zoom.md`

## Acceptance criteria

- AC-1: Wheel down narrows visible step range; `data-visible-step-min/max` attributes set ✓
- AC-2: Wheel up restores full range; fully-out zoom resets to `null` ✓
- AC-3: `preventDefault()` called on every wheel event over Zone 1A ✓
- AC-4: Double-click resets to full range ✓
- AC-5: No touch event listeners registered ✓
- AC-6: `CompositeChartSVG` filters step geometry to visible range ✓

## Test plan

- [x] `npm run build` — PASS (pre-push gate)
- [x] All `trajectoryViewModel.test.ts` tests GREEN (33/33)
- [ ] E2E `m19-g5-zone1a-trackwheel-zoom.spec.ts` — runs against live stack (CI passes when backend available)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbnQhDhZEfLBRcxEmRGo4S