### PR TITLE
process(ds): CI backtesting incident log — NM-097 + ci-health infra review

### DIFF
--- a/docs/compliance/infra-reviews/2026-07-04-ci-health-review.md
+++ b/docs/compliance/infra-reviews/2026-07-04-ci-health-review.md
@@ -1,0 +1,252 @@
+# DevSecOps Infra Review — CI Health: Persistent backtesting Job Failure on release/m19
+
+**Type:** ci-health
+**Date:** 2026-07-04
+**Milestone:** M19 — Constraint Search and Empirical Calibration
+**Authored by:** DevSecOps Agent (DS)
+**Triggered by:** EL request — "DS Agent: please investigate and log this incident" (session 2026-07-04, following observation of CI failure on release/m19 during sprint/m19-g7 push attempt)
+**Sources:** GitHub Actions run logs (run IDs 28710969094, 28711570146, 28711962035); `ci.yml` workflow; CM Sprint A/B/C test files; near-miss registry; known-issues registry
+
+---
+
+## Incident Summary
+
+The `backtesting` CI job has been failing persistently on `release/m19` across multiple
+consecutive runs. The sprint/m19-g7 push was initially blocked because a required Ruleset
+check (`lint`) was in-progress on `release/m19` — the block resolved once CI completed,
+revealing the persistent backtesting failures below.
+
+**Affected CI runs (all on `release/m19`, event: `push`):**
+
+| Run ID | Created UTC | Conclusion |
+|---|---|---|
+| 28710969094 | 2026-07-04 15:32 | failure |
+| 28711570146 | 2026-07-04 15:54 | failure |
+| 28711923210 | 2026-07-04 16:07 | failure |
+| 28711962035 | 2026-07-04 16:09 | failure |
+
+**All four required Ruleset checks pass in each run:**
+`changes` ✅ · `lint` ✅ · `test-backend` ✅ · `compliance-scan` ✅
+
+The `backtesting` job is NOT a required check in `sprint-branch-ci-gate` or
+`release-branch-ci-gate`. PRs continue to auto-merge. The failure is visible in the
+overall run status but does not block merges.
+
+---
+
+## Part 1 — Root Cause Analysis
+
+### 1.1 Failing tests
+
+In each run, `pytest -m backtesting --tb=short -v` (run from `cd backend`) collects
+59 tests and produces 4 failures, all from CM Sprint A/B/C calibration test files:
+
+| Test | File | Failure |
+|---|---|---|
+| `test_grc_counterfactual_hd_composite_magnitude_at_step_4` | `tests/test_m19_cm_a_elasticity_calibration.py` | `per_step_diff[3]` not in [0.010, 0.20] |
+| `test_grc_counterfactual_per_step_diff_positive_at_step_4` | `tests/test_m19_cm_a_elasticity_calibration.py` | value non-positive |
+| `test_arg_hd_composite_divergence_within_magnitude_bounds` | `tests/test_m19_cm_b_elasticity_calibration.py` | `per_step_diff[2]` not in [0.003, 0.050] |
+| `test_pak_hd_composite_divergence_within_magnitude_bounds` | `tests/test_m19_cm_c_elasticity_calibration.py` | `per_step_diff[2]` not in [0.002, 0.035] |
+
+All 55 remaining tests PASS (standard backtesting fixtures: Greece, Argentina, Ecuador,
+Lebanon, Iceland, SEN, ZMB, G2A/G2C harness tests).
+
+### 1.2 Skip guard analysis
+
+All three CM calibration test files contain the same fixture-level skip guard:
+
+```python
+_DATABASE_URL = os.environ.get("DATABASE_URL")
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def asgi_client(self) -> AsyncGenerator[httpx.AsyncClient, None]:
+    if not _DATABASE_URL:
+        pytest.skip(
+            "DATABASE_URL not set — skipping CM Sprint A harness integration tests"
+        )
+```
+
+**The guard evaluates `_DATABASE_URL != None`.** This is insufficient.
+
+The CI `backtesting` job provides a full PostGIS service and sets:
+```yaml
+env:
+  DATABASE_URL: postgresql://worldsim:worldsim@localhost:5432/worldsim
+```
+
+So `_DATABASE_URL` IS set. The skip guard does NOT fire. The tests run.
+
+### 1.3 Database seeding gap
+
+The CI `backtesting` job seeds with:
+```yaml
+- name: Seed Natural Earth data (creates GRC entity required by backtesting)
+  run: cd backend && python -m app.db.seed.natural_earth_loader
+```
+
+`natural_earth_loader` creates entity records (country IDs, names, ISO codes). It does
+NOT load:
+- Economic scenario configurations (GDP growth rates, fiscal multipliers, initial state)
+- Simulation run input data (the parameters GRC/ARG/PAK counter-factual runs require)
+- Pre-computed hd_composite trajectory data
+
+The CM MAGNITUDE tests run a live simulation against the API (`httpx.AsyncClient` →
+`ASGITransport(app=app)`) — they require the API to return meaningful `hd_composite`
+divergence between heterodox and orthodox scenario paths. With only entity records
+seeded, the simulation has no economic input data and produces near-zero `hd_composite`
+values across all steps. `per_step_diff[3]` ≈ 0 → magnitude bounds fail.
+
+### 1.4 Why the `backtesting` job runs at all
+
+The `backtesting` job condition is:
+```yaml
+if: needs.changes.outputs.backtesting == 'true' ||
+    (github.event_name == 'workflow_dispatch' && inputs.force_backtesting == true)
+```
+
+The paths filter:
+```yaml
+backtesting:
+  - 'backend/tests/backtesting/**'
+  - 'backend/tests/fixtures/**'
+```
+
+The CM calibration test files are at `backend/tests/test_m19_cm_a/b/c_*.py` — NOT in
+`backend/tests/backtesting/`. They do not trigger the `backtesting` filter directly.
+
+**Observed trigger:** The `backtesting` job ran on all four push events. At least one
+of the triggering pushes corresponds to a merge of a PR that touched
+`backend/tests/backtesting/` or `backend/tests/fixtures/` (e.g., G2B SEN/ZMB fixture
+integration, G2C harness integration). The `dorny/paths-filter` action for push events
+compares against `github.event.before` — when multiple PRs merge rapidly or a prior
+CI run was queued, the diff window may span multiple PR merges, including ones that
+touched `backend/tests/backtesting/`. Once the backtesting filter fires, `pytest -m
+backtesting` collects ALL tests with that mark, including the CM calibration tests in
+`backend/tests/`.
+
+**Secondary finding:** The CM calibration test files carry `@pytest.mark.backtesting`
+but live in `backend/tests/` (not `backend/tests/backtesting/`). This creates a
+systematic divergence between "what files trigger the backtesting job" and "what tests
+the backtesting job runs." Changes to CM calibration files do NOT trigger the backtesting
+job; changes to unrelated backtesting fixture files DO pull in CM calibration test
+failures.
+
+### 1.5 Relationship to open issues
+
+The 4 failing tests are the AC-1 MAGNITUDE forward-condition tests for CM Sprint A
+(GRC), CM Sprint B (ARG), and CM Sprint C (PAK). These are tracked as:
+
+- **#1711** — Demo 8 Act 2 verification: GRC AC-1 live harness run
+- **#1712** — Demo 8 Act 2 verification: ARG AC-1 live harness run
+- **#1713** — Demo 8 Act 2 verification: PAK AC-1 live harness run
+
+All three are OPEN with status "DATABASE_URL prerequisite — no code changes." The intent
+was always to run these tests in a properly seeded environment, not in the CI backtesting
+job. They are designed as operational verification steps, not CI gates.
+
+---
+
+## Part 2 — Classification
+
+### 2.1 Known Issue vs Near-Miss determination
+
+Per CLAUDE.md: *"If the fix requires changing our own code, process, or documents →
+near-miss. If the fix requires waiting for an upstream vendor → Known Issue."*
+
+The fix requires changing our own code (the skip guard) or process (separating MAGNITUDE
+integration tests from the CI backtesting job). **This is a Near-Miss, not a Known Issue.**
+
+The root gaps are:
+
+1. **Skip guard scope mismatch (NM-097 — primary):** The `DATABASE_URL` guard prevents
+   skipping when CI has a database but the database lacks economic data. The correct
+   guard should verify data presence, not just database connectivity.
+
+2. **Test file location mismatch (NM-097 — secondary):** CM calibration MAGNITUDE tests
+   live in `backend/tests/` but carry `@pytest.mark.backtesting`. The backtesting job
+   CI filter watches `backend/tests/backtesting/**`. MAGNITUDE tests are invisibly pulled
+   into CI runs when unrelated fixture files change.
+
+### 2.2 Severity
+
+**Medium.** The `backtesting` job is not a required Ruleset check; PRs auto-merge
+regardless of its result. However:
+
+- `release/m19` has been showing "CI failure" status on every push for multiple days
+- The failure misleads engineers reviewing CI health (the run looks broken when it isn't)
+- If `backtesting` is ever added to a required check list, it would immediately block all
+  `release/m19` merges
+- The fix is straightforward and should precede Demo 8
+
+---
+
+## Part 3 — Recommended Process Improvements
+
+### 3.1 Immediate fix (data-presence guard)
+
+Add a data-presence check to the `asgi_client` fixture in all three CM calibration test
+files. The check verifies that the entity has economic scenario data loaded, not just
+that DATABASE_URL is set. Suggested implementation:
+
+```python
+@pytest_asyncio.fixture(loop_scope="session")
+async def asgi_client(self) -> AsyncGenerator[httpx.AsyncClient, None]:
+    if not _DATABASE_URL:
+        pytest.skip("DATABASE_URL not set — skipping CM harness integration tests")
+    # Verify GRC/ARG/PAK entity exists AND has simulation data beyond entity record
+    async with get_db_session() as session:
+        result = await session.execute(
+            text("SELECT COUNT(*) FROM simulation_runs WHERE entity_id = :eid"),
+            {"eid": ENTITY_ID}
+        )
+        if result.scalar_one() == 0:
+            pytest.skip(
+                f"No simulation runs for {ENTITY_ID} — live harness seeding required. "
+                f"See issues #1711/#1712/#1713."
+            )
+    async with httpx.AsyncClient(...) as client:
+        yield client
+```
+
+This makes the skip condition accurate: tests skip gracefully when the CI database has
+entity records but no simulation data. Tests run (and are expected to pass) only in a
+fully seeded environment.
+
+### 3.2 File location clarification
+
+Consider moving `test_m19_cm_a/b/c_elasticity_calibration.py` to
+`backend/tests/backtesting/` so that the paths filter correctly triggers the backtesting
+job when these files change. Currently changes to CM calibration test files do not
+re-trigger the backtesting CI job, which means test file changes are not validated by
+the full backtesting suite in CI.
+
+Alternatively, expand the `backtesting` paths filter to include `backend/tests/test_m19_cm_*.py`.
+
+### 3.3 NM filing
+
+Both root gaps are filed as NM-097 in `docs/process/near-miss-registry.md`.
+
+---
+
+## Part 4 — Ruleset Health Status
+
+**sprint-branch-ci-gate** (Node ID `RRS_lACqUmVwb3NpdG9yecc5IKi2kzgEV92A`)
+Required checks: `changes`, `lint`, `test-backend`, `compliance-scan` — all passing ✅
+`backtesting` NOT required — intentional (live database requirement). **Status: NOMINAL.**
+
+**release-branch-ci-gate** — required checks per CLAUDE.md equivalent.
+All required checks passing on `release/m19`. **Status: NOMINAL.**
+
+**`backtesting` job:** FAILING persistently due to CM MAGNITUDE tests (NM-097). Not
+blocking merges. **Status: DEGRADED — fix tracked NM-097.**
+
+---
+
+## Part 5 — Immediate Recommendations
+
+| Priority | Action | Owner | Blocker |
+|---|---|---|---|
+| High | Add data-presence guard to CM calibration test fixtures | CE Agent / DS Agent | Demo 8 internal review |
+| High | File NM-097 | PI Agent | — |
+| Medium | Move `test_m19_cm_a/b/c_*` to `backend/tests/backtesting/` or expand filter | DS Agent | Post-G7 |
+| Low | Add economic data seeding step to backtesting CI job for full MAGNITUDE test support | DS Agent | Post-M19 |

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -4780,6 +4780,107 @@ Near-miss cross-references: NM-056 (no pytest.skip() in test bodies); NM-090/091
 
 ---
 
+## NM-097 — CM Sprint A/B/C MAGNITUDE Tests Run Against Under-Seeded CI Database; Skip Guard Checks DATABASE_URL Presence Only; Four Tests Fail Persistently on release/m19 (Reactive)
+
+**Date:** 2026-07-04
+**Milestone:** M19 — Constraint Search and Empirical Calibration
+**Detected by:** DS Agent — CI health review (2026-07-04), triggered by EL observation of persistent `backtesting` CI failure during sprint/m19-g7 push monitoring
+**Severity:** Medium
+
+### What happened
+
+Three CM calibration test files (`test_m19_cm_a/b/c_elasticity_calibration.py`) carry
+`@pytest.mark.backtesting` and contain MAGNITUDE forward-condition tests (AC-1). Each
+file's `asgi_client` fixture has a skip guard: `if not _DATABASE_URL: pytest.skip(...)`.
+
+The CI `backtesting` job provides a full PostGIS service and sets `DATABASE_URL` in
+its environment. The skip guard evaluates only `_DATABASE_URL != None` — it does NOT
+verify that the database contains the economic simulation data required to produce
+non-zero `hd_composite` divergence. When the guard fires (it never does in CI), the
+condition is never correct: DATABASE_URL is always set.
+
+The CI backtesting job seeds only Natural Earth entity records (`natural_earth_loader`).
+GRC/ARG/PAK counter-factual simulation runs require economic scenario configuration data
+that is never loaded. The simulation produces near-zero `hd_composite` values across all
+steps. The magnitude bounds (`per_step_diff[3] ∈ [0.010, 0.20]` for GRC, etc.) are not
+satisfied. Four tests fail in every CI run that collects them.
+
+**Secondary gap:** CM calibration test files live in `backend/tests/` (root), not in
+`backend/tests/backtesting/`. The `backtesting` paths filter watches
+`backend/tests/backtesting/**` and `backend/tests/fixtures/**`. Changes to CM calibration
+files do NOT trigger the backtesting job; changes to unrelated backtesting fixture files
+DO pull in CM calibration test failures.
+
+Result: `release/m19` has shown persistent "CI failure" status for multiple consecutive
+push events (run IDs: 28710969094, 28711570146, 28711923210, 28711962035 — all `push`
+events on `release/m19`). All four required Ruleset checks continue to pass; auto-merge
+is not affected. But the CI signal is degraded and misleading.
+
+### What was at risk
+
+1. **CI signal integrity:** `release/m19` appearing permanently "broken" makes it
+   harder to detect real regressions. Engineers reviewing CI health see failure and
+   cannot immediately distinguish this known failure from a new real failure.
+
+2. **Merge-blocking if Ruleset is ever updated:** If `backtesting` is added to
+   `sprint-branch-ci-gate` or `release-branch-ci-gate` required checks, this failure
+   would immediately block all PRs on `release/m19` until fixed.
+
+3. **False test signal:** The MAGNITUDE tests are designed to verify that calibrated
+   elasticity values produce empirically grounded `hd_composite` divergence in a live
+   scenario. Running them against an under-seeded database produces a false failure
+   that obscures whether the code is actually correct — the tests are neither passing
+   for the right reason nor failing for the right reason.
+
+4. **Ongoing Demo 8 pre-flight:** With Demo 8 approaching at M19 close, a persistently
+   failing CI job on the release branch creates unnecessary noise during a critical
+   verification period.
+
+### What caught it
+
+DS Agent CI health review on 2026-07-04, triggered by EL observation that the
+`sprint/m19-g7` push appeared to be blocked (it was blocked briefly by an in-progress
+`lint` run; the real CI failure was visible once the run completed). The `backtesting`
+failure had been present across all monitored `release/m19` runs, meaning it predates
+this session by multiple PRs. No agent or automated gate caught it earlier — the
+Ruleset correctly excludes `backtesting` from required checks, so merge gates did not
+fire, and no process required reviewing the non-required job results.
+
+This is a process gap: non-required CI jobs on a release branch should have a defined
+review cadence (e.g., DS Agent CI health review at each wave entry) so persistent
+degraded jobs are noticed before they accumulate.
+
+### Process improvement
+
+**Immediate fix (test-level):** Add a data-presence check to the `asgi_client`
+fixture in all three CM calibration test files. The check queries the database for
+the presence of simulation run data for the relevant entity (GRC/ARG/PAK) — if absent,
+skip gracefully with a message directing to #1711/#1712/#1713. This makes the skip
+condition semantically accurate: tests skip when the database is under-seeded, not only
+when the database is absent.
+
+**File location clarification:** Move `test_m19_cm_a/b/c_elasticity_calibration.py`
+to `backend/tests/backtesting/` OR expand the `backtesting` paths filter to include
+`backend/tests/test_m19_cm_*.py`. Currently these files are invisible to the paths
+filter, meaning changes to them do not re-trigger the backtesting job.
+
+**CI health review cadence:** DS Agent should perform a `ci-health` infra review at
+each sprint wave entry as part of the standard gate sequence. Non-required CI job
+failures should be reviewed and classified (near-miss or known-issue) within one sprint
+group of first appearance.
+
+**Filed artifacts:**
+- This NM-097 entry
+- `docs/compliance/infra-reviews/2026-07-04-ci-health-review.md` (DS Agent, 2026-07-04)
+
+**Fix tracked:** Issue #1711/#1712/#1713 operational verification path. The data-presence
+guard fix should be a separate ticket or folded into the DATABASE_URL live harness
+seeding work already tracked in those issues. EL to decide sprint assignment.
+
+Near-miss cross-references: NM-056 (pytest.skip() usage pattern — skip guard in fixture is NM-056-compliant in form but semantically broken for the CI under-seeded case); NM-096 (same sprint era — CI health review prompted by G7 work reveals adjacent CI gap).
+
+---
+
 ## NM-NNN — [Short descriptive title]
 
 **Date:** YYYY-MM-DD (or approximate milestone era)


### PR DESCRIPTION
## Summary

DS Agent incident log for persistent `backtesting` CI failure on `release/m19`.

**Root cause (NM-097):**
- CM Sprint A/B/C MAGNITUDE tests carry `@pytest.mark.backtesting` and a skip guard that checks only `DATABASE_URL` presence
- CI `backtesting` job provides `DATABASE_URL` (full PostGIS) but seeds only Natural Earth entity records — not the economic simulation data required for non-zero `hd_composite` divergence
- Four MAGNITUDE tests fail in every CI run: `test_grc_counterfactual_hd_composite_magnitude_at_step_4`, `test_grc_counterfactual_per_step_diff_positive_at_step_4`, `test_arg_hd_composite_divergence_within_magnitude_bounds`, `test_pak_hd_composite_divergence_within_magnitude_bounds`
- Secondary gap: CM calibration files live in `backend/tests/` (not `backend/tests/backtesting/`) — path filter and test collection are misaligned

**Severity:** Medium — `backtesting` is not a required Ruleset check so PRs auto-merge; but CI signal is persistently degraded on `release/m19`

## Artifacts

- `docs/compliance/infra-reviews/2026-07-04-ci-health-review.md` (type: `ci-health`, DS Agent)
- NM-097 appended to `docs/process/near-miss-registry.md`

## Fix required

Add data-presence guard to `asgi_client` fixture in all three CM calibration test files (checks for presence of simulation run data, not just DATABASE_URL). EL to decide sprint assignment — tracked via #1711/#1712/#1713 operational verification path.

## Process lane

PM Agent shared-state lane (`chore/m19-state-sync-NNN` → `release/m19`). Pre-push gates: all passed ✅