### PR TITLE
fix(m19-g6): #1710 — AC-12 remove skip guard; fix timing; confirm SAD sentinel

### DIFF
--- a/frontend/tests/e2e/m19-g1-constraint-floor-search.spec.ts
+++ b/frontend/tests/e2e/m19-g1-constraint-floor-search.spec.ts
@@ -362,17 +362,17 @@ test("AC-11: FOUND result includes 'synthetic' word when indicator is Tier 3", a
 });
 
 // ---------------------------------------------------------------------------
-// AC-12: Structural absence — Tier 4+
+// AC-12: Structural absence — SAD sentinel indicator_key (#1710)
 // ---------------------------------------------------------------------------
 
-test("AC-12: constraint-search-structural-absence shown when indicator is Tier 4+", async ({
+test("AC-12: constraint-search-structural-absence shown for SAD sentinel indicator_key", async ({
   page,
 }) => {
-  // Gap 8 fix: mock the scenario to return a structural-absence indicator.
-  // Without this mock, the test permanently skips post-implementation because
-  // the default scenario never loads a Tier 4+ indicator.
-  // The exact indicator_key value that triggers structural absence must be
-  // confirmed with the Frontend Architect before the G1 PR opens.
+  // Structural absence is detected by indicator_key.startsWith("__") in
+  // ControlPlaneColumn (ADR-021 §D-5). "__structural_absence__" is the canonical
+  // SAD sentinel — any __ prefix activates the path. constraint-search-section
+  // is suppressed when SAD is active; the SAD panel renders instead.
+  // #1710: removed skip guard and fixed timing (waitForTimeout → waitFor).
   const SA_ID = "zmb-structural-absence-test";
   await setupScenarioMocks(page, SA_ID, [
     { ...FOCAL_COHORT_CONFIG, indicator_key: "__structural_absence__" },
@@ -380,22 +380,13 @@ test("AC-12: constraint-search-structural-absence shown when indicator is Tier 4
   await page.goto(`/?scenario=${SA_ID}`);
   await waitForScenarioLoad(page, SA_ID);
   const btn = page.getByTestId("enter-active-control-btn");
-  if (await btn.isVisible({ timeout: 8_000 }).catch(() => false)) {
-    await btn.click();
-  }
-  await page.waitForTimeout(500);
-
-  const structuralAbsence = page.getByTestId(
-    "constraint-search-structural-absence"
-  );
-  if (!(await structuralAbsence.isVisible().catch(() => false))) {
-    test.skip();
-    return;
-  }
-  await expect(structuralAbsence).toBeVisible();
+  await btn.waitFor({ state: "visible", timeout: 8_000 });
+  await btn.click();
+  // Wait for the SAD panel — constraint-search-section is intentionally absent here.
   await expect(
-    page.getByTestId("constraint-search-btn")
-  ).not.toBeVisible();
+    page.getByTestId("constraint-search-structural-absence")
+  ).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("constraint-search-btn")).not.toBeVisible();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Rewrites AC-12 in `frontend/tests/e2e/m19-g1-constraint-floor-search.spec.ts`
- Removes the skip guard that was silently hiding the test on every CI run
- Replaces `page.waitForTimeout(500)` (unreliable) with `btn.waitFor({ state: "visible" })` → click → `expect(sad).toBeVisible({ timeout: 5_000 })`
- Documents that `__structural_absence__` IS the canonical SAD sentinel (`indicator_key.startsWith("__")` in `ControlPlaneColumn.tsx`, ADR-021 §D-5)

**Root cause of the skip:** The test used `isVisible().catch(() => false)` to guard the button click and `waitForTimeout(500)` to wait for Mode 3 to render. If the button didn't appear within the implicit timeout, the test clicked nothing, `constraint-search-structural-absence` never appeared, and the skip guard fired. The 500ms delay was not long enough when CI is under load.

**No code change to `ControlPlaneColumn.tsx`** — the detection logic (`startsWith("__")`) is correct. This is a test reliability fix only.

## Test plan

- [ ] CI playwright-e2e: AC-12 passes without skip
- [ ] AC-12 asserts `constraint-search-structural-absence` visible + `constraint-search-btn` absent
- [ ] No regression on AC-1 through AC-T4

Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFFbvSVhDQsQ5w35kmbhur