### PR TITLE
fix(harness): _classify_direction respects primary_indicator for composite fields (#1739)

### DIFF
--- a/backend/app/harness/mode3_harness.py
+++ b/backend/app/harness/mode3_harness.py
@@ -355,6 +355,11 @@ def _classify_fidelity(
     )
 
 
+_COMPOSITE_INDICATOR_FIELDS = frozenset(
+    {"hd_composite", "fin_composite", "eco_composite", "gov_composite"}
+)
+
+
 def _classify_direction(
     cf_records: list[dict[str, Any]],
     baseline_records: list[dict[str, Any]],
@@ -363,30 +368,44 @@ def _classify_direction(
 ) -> tuple[DirectionVerdict, list[Decimal], int | None]:
     """Compute per-step differential and classify Type B direction verdict.
 
-    Uses PSP as the primary comparison metric; falls back to financial
-    composite when PSP is unavailable. Both trajectories produce INDISTINGUISHABLE
-    when composite data is absent from both sides (unit-test path).
+    When primary_indicator names a composite field (hd_composite, fin_composite,
+    eco_composite, gov_composite), that field is used directly for comparison.
+    Otherwise falls back to: PSP → fin_composite → 0.
     """
     per_step_diff: list[Decimal] = []
     threshold = Decimal("0.01")
 
     for i in range(n_steps):
-        cf_psp = cf_records[i].get("psp") if i < len(cf_records) else None
-        bl_psp = baseline_records[i].get("psp") if i < len(baseline_records) else None
-
-        if cf_psp is not None and bl_psp is not None:
-            per_step_diff.append(cf_psp - bl_psp)
-        else:
-            cf_fin = cf_records[i].get("fin_composite") if i < len(cf_records) else None
-            bl_fin = (
-                baseline_records[i].get("fin_composite")
+        if primary_indicator in _COMPOSITE_INDICATOR_FIELDS:
+            cf_val = cf_records[i].get(primary_indicator) if i < len(cf_records) else None
+            bl_val = (
+                baseline_records[i].get(primary_indicator)
                 if i < len(baseline_records)
                 else None
             )
-            if cf_fin is not None and bl_fin is not None:
-                per_step_diff.append(cf_fin - bl_fin)
+            if cf_val is not None and bl_val is not None:
+                per_step_diff.append(cf_val - bl_val)
             else:
                 per_step_diff.append(Decimal("0"))
+        else:
+            cf_psp = cf_records[i].get("psp") if i < len(cf_records) else None
+            bl_psp = baseline_records[i].get("psp") if i < len(baseline_records) else None
+
+            if cf_psp is not None and bl_psp is not None:
+                per_step_diff.append(cf_psp - bl_psp)
+            else:
+                cf_fin = (
+                    cf_records[i].get("fin_composite") if i < len(cf_records) else None
+                )
+                bl_fin = (
+                    baseline_records[i].get("fin_composite")
+                    if i < len(baseline_records)
+                    else None
+                )
+                if cf_fin is not None and bl_fin is not None:
+                    per_step_diff.append(cf_fin - bl_fin)
+                else:
+                    per_step_diff.append(Decimal("0"))
 
     first_significant: int | None = None
     for idx, diff in enumerate(per_step_diff):

--- a/backend/tests/backtesting/test_m19_g2a_headless_harness.py
+++ b/backend/tests/backtesting/test_m19_g2a_headless_harness.py
@@ -726,3 +726,5 @@ class TestGreeceTypeARegressionFidelity:
             )
         finally:
             await asgi_client.delete(f"/api/v1/scenarios/{scenario_id}")
+
+

--- a/backend/tests/unit/test_m19_g8_classify_direction.py
+++ b/backend/tests/unit/test_m19_g8_classify_direction.py
@@ -1,0 +1,82 @@
+"""Unit tests for _classify_direction — NM-098 fix (G8).
+
+Verifies that primary_indicator is respected when it names a composite field,
+and that the PSP → fin_composite fallback chain is preserved for None / 'psp'.
+"""
+
+from decimal import Decimal
+
+from app.harness.mode3_harness import DirectionVerdict, _classify_direction
+
+
+class TestClassifyDirection:
+    def _make_records(self, **kwargs: str) -> list[dict]:
+        return [{k: Decimal(v) for k, v in kwargs.items()}]
+
+    def test_hd_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(hd_composite="0.70", fin_composite="0.50")
+        bl = self._make_records(hd_composite="0.60", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "hd_composite")
+        assert diffs == [Decimal("0.10")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+
+    def test_fin_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(hd_composite="0.90", fin_composite="0.40")
+        bl = self._make_records(hd_composite="0.80", fin_composite="0.55")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "fin_composite")
+        assert diffs == [Decimal("-0.15")]
+        assert verdict == DirectionVerdict.BASELINE_BETTER
+
+    def test_eco_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(eco_composite="0.30", fin_composite="0.50")
+        bl = self._make_records(eco_composite="0.20", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "eco_composite")
+        assert diffs == [Decimal("0.10")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+
+    def test_gov_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(gov_composite="0.65", fin_composite="0.50")
+        bl = self._make_records(gov_composite="0.65", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "gov_composite")
+        assert diffs == [Decimal("0.00")]
+        assert verdict == DirectionVerdict.INDISTINGUISHABLE
+
+    def test_none_primary_indicator_falls_back_to_psp(self) -> None:
+        cf = self._make_records(psp="0.05", fin_composite="0.50")
+        bl = self._make_records(psp="0.02", fin_composite="0.50")
+        _, diffs, _ = _classify_direction(cf, bl, 1, None)
+        assert diffs == [Decimal("0.03")]
+
+    def test_none_primary_indicator_falls_back_to_fin_composite_when_no_psp(self) -> None:
+        cf = self._make_records(fin_composite="0.60")
+        bl = self._make_records(fin_composite="0.40")
+        _, diffs, _ = _classify_direction(cf, bl, 1, None)
+        assert diffs == [Decimal("0.20")]
+
+    def test_psp_primary_indicator_uses_fallback_chain(self) -> None:
+        cf = self._make_records(psp="0.04", hd_composite="0.90")
+        bl = self._make_records(psp="0.02", hd_composite="0.50")
+        _, diffs, _ = _classify_direction(cf, bl, 1, "psp")
+        assert diffs == [Decimal("0.02")]
+
+    def test_composite_field_absent_appends_zero(self) -> None:
+        cf = self._make_records(fin_composite="0.50")
+        bl = self._make_records(fin_composite="0.40")
+        _, diffs, _ = _classify_direction(cf, bl, 1, "hd_composite")
+        assert diffs == [Decimal("0")]
+
+    def test_hd_composite_multi_step(self) -> None:
+        cf = [
+            {"hd_composite": Decimal("0.70")},
+            {"hd_composite": Decimal("0.72")},
+            {"hd_composite": Decimal("0.74")},
+        ]
+        bl = [
+            {"hd_composite": Decimal("0.60")},
+            {"hd_composite": Decimal("0.58")},
+            {"hd_composite": Decimal("0.57")},
+        ]
+        verdict, diffs, first_sig = _classify_direction(cf, bl, 3, "hd_composite")
+        assert diffs == [Decimal("0.10"), Decimal("0.14"), Decimal("0.17")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+        assert first_sig == 1


### PR DESCRIPTION
## Summary

- **NM-098 fix**: `_classify_direction` accepted `primary_indicator: str | None` but the function body ignored it, always falling back to PSP → fin_composite.
- Added `_COMPOSITE_INDICATOR_FIELDS = frozenset({"hd_composite", "fin_composite", "eco_composite", "gov_composite"})` and a routing branch that reads the named field directly when `primary_indicator` is in that set.
- Fallback chain (PSP → fin_composite → 0) preserved for `None` and non-composite values.
- 9 new unit tests in `tests/unit/test_m19_g8_classify_direction.py` (no asyncio pytestmark).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy app/` — clean (73 source files)
- [x] `npm run build` — clean
- [x] `tests/unit/test_m19_g8_classify_direction.py` — 9/9 PASS
- [ ] After merge: GRC Act 2 live verification — expect `per_step_diff[3] = 0.1561 ∈ [0.010, 0.20]` PASS (#1711)

## Issues

Closes #1739
Unblocks #1711 (GRC Act 2 verification)

Sprint: G8 (`sprint/m19-g8`)
Sprint entry: `docs/process/sprint-plans/m19-g8-sprint-entry.md`
Near-miss: NM-098

🤖 Generated with [Claude Code](https://claude.com/claude-code)