### PR TITLE
test(cm-b): cap ARG baseline pre-advance to baseline n_steps

### DIFF
--- a/backend/tests/test_m19_cm_b_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_b_elasticity_calibration.py
@@ -797,9 +797,12 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
-
-        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
-        for _step in range(1, cf_req.configuration.n_steps + 1):
+        # Advance baseline only to its own n_steps. ARG baseline has 2 steps (crisis window);
+        # CF has 3 steps (includes Kirchner recovery). Step-3 BL will be absent until CM-D
+        # adds recovery inputs — that absence should surface as a magnitude assertion failure,
+        # not a setup 409.
+        baseline_n_steps = build_argentina_scenario().configuration.n_steps
+        for _step in range(1, baseline_n_steps + 1):
             _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
             assert _adv.status_code == 200, (
                 f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
@@ -860,8 +863,8 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
-
-        for _step in range(1, cf_req.configuration.n_steps + 1):
+        baseline_n_steps = build_argentina_scenario().configuration.n_steps
+        for _step in range(1, baseline_n_steps + 1):
             _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
             assert _adv.status_code == 200, (
                 f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"


### PR DESCRIPTION
## Fix

Follow-up to #1745. CM_B `test_arg_type_b_harness_completes` and `test_arg_hd_composite_divergence_within_magnitude_bounds` were failing with setup 409s:

> Baseline advance step 3 failed: 409 {"detail":"Scenario already completed."}

Root cause: `build_argentina_scenario()` has `n_steps=2` (crisis window); `build_argentina_counterfactual_scenario()` has `n_steps=3` (includes Kirchner recovery). PR #1745 used `cf_req.configuration.n_steps` for the baseline loop — which is 3 — so step 3 hit the "already completed" guard.

Fix: advance baseline only `build_argentina_scenario().configuration.n_steps` steps (2). Step-3 BL will be absent until CM-D adds Kirchner recovery inputs to the ARG baseline. Until then, the magnitude assertion at step index 2 is the correct "RED" failure signal, not a setup crash.

Confirmed from the dispatch run: CM_A (GRC) 3/3 PASSED, CM_C (PAK) 3/3 PASSED, CM_B needs CM-D for step-3 BL data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)