### PR TITLE
feat(m19-g6): #1709 — FOUND state tolerance band in separate testable element

### DIFF
--- a/frontend/src/components/ControlPlaneColumn.tsx
+++ b/frontend/src/components/ControlPlaneColumn.tsx
@@ -834,12 +834,16 @@ export function ControlPlaneColumn({
                         marginBottom: 2,
                       }}
                     >
-                      fiscal multiplier ≥ {searchResult.boundary?.toFixed(2)} (±{
-                        (
-                          (searchResult.uncertainty_hi ?? 0) -
-                          (searchResult.uncertainty_lo ?? 0)
-                        ).toFixed(2)
-                      })
+                      fiscal multiplier ≥ {searchResult.boundary?.toFixed(2)}
+                    </div>
+                    <div
+                      data-testid="constraint-tolerance-band"
+                      style={{ fontSize: 11, color: "#6b7280", marginTop: 1 }}
+                    >
+                      ±{(
+                        (searchResult.uncertainty_hi ?? 0) -
+                        (searchResult.uncertainty_lo ?? 0)
+                      ).toFixed(2)} precision
                     </div>
                     <div style={{ fontSize: 10, color: "#6b7280" }}>
                       {searchResult.evaluations} evaluations · [{searchResult.search_lo?.toFixed(1)}, {searchResult.search_hi?.toFixed(1)}] searched


### PR DESCRIPTION
## Summary

- Extracts `(±...)` suffix from `data-testid="constraint-boundary-value"` into a new `data-testid="constraint-tolerance-band"` element
- Band width = `uncertainty_hi - uncertainty_lo` per ADR-021 §D-4 State 2 (no API change)
- Clears Demo 8 Act 1 condition: tolerance band is now independently addressable by E2E

**Before:** `fiscal multiplier ≥ 0.83 (±0.01)` — single fused element
**After:**
```
fiscal multiplier ≥ 0.83     ← constraint-boundary-value (bold teal 14px)
±0.01 precision              ← constraint-tolerance-band (gray 11px, separate line)
```

## Test plan

QA tests in PR #1718 (merged to `sprint/m19-g6`):
- [x] AC-T1: `constraint-tolerance-band` visible in FOUND state — **GREEN (was RED)**
- [x] AC-T2: band text matches `±0.02 precision` — **GREEN (was RED)**
- [x] AC-T3/AC-T3b: band absent in NOT_FOUND/ERROR states — GREEN (unchanged)
- [x] AC-T4: `constraint-boundary-value` not contains `±` — **GREEN (was RED)**
- [x] AC-5: `constraint-boundary-value` still contains `1.18` — GREEN (unchanged)
- [x] Pre-push build gate: PASS (both runs)

Closes #1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFFbvSVhDQsQ5w35kmbhur