### PR TITLE
fix(g7): NM-056 — convert pytest.skip() guards to assert in G6 test file (#1729)

### DIFF
--- a/backend/tests/test_m19_g6_demographic_subscriptions.py
+++ b/backend/tests/test_m19_g6_demographic_subscriptions.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
-import pytest
-
 from app.simulation.modules.demographic.cohort import (
     AgeBand,
     CohortSpec,
@@ -227,8 +225,10 @@ def test_imf_program_acceptance_delta_is_positive() -> None:
     event = _emergency_policy_event(ENTITY, "imf_program_acceptance")
     events = _run_module(ENTITY, event)
     delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
-    if delta is None:
-        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q1 INFORMAL on "
+        "emergency_policy_imf_program_acceptance — elasticity row missing from registry."
+    )
     assert delta > Decimal("0"), (
         f"IMF programme acceptance must increase Q1 informal PHC (δ > 0); got {delta}."
     )
@@ -285,8 +285,10 @@ def test_emergency_declaration_delta_is_positive() -> None:
     event = _emergency_policy_event(ENTITY, "emergency_declaration")
     events = _run_module(ENTITY, event)
     delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
-    if delta is None:
-        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q1 INFORMAL on "
+        "emergency_policy_emergency_declaration — elasticity row missing from registry."
+    )
     assert delta > Decimal("0"), (
         f"Emergency declaration must increase Q1 informal PHC (δ > 0); got {delta}."
     )


### PR DESCRIPTION
## Summary

Fixes NM-056 violations in `backend/tests/test_m19_g6_demographic_subscriptions.py`.

Two tests (`test_imf_program_acceptance_delta_is_positive` and `test_emergency_declaration_delta_is_positive`) used `pytest.skip()` when the elasticity row was absent. This caused the G6 sprint exit to report "9/9 GREEN" when the true state was "7 PASS + 2 SKIP" — a false CI signal captured in NM-096.

**Discovery:** The 4 elasticity rows (`imf_program_acceptance` Q1/Q2 and `emergency_declaration` Q1/Q2) were already present in `elasticities.py` on `release/m19`. The `pytest.skip()` path was dead code — `delta` was never `None` in actual test runs. The structural NM-056 violation (skip in test body) remained regardless.

## Changes

- `backend/tests/test_m19_g6_demographic_subscriptions.py`
  - Lines 230–231: `if delta is None: pytest.skip(...)` → `assert delta is not None, "..."`
  - Lines 288–289: same fix for emergency declaration test
  - Remove unused `import pytest` (ruff F401)

## Verification

```
9/9 PASS; 0 SKIP
ruff check: All checks passed!
mypy: Success: no issues found in 73 source files
```

## Acceptance criteria satisfied

- AC-1–AC-4: elasticity rows exist (pre-existing on release/m19) ✅
- AC-3–AC-6: 4 delta tests PASS ✅
- AC-7: NM-056 fix applied — no `pytest.skip()` in test bodies ✅
- AC-8: 9/9 PASS, 0 SKIP ✅

## References

NM-056, NM-096, #1729, #1657, G7 sprint entry `m19-g7-sprint-entry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)