### PR TITLE
test(cm-a/b/c): pre-advance baseline before TYPE_B run_harness

### DIFF
--- a/backend/tests/test_m19_cm_a_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_a_elasticity_calibration.py
@@ -798,6 +798,14 @@ class TestAC1MagnitudeDivergence:
         )
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"AC-1 FAIL (baseline advance step {_step}): "
+                f"{_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=build_greece_counterfactual_scenario().model_dump(mode="json"),
@@ -882,6 +890,12 @@ class TestAC1MagnitudeDivergence:
         assert baseline_resp.status_code == 201
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=build_greece_counterfactual_scenario().model_dump(mode="json"),
@@ -932,6 +946,12 @@ class TestAC1MagnitudeDivergence:
         )
         assert baseline_resp.status_code == 201
         baseline_id: str = baseline_resp.json()["scenario_id"]
+
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
 
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",

--- a/backend/tests/test_m19_cm_b_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_b_elasticity_calibration.py
@@ -797,6 +797,14 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
+
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),
@@ -852,6 +860,13 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
+
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),

--- a/backend/tests/test_m19_cm_c_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_c_elasticity_calibration.py
@@ -852,6 +852,14 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_pakistan_counterfactual_scenario()
+
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),
@@ -908,6 +916,13 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_pakistan_counterfactual_scenario()
+
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),


### PR DESCRIPTION
## Root cause

`run_harness` TYPE_B fetches the baseline trajectory without advancing it — the caller must pre-advance. All three CM sprint `TestAC1MagnitudeDivergence` tests created the baseline scenario and immediately called `run_harness(TYPE_B, baseline_run_id=baseline_id)`. The baseline had zero snapshots, the trajectory endpoint returned 409, `_fetch_trajectory` returned `[]`, and every baseline per-step record had `hd_composite=None`. With the G8 `_classify_direction` fix in place, `cf_val - bl_val` becomes `0 - None → Decimal('0')` for every step, producing `per_step_diff=[0,0,0,0,0,0]` and `direction_verdict=INDISTINGUISHABLE`.

Root cause identified in G8 CM Agent consultation (2026-07-04). NM-098.

Note: the fixture comment at `greece_2010_scenario.py:640` ("Financial and human_development composites are null — Issue #193") is in `build_greece_demo_scenario()` only — that variant uses governance-only indicators. `build_greece_scenario()` includes `unemployment_rate` + `net_enrollment_secondary` and produces non-null `hd_composite` via `_normalized_absolute_strategy`. This was confirmed by the empirical data already recorded in `m19-g8-sprint-entry.md` (BL `hd_composite=0.5464` at step 1).

## Changes

- `test_m19_cm_a_elasticity_calibration.py`: 3 tests — advance GRC baseline 6 steps before `run_harness`
- `test_m19_cm_b_elasticity_calibration.py`: 2 tests — advance ARG baseline `n_steps` before `run_harness`  
- `test_m19_cm_c_elasticity_calibration.py`: 2 tests — advance PAK baseline `n_steps` before `run_harness`

## Test plan

- [ ] `pytest -m backtesting -k TestAC1MagnitudeDivergence` with `DATABASE_URL` set: all tests should pass (direction_verdict=COUNTER_FACTUAL_BETTER, per_step_diff[3] ∈ [0.010, 0.20] for GRC)
- [ ] ruff + mypy PASS (confirmed locally)
- [ ] Frontend build PASS (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)