### PR TITLE
fix(demographic): dead subscription strings + emergency policy elasticities (#1657)

### DIFF
--- a/backend/app/simulation/modules/demographic/elasticities.py
+++ b/backend/app/simulation/modules/demographic/elasticities.py
@@ -329,4 +329,130 @@ ELASTICITY_REGISTRY: list[CohortElasticity] = [
         confidence_tier=3,
         entity_families=frozenset({"PAK", "LKA", "BGD"}),
     ),
+    # ---------------------------------------------------------------------------
+    # IMF programme acceptance → Q1/Q2 INFORMAL poverty headcount (#1657)
+    # CM cert: issue #1657 comment 2026-07-04 — Chief Methodologist.
+    #
+    # Direct conditionality channel: subsidy removal (fuel, food staples), public
+    # sector wage freeze, import liberalisation on programme acceptance. Distinct
+    # from the GDP-mediated gdp_growth_change channel already in registry.
+    # Event magnitude: +1.0 (binary signal per EmergencyPolicyInput).
+    # φ = +0.04 (Q1 INFORMAL): IMF IEO (2018) "The IMF and Social Protection" —
+    # average 3–5pp Q1 PHC increase in first year of programme; informal workers
+    # primarily affected via subsidy pass-through. Mid-range = 4pp. T3: cross-
+    # regional inference; T2 requires SEN 2015 ECF or ZMB 2017 SBA event-study.
+    # Uncertainty range: +0.02 to +0.06.
+    # ---------------------------------------------------------------------------
+    CohortElasticity(
+        event_type="emergency_policy_imf_program_acceptance",
+        cohort_spec=CohortSpec(
+            IncomeQuintile.Q1,
+            AgeBand.AGE_25_54,
+            EmploymentSector.INFORMAL,
+        ),
+        attribute_key="poverty_headcount_ratio",
+        elasticity=Decimal("0.04"),
+        source=(
+            "IMF Independent Evaluation Office (2018): The IMF and Social Protection."
+            " IEO Evaluation Report. Average 3–5pp Q1 poverty headcount increase in"
+            " first programme year, predominantly informal workers via subsidy removal"
+            " and consumption goods price inflation. Abouharb, M.R. & Cingranelli,"
+            " D.L. (2006): IMF Programs and Human Rights, 1981–2003. International"
+            " Studies Quarterly 50(2): 233–267. Consistent across 130+ programme"
+            " episodes. Direct conditionality channel; additive to GDP-mediated"
+            " gdp_growth_change channel. Point estimate +0.04 (mid-range 3–5pp)."
+            " M19-G6 calibration. Uncertainty range: +0.02 to +0.06."
+        ),
+        source_registry_id="ACADEMIC_LITERATURE_IMF_IEO_2018_IMF_SOCIAL_PROTECTION",
+        confidence_tier=3,
+    ),
+    # Q2 INFORMAL: Ball et al. (2013) 0.60 between-quintile scaling.
+    # 0.60 × 0.04 = 0.024 → +0.02 (rounded to 2dp per registry convention).
+    # Q2 informal workers have stronger employment tenure than Q1; absorb 0.60x
+    # the per-unit conditionality impact. Uncertainty range: +0.01 to +0.04.
+    CohortElasticity(
+        event_type="emergency_policy_imf_program_acceptance",
+        cohort_spec=CohortSpec(
+            IncomeQuintile.Q2,
+            AgeBand.AGE_25_54,
+            EmploymentSector.INFORMAL,
+        ),
+        attribute_key="poverty_headcount_ratio",
+        elasticity=Decimal("0.02"),
+        source=(
+            "Ball, Furceri, Leigh, Loungani (2013): The Distributional Effects"
+            " of Fiscal Consolidation. IMF Working Paper WP/13/151."
+            " 0.60 between-quintile scaling of Q1 INFORMAL (+0.04):"
+            " 0.60 × 0.04 = 0.024 → +0.02. Q2 informal workers have stronger"
+            " employment tenure; absorb 0.60x the per-unit conditionality impact."
+            " M19-G6 calibration. Uncertainty range: +0.01 to +0.04."
+        ),
+        source_registry_id="ACADEMIC_LITERATURE_BALL_2013_FISCAL_CONSOLIDATION",
+        confidence_tier=3,
+    ),
+    # ---------------------------------------------------------------------------
+    # Emergency declaration → Q1/Q2 INFORMAL poverty headcount (#1657)
+    # CM cert: issue #1657 comment 2026-07-04 — Chief Methodologist.
+    #
+    # Direct disruption channel: informal market closure, movement restriction,
+    # supply chain interruption on emergency declaration. Not mediated by GDP.
+    # Consistent with credit_contraction_labour_shock precedent (ADR-020 Channel C).
+    # Event magnitude: +1.0 (binary signal per EmergencyPolicyInput).
+    # φ = +0.06 (Q1 INFORMAL): ILO (2020) "COVID-19 and the World of Work" —
+    # 20–25% informal employment contraction within 4–6 weeks of emergency
+    # declaration in SSA/LIC contexts. World Bank (2020) "Poverty and Shared
+    # Prosperity": 3–8pp immediate PHC increase for Q1 informal workers.
+    # ZMB 2020 near-reference: emergency powers March 2020; informal sector
+    # contraction within ILO/World Bank range. T3: cross-regional inference.
+    # T2 requires ZMB 2020 event-study validation. Uncertainty range: +0.04 to +0.09.
+    # ---------------------------------------------------------------------------
+    CohortElasticity(
+        event_type="emergency_policy_emergency_declaration",
+        cohort_spec=CohortSpec(
+            IncomeQuintile.Q1,
+            AgeBand.AGE_25_54,
+            EmploymentSector.INFORMAL,
+        ),
+        attribute_key="poverty_headcount_ratio",
+        elasticity=Decimal("0.06"),
+        source=(
+            "ILO (2020): COVID-19 and the World of Work — Impact and Policy"
+            " Responses. ILO Monitor 2nd edition. 20–25% informal employment"
+            " contraction within 4–6 weeks of emergency/lockdown declaration in"
+            " SSA and LIC contexts. World Bank (2020): Poverty and Shared"
+            " Prosperity 2020: Reversals of Fortune. Chapters 1 and 3: emergency"
+            " declarations in developing countries associated with 3–8pp immediate"
+            " PHC increase for Q1 informal workers. ZMB 2020 emergency declaration"
+            " March 2020 — informal sector contraction within estimated range."
+            " Direct disruption channel (market closure, movement restriction);"
+            " additive to GDP-mediated channel. M19-G6 calibration."
+            " Uncertainty range: +0.04 to +0.09."
+        ),
+        source_registry_id="ACADEMIC_LITERATURE_ILO_2020_COVID_WORLD_OF_WORK",
+        confidence_tier=3,
+    ),
+    # Q2 INFORMAL: Ball et al. (2013) 0.60 between-quintile scaling.
+    # 0.60 × 0.06 = 0.036 → +0.04 (rounded to 2dp). Q2 informal workers have
+    # stronger employment tenure and more access to informal safety nets.
+    # Uncertainty range: +0.02 to +0.06.
+    CohortElasticity(
+        event_type="emergency_policy_emergency_declaration",
+        cohort_spec=CohortSpec(
+            IncomeQuintile.Q2,
+            AgeBand.AGE_25_54,
+            EmploymentSector.INFORMAL,
+        ),
+        attribute_key="poverty_headcount_ratio",
+        elasticity=Decimal("0.04"),
+        source=(
+            "Ball, Furceri, Leigh, Loungani (2013): The Distributional Effects"
+            " of Fiscal Consolidation. IMF Working Paper WP/13/151."
+            " 0.60 between-quintile scaling of Q1 INFORMAL (+0.06):"
+            " 0.60 × 0.06 = 0.036 → +0.04. Q2 informal workers have stronger"
+            " employment tenure and access to informal safety nets."
+            " M19-G6 calibration. Uncertainty range: +0.02 to +0.06."
+        ),
+        source_registry_id="ACADEMIC_LITERATURE_BALL_2013_FISCAL_CONSOLIDATION",
+        confidence_tier=3,
+    ),
 ]

--- a/backend/app/simulation/modules/demographic/module.py
+++ b/backend/app/simulation/modules/demographic/module.py
@@ -31,9 +31,9 @@ _log = logging.getLogger(__name__)
 
 _SUBSCRIBED_EVENTS = frozenset({
     "gdp_growth_change",
-    "imf_program_acceptance",
-    "credit_contraction_labour_shock",  # ADR-020 Channel C bridge
-    "emergency_declaration",
+    "emergency_policy_imf_program_acceptance",   # #1657: was "imf_program_acceptance" (dead)
+    "credit_contraction_labour_shock",            # ADR-020 Channel C bridge
+    "emergency_policy_emergency_declaration",     # #1657: was "emergency_declaration" (dead)
 })
 
 

--- a/backend/tests/test_m19_g6_demographic_subscriptions.py
+++ b/backend/tests/test_m19_g6_demographic_subscriptions.py
@@ -1,0 +1,292 @@
+"""QA tests for #1657: DemographicModule dead subscription strings + elasticity rows.
+
+RED-before-implementation tests (flip GREEN when #1657 impl PR merges):
+  - test_subscribed_events_no_dead_bare_strings: currently "imf_program_acceptance"
+    and "emergency_declaration" (bare) are in _SUBSCRIBED_EVENTS — should NOT be.
+  - test_subscribed_events_has_prefixed_imf_string: "emergency_policy_imf_program_acceptance"
+    not yet in _SUBSCRIBED_EVENTS (it is the bare string instead).
+  - test_subscribed_events_has_prefixed_emergency_declaration_string: same for emergency.
+  - test_imf_program_acceptance_triggers_q1_informal_delta: no elasticity row + dead string.
+  - test_imf_program_acceptance_triggers_q2_informal_delta: same.
+  - test_emergency_declaration_triggers_q1_informal_delta: same.
+  - test_emergency_declaration_triggers_q2_informal_delta: same.
+
+GREEN before implementation (value / type guards; will remain GREEN after):
+  - test_imf_program_acceptance_delta_is_positive
+  - test_emergency_declaration_delta_is_positive
+
+CM cert: issue #1657 comment 2026-07-04 — values certified by Chief Methodologist.
+NM-084 gate satisfied.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.simulation.modules.demographic.cohort import (
+    AgeBand,
+    CohortSpec,
+    EmploymentSector,
+    IncomeQuintile,
+)
+from app.simulation.modules.demographic.module import DemographicModule
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(entity_id: str, prior_events: list) -> object:
+    from app.simulation.engine.models import (
+        ResolutionConfig,
+        ScenarioConfig,
+        SimulationEntity,
+        SimulationState,
+    )
+
+    ts = datetime(2020, 1, 1, tzinfo=UTC)
+    return SimulationState(
+        timestep=ts,
+        resolution=ResolutionConfig(),
+        entities={
+            entity_id: SimulationEntity(
+                id=entity_id,
+                entity_type="country",
+                attributes={},
+                metadata={},
+            )
+        },
+        relationships=[],
+        events=prior_events,
+        scenario_config=ScenarioConfig(
+            scenario_id="test-1657",
+            name="Test #1657",
+            description="",
+            start_date=ts,
+            end_date=ts,
+        ),
+    )
+
+
+def _emergency_policy_event(
+    entity_id: str, instrument_value: str, magnitude: float = 1.0
+) -> object:
+    """Build an emergency policy Event as EmergencyPolicyInput.to_events() would emit it.
+
+    event_type = f"emergency_policy_{instrument_value}"
+    affected_attributes = {instrument_value: Quantity(magnitude)}
+    """
+    from app.simulation.engine.models import Event, MeasurementFramework
+    from app.simulation.engine.quantity import Quantity, VariableType
+
+    ts = datetime(2020, 1, 1, tzinfo=UTC)
+    delta = Quantity(
+        value=Decimal(str(magnitude)),
+        unit="dimensionless",
+        variable_type=VariableType.DIMENSIONLESS,
+        measurement_framework=MeasurementFramework.GOVERNANCE,
+        confidence_tier=1,
+    )
+    return Event(
+        event_id=f"test-{instrument_value}-event",
+        source_entity_id=entity_id,
+        event_type=f"emergency_policy_{instrument_value}",
+        affected_attributes={instrument_value: delta},
+        propagation_rules=[],
+        timestep_originated=ts,
+        framework=MeasurementFramework.GOVERNANCE,
+    )
+
+
+def _run_module(entity_id: str, event: object) -> list:
+    state = _make_state(entity_id, [event])
+    module = DemographicModule(cohort_resolution_entity_ids=[entity_id])
+    entity = state.entities[entity_id]
+    ts = datetime(2020, 4, 1, tzinfo=UTC)
+    return module.compute(entity, state, ts)
+
+
+def _delta_for_cohort(events: list, entity_id: str, cohort_spec: CohortSpec) -> Decimal | None:
+    """Return the poverty_headcount_ratio delta for the given cohort, or None."""
+    target_id = cohort_spec.entity_id(entity_id)
+    for event in events:
+        if event.metadata.get("target_entity_id") == target_id:
+            qty = event.affected_attributes.get("poverty_headcount_ratio")
+            if qty is not None:
+                return qty.value
+    return None
+
+
+Q1_INFORMAL = CohortSpec(IncomeQuintile.Q1, AgeBand.AGE_25_54, EmploymentSector.INFORMAL)
+Q2_INFORMAL = CohortSpec(IncomeQuintile.Q2, AgeBand.AGE_25_54, EmploymentSector.INFORMAL)
+ENTITY = "ZMB"
+
+
+# ---------------------------------------------------------------------------
+# AC-S1: Subscription string correctness
+# RED before #1657: bare strings "imf_program_acceptance" and
+# "emergency_declaration" are present; prefixed strings are absent.
+# ---------------------------------------------------------------------------
+
+
+def test_subscribed_events_has_prefixed_imf_string() -> None:
+    """'emergency_policy_imf_program_acceptance' must be in subscribed events.
+
+    RED before #1657: only 'imf_program_acceptance' (bare) is present.
+    """
+    subscribed = DemographicModule().get_subscribed_events()
+    assert "emergency_policy_imf_program_acceptance" in subscribed, (
+        "DemographicModule must subscribe to 'emergency_policy_imf_program_acceptance' — "
+        "the correct event_type emitted by EmergencyPolicyInput for IMF_PROGRAM_ACCEPTANCE. "
+        "Currently the bare string 'imf_program_acceptance' is used, which is a dead subscription."
+    )
+
+
+def test_subscribed_events_has_prefixed_emergency_declaration_string() -> None:
+    """'emergency_policy_emergency_declaration' must be in subscribed events.
+
+    RED before #1657: only 'emergency_declaration' (bare) is present.
+    """
+    subscribed = DemographicModule().get_subscribed_events()
+    assert "emergency_policy_emergency_declaration" in subscribed, (
+        "DemographicModule must subscribe to 'emergency_policy_emergency_declaration' — "
+        "the correct event_type emitted by EmergencyPolicyInput for EMERGENCY_DECLARATION. "
+        "Currently the bare string 'emergency_declaration' is used, which is a dead subscription."
+    )
+
+
+def test_subscribed_events_no_dead_bare_strings() -> None:
+    """Bare 'imf_program_acceptance' and 'emergency_declaration' must NOT be subscribed.
+
+    RED before #1657: both bare strings are in _SUBSCRIBED_EVENTS.
+    """
+    subscribed = set(DemographicModule().get_subscribed_events())
+    assert "imf_program_acceptance" not in subscribed, (
+        "'imf_program_acceptance' is a dead subscription string — "
+        "EmergencyPolicyInput emits 'emergency_policy_imf_program_acceptance'. "
+        "Remove the bare string and replace with the prefixed form."
+    )
+    assert "emergency_declaration" not in subscribed, (
+        "'emergency_declaration' is a dead subscription string — "
+        "EmergencyPolicyInput emits 'emergency_policy_emergency_declaration'. "
+        "Remove the bare string and replace with the prefixed form."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S2: IMF programme acceptance → Q1/Q2 INFORMAL poverty headcount delta
+# CM cert: +0.04 (Q1), +0.02 (Q2); entity_families=None; T3.
+# RED before #1657: no elasticity row + dead subscription string.
+# ---------------------------------------------------------------------------
+
+
+def test_imf_program_acceptance_triggers_q1_informal_delta() -> None:
+    """emergency_policy_imf_program_acceptance must raise Q1 INFORMAL PHC by 0.04.
+
+    CM cert 2026-07-04 (issue #1657 comment): IMF IEO (2018) mid-range 3–5pp
+    Q1 informal PHC increase → +0.04 per acceptance event (magnitude=1.0).
+    """
+    event = _emergency_policy_event(ENTITY, "imf_program_acceptance")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta produced for Q1 INFORMAL on "
+        "emergency_policy_imf_program_acceptance. Add the elasticity row (φ=+0.04) "
+        "to ELASTICITY_REGISTRY and fix the subscription string."
+    )
+    assert delta == Decimal("0.04"), (
+        f"Expected Q1 INFORMAL delta = +0.04 (CM cert: IMF IEO 2018 mid-range); got {delta}."
+    )
+
+
+def test_imf_program_acceptance_triggers_q2_informal_delta() -> None:
+    """emergency_policy_imf_program_acceptance must raise Q2 INFORMAL PHC by 0.02.
+
+    CM cert 2026-07-04: Ball et al. (2013) 0.60 scaling of Q1: 0.60 × 0.04 = 0.024 → +0.02.
+    """
+    event = _emergency_policy_event(ENTITY, "imf_program_acceptance")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q2_INFORMAL)
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q2 INFORMAL on "
+        "emergency_policy_imf_program_acceptance. Add Q2 INFORMAL elasticity row (φ=+0.02)."
+    )
+    assert delta == Decimal("0.02"), (
+        f"Expected Q2 INFORMAL delta = +0.02 (Ball 2013 0.60 scaling); got {delta}."
+    )
+
+
+def test_imf_program_acceptance_delta_is_positive() -> None:
+    """IMF programme acceptance must raise (not lower) Q1 informal poverty headcount.
+
+    Sign guard: conditionality channel raises PHC; negative elasticity would be wrong.
+    GREEN both before and after #1657 (verifies sign once row is present).
+    """
+    event = _emergency_policy_event(ENTITY, "imf_program_acceptance")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
+    if delta is None:
+        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta > Decimal("0"), (
+        f"IMF programme acceptance must increase Q1 informal PHC (δ > 0); got {delta}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S3: Emergency declaration → Q1/Q2 INFORMAL poverty headcount delta
+# CM cert: +0.06 (Q1), +0.04 (Q2); entity_families=None; T3.
+# RED before #1657: no elasticity row + dead subscription string.
+# ---------------------------------------------------------------------------
+
+
+def test_emergency_declaration_triggers_q1_informal_delta() -> None:
+    """emergency_policy_emergency_declaration must raise Q1 INFORMAL PHC by 0.06.
+
+    CM cert 2026-07-04: ILO (2020) 20–25% informal employment contraction → +0.06
+    per declaration (magnitude=1.0). Direct disruption channel, not GDP-mediated.
+    """
+    event = _emergency_policy_event(ENTITY, "emergency_declaration")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q1 INFORMAL on "
+        "emergency_policy_emergency_declaration. Add the elasticity row (φ=+0.06) "
+        "to ELASTICITY_REGISTRY and fix the subscription string."
+    )
+    assert delta == Decimal("0.06"), (
+        f"Expected Q1 INFORMAL delta = +0.06 (CM cert: ILO 2020); got {delta}."
+    )
+
+
+def test_emergency_declaration_triggers_q2_informal_delta() -> None:
+    """emergency_policy_emergency_declaration must raise Q2 INFORMAL PHC by 0.04.
+
+    CM cert 2026-07-04: Ball et al. (2013) 0.60 scaling: 0.60 × 0.06 = 0.036 → +0.04.
+    """
+    event = _emergency_policy_event(ENTITY, "emergency_declaration")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q2_INFORMAL)
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q2 INFORMAL on "
+        "emergency_policy_emergency_declaration. Add Q2 INFORMAL elasticity row (φ=+0.04)."
+    )
+    assert delta == Decimal("0.04"), (
+        f"Expected Q2 INFORMAL delta = +0.04 (Ball 2013 0.60 scaling); got {delta}."
+    )
+
+
+def test_emergency_declaration_delta_is_positive() -> None:
+    """Emergency declaration must raise (not lower) Q1 informal poverty headcount.
+
+    Sign guard. GREEN both before and after #1657.
+    """
+    event = _emergency_policy_event(ENTITY, "emergency_declaration")
+    events = _run_module(ENTITY, event)
+    delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
+    if delta is None:
+        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta > Decimal("0"), (
+        f"Emergency declaration must increase Q1 informal PHC (δ > 0); got {delta}."
+    )

--- a/docs/adr/ADR-020-emergency-instrument-transmission-pattern.md
+++ b/docs/adr/ADR-020-emergency-instrument-transmission-pattern.md
@@ -279,6 +279,16 @@ EmergencyInstrument variants. The implementing agent must:
 This audit is a **blocking prerequisite** for the G2D implementation PR. The CE agent
 must report audit findings to the Architect Agent before the PR is opened.
 
+**Audit completion record (2026-07-04, #1657):**
+Audit found two additional dead subscription strings: `"imf_program_acceptance"` and
+`"emergency_declaration"` (bare). Both were registered in NM-090. Fixed in #1657:
+- Subscription strings corrected to `"emergency_policy_imf_program_acceptance"` and
+  `"emergency_policy_emergency_declaration"` in `_SUBSCRIBED_EVENTS`
+- Elasticity rows added to `ELASTICITY_REGISTRY`: Q1 INFORMAL (+0.04 / +0.06) and
+  Q2 INFORMAL (+0.02 / +0.04); `entity_families=None`; T3; CM-certified 2026-07-04
+- Transmission table updated: both rows now show `✅ Active` in DemographicModule column
+- 9/9 unit tests GREEN post-implementation
+
 ### Decision 4: `known_limitations` Auto-Emission for CAPITAL_CONTROLS Gap Closure
 
 From the merge of the G2D ADR-020 implementation PR onward, the `emergency_policy_capital_controls`

--- a/docs/architecture/emergency-instrument-transmission-table.md
+++ b/docs/architecture/emergency-instrument-transmission-table.md
@@ -152,8 +152,8 @@ DemographicModule's `_SUBSCRIBED_EVENTS` as found in code (pre-ADR-020 fix):
 | Instrument | Canonical event string | GovernanceModule | ExternalSectorModule | MacroeconomicModule | DemographicModule | Audit status |
 |---|---|---|---|---|---|---|
 | `capital_controls` | `emergency_policy_capital_controls` | ❌ not subscribed (⚠️ original ✅ incorrect) | 🆕 ADR-020 | 🆕 ADR-020 | 🔧 fix + bridge | **AUDITED (ADR-020)** |
-| `imf_program_acceptance` | `emergency_policy_imf_program_acceptance` | ✅ (elasticity: `democratic_quality_score`) | ❌ not subscribed | ❌ not subscribed | ❌ `dead` (NM-090) | **AUDITED** |
-| `emergency_declaration` | `emergency_policy_emergency_declaration` | ✅ (elasticity: `democratic_quality_score`) | ❌ not subscribed | ❌ not subscribed | ❌ `dead` (NM-090) | **AUDITED** |
+| `imf_program_acceptance` | `emergency_policy_imf_program_acceptance` | ✅ (elasticity: `democratic_quality_score`) | ❌ not subscribed | ❌ not subscribed | ✅ Active (φ: Q1 INFORMAL +0.04, Q2 INFORMAL +0.02; T3; #1657) | **FIXED (#1657)** |
+| `emergency_declaration` | `emergency_policy_emergency_declaration` | ✅ (elasticity: `democratic_quality_score`) | ❌ not subscribed | ❌ not subscribed | ✅ Active (φ: Q1 INFORMAL +0.06, Q2 INFORMAL +0.04; T3; #1657) | **FIXED (#1657)** |
 | `debt_moratorium` | `emergency_policy_debt_moratorium` | ❌ not subscribed (⚠️ original ✅ unverified) | ❌ not subscribed | ❌ not subscribed | ❌ not subscribed | **AUDITED — no module channels active** |
 | `default_declaration` | `emergency_policy_default_declaration` | ❌ not subscribed (⚠️ original ✅ unverified) | ❌ not subscribed | ❌ not subscribed | ❌ not subscribed | **AUDITED — no module channels active** |
 | `bank_holiday` | `emergency_policy_bank_holiday` | ❌ not subscribed | ❌ not subscribed | ❌ not subscribed | ❌ not subscribed | **AUDITED — no module channels active** |


### PR DESCRIPTION
## Summary

- Fixes `_SUBSCRIBED_EVENTS` in `DemographicModule`: bare strings `"imf_program_acceptance"` and `"emergency_declaration"` replaced with canonical `"emergency_policy_imf_program_acceptance"` and `"emergency_policy_emergency_declaration"` (NM-090 resolution)
- Adds 4 `ELASTICITY_REGISTRY` rows for IMF programme acceptance and emergency declaration events, Q1/Q2 INFORMAL `poverty_headcount_ratio`; CM-certified 2026-07-04 on issue #1657
- Adds 9-test QA suite (`test_m19_g6_demographic_subscriptions.py`); all 9 GREEN post-implementation
- Updates `emergency-instrument-transmission-table.md`: both rows now `✅ Active`
- Records Decision 3 audit completion in ADR-020

## Test plan

- [x] Backend pre-push lint gate: `ruff check . && mypy app/` — PASS
- [x] `pytest tests/test_m19_g6_demographic_subscriptions.py` — 9/9 GREEN
- [x] Transmission table updated; ADR-020 Decision 3 audit record filed

## NM-084 gate

CM cert posted on issue #1657 (2026-07-04). PI Agent gate comment required on this PR.

Closes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFFbvSVhDQsQ5w35kmbhur