### PR TITLE
fix(m19-g5): replace __dirname with import.meta.dirname in zone1d E2E spec

### DIFF
--- a/frontend/tests/e2e/m19-g5-zone1d-delta-annotations.spec.ts
+++ b/frontend/tests/e2e/m19-g5-zone1d-delta-annotations.spec.ts
@@ -432,7 +432,7 @@ test("AC-4: demo-narrated Act 1 narration string does not imply per-framework Zo
   const { readFileSync } = await import("fs");
   const { join } = await import("path");
   const narrationFile = join(
-    __dirname,
+    import.meta.dirname,
     "demo-narrated.spec.ts",
   );
   let contents: string;


### PR DESCRIPTION
## Summary

- Replaces `__dirname` (CommonJS) with `import.meta.dirname` (ESM) in `m19-g5-zone1d-delta-annotations.spec.ts` line 435
- Root cause: `frontend/package.json` has `"type": "module"` — all files are ESM; `__dirname` is undefined in ESM context
- `import.meta.dirname` is the correct ESM equivalent; available natively in Node 24 (CI environment)

## Why this unblocks #1684

Integration PR `sprint/m19-g5 → release/m19` is blocked by `release-branch-ci-gate` which requires `playwright-e2e`. The `playwright-e2e` check was failing with `ReferenceError: __dirname is not defined` at spec line 435. This single-line fix resolves that error.

## Test plan

- [ ] `playwright-e2e` check passes on this PR's CI run on `sprint-branch-ci-gate`
- [ ] After this merges to `sprint/m19-g5`, re-run CI on integration PR #1684 — `playwright-e2e` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbnQhDhZEfLBRcxEmRGo4S