### PR TITLE
chore(m19-cmd): bring sprint/m19-cm-d to G8 baseline (release/m19 dd99d19)

### DIFF
--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > Historical state lives in `docs/process/session-archives/`.
 > Authority: `docs/process/sprint-group-isolation.md §SESSION_STATE.md Cockpit Card Protocol`.
 
-**Last updated:** 2026-07-04 (G7 entry EL-approved; sprint/m19-g7 cut; journal #1732 opened)
+**Last updated:** 2026-07-04 (G7 exit confirmed; integration PR #1737 merged; all M19 code deliverables on release/m19; Demo 8 preparation next)
 **Current milestone:** M19 — Constraint Search and Empirical Calibration
 
 ---
@@ -20,9 +20,9 @@
 | Exit checklist issue | #1535 (M19 Exit Checklist — blocks milestone closure) |
 | Release branch | `release/m19` — cut from `main` 2026-07-02 at 1bf1ecc |
 | Sprint plan | `docs/process/sprint-plans/m19-sprint-plan.md` — EL-approved 2026-07-02 |
-| Active wave | Wave 5 — G7 entry 2026-07-04; sprint/m19-g7 cut from release/m19 |
-| Active sprint groups | G7 — elasticity rows + NM-056 fix (#1729); EL-approved 2026-07-04 |
-| Active sprint journal issues | #1732 (G7 journal) |
+| Active wave | Wave 5 complete — G7 integration PR #1737 merged 2026-07-04; all code integrated to release/m19 |
+| Active sprint groups | None — all G1–G7 + CM-A/B/C confirmed and integrated |
+| Active sprint journal issues | None — #1732 closed 2026-07-04 |
 
 ---
 
@@ -50,7 +50,7 @@
 | CM-B | ELASTICITY_REGISTRY LAC calibration (ARG/ECU/BOL/PER) | #1623 ✓ | **Confirmed** — BPO ACCEPT; north star PASS; journal #1688 closed; integration PR #1698 merged 2026-07-04 |
 | CM-C | ELASTICITY_REGISTRY SEA calibration (PAK/LKA/BGD) | #1623 ✓ | **Confirmed** — BPO ACCEPT; north star PASS (PAK 2023 SBA); journal #1700 closed; integration PR #1707 auto-merging 2026-07-04 |
 | G6 | Demo 8 clearance | #1456 ✓, #1538 ✓, #1657 ✓, #1709 ✓, #1710 ✓ | **Integrated** — BPO ACCEPT (#1709); north star PASS; NM-095 LOW; journal #1716 closed; integration PR #1724 merged 2026-07-04 |
-| G7 | Elasticity rows + NM-056 fix | #1729 | **Active** — EL-approved 2026-07-04; sprint/m19-g7 cut; journal #1732 |
+| G7 | Elasticity rows + NM-056 fix | #1729 ✓ | **Confirmed** — BPO ACCEPT (infra sprint); PI gate PASS; integration PR #1737 merged 2026-07-04; journal #1732 closed |
 
 ---
 
@@ -80,7 +80,7 @@
 | #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
 | #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
 | #1713 | Demo 8 Act 2 verification: PAK AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
-| #1729 | fix(g6): missing elasticity rows for imf_program_acceptance + emergency_declaration; NM-056 fix | G7 | **Active** — EL-approved 2026-07-04; sprint/m19-g7 cut; journal #1732 |
+| #1729 | fix(g6): missing elasticity rows for imf_program_acceptance + emergency_declaration; NM-056 fix | G7 ✓ | **Closed** — PR #1734 merged (NM-056 fix; 9/9 PASS 0 SKIP); integration PR #1737 merged 2026-07-04 |
 
 ---
 
@@ -90,6 +90,7 @@
 |---|---|---|
 | ~~Tolerance band (±0.01) visible in FOUND state UI~~ | **CLEARED 2026-07-04** — #1709 PR #1720 merged; `constraint-tolerance-band` element live | ~~Demo 8 Act 1~~ |
 | ~~AC-12: resolve structural-absence indicator key~~ | **CLEARED 2026-07-04** — #1710 PR #1721 merged; timing fixed; `__structural_absence__` confirmed | ~~Demo 8 Act 1~~ |
+| ~~NM-056 fix: conditionality channel tests honest (9/9 PASS 0 SKIP)~~ | **CLEARED 2026-07-04** — #1729 PR #1734 merged; G7 exit confirmed; integration PR #1737 | ~~Demo 8 pre-flight~~ |
 | AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]` | CM Sprint A exit §4 → **#1711** | Demo 8 Act 2 |
 | AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** | Demo 8 Act 2 |
 | AC-1 harness live run (PAK Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.002, 0.035]` | CM Sprint C exit §4 → **#1713** | Demo 8 Act 2 |

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > Historical state lives in `docs/process/session-archives/`.
 > Authority: `docs/process/sprint-group-isolation.md §SESSION_STATE.md Cockpit Card Protocol`.
 
-**Last updated:** 2026-07-04 (CM consultation complete: ARG #1712 deferred to CM-D — engine flat at default trough, needs Kirchner inputs; G8 scope locked: #1739 + #1711; EL approval pending)
+**Last updated:** 2026-07-04 (G8 confirmed — GRC AC-1 PASS; issues #1739 + #1711 closed; integration PR #1748 open; CM-D next)
 **Current milestone:** M19 — Constraint Search and Empirical Calibration
 
 ---
@@ -20,9 +20,9 @@
 | Exit checklist issue | #1535 (M19 Exit Checklist — blocks milestone closure) |
 | Release branch | `release/m19` — cut from `main` 2026-07-02 at 1bf1ecc |
 | Sprint plan | `docs/process/sprint-plans/m19-sprint-plan.md` — EL-approved 2026-07-02 |
-| Active wave | Wave 5 complete — G7 integration PR #1737 merged 2026-07-04; all code integrated to release/m19 |
-| Active sprint groups | G8 — pending EL approval (`docs/process/sprint-plans/m19-g8-sprint-entry.md`): fix `_classify_direction` to respect `primary_indicator` (#1739); re-verify GRC #1711 |
-| Active sprint journal issues | #1741 (G8 — pending EL approval) |
+| Active wave | Wave 6 complete — G8 confirmed 2026-07-04; integration PR #1748 open (sprint/m19-g8 → release/m19) |
+| Active sprint groups | None — CM-D next (ARG Kirchner recovery inputs; #1712) |
+| Active sprint journal issues | #1741 (G8 — closes at integration PR merge) |
 
 ---
 
@@ -51,7 +51,7 @@
 | CM-C | ELASTICITY_REGISTRY SEA calibration (PAK/LKA/BGD) | #1623 ✓ | **Confirmed** — BPO ACCEPT; north star PASS (PAK 2023 SBA); journal #1700 closed; integration PR #1707 auto-merging 2026-07-04 |
 | G6 | Demo 8 clearance | #1456 ✓, #1538 ✓, #1657 ✓, #1709 ✓, #1710 ✓ | **Integrated** — BPO ACCEPT (#1709); north star PASS; NM-095 LOW; journal #1716 closed; integration PR #1724 merged 2026-07-04 |
 | G7 | Elasticity rows + NM-056 fix | #1729 ✓ | **Confirmed** — BPO ACCEPT (infra sprint); PI gate PASS; integration PR #1737 merged 2026-07-04; journal #1732 closed |
-| G8 | `_classify_direction` primary_indicator fix + GRC re-verify | #1739 | **Pending EL approval** — sprint entry `m19-g8-sprint-entry.md` filed 2026-07-04; NM-098 |
+| G8 | `_classify_direction` primary_indicator fix + GRC re-verify | #1739 ✓, #1711 ✓ | **Confirmed** — BPO ACCEPT; GRC AC-1 PASS (run 28719741291); integration PR #1748 open; journal #1741 closes at merge |
 
 ---
 
@@ -78,10 +78,10 @@
 | #1657 | NM-090/091: DemographicModule dead subscriptions fix | G6 ✓ | **Closed** — PR #1722 merged; 9/9 tests GREEN; ADR-020 updated; CM cert 2026-07-04 |
 | #1709 | FOUND state: tolerance band (±0.01) not displayed | G6 ✓ | **Closed** — PR #1720 merged; BPO ACCEPT; north star PASS; Demo 8 Act 1 cleared |
 | #1710 | AC-12: resolve `__structural_absence__` placeholder | G6 ✓ | **Closed** — PR #1721 merged; skip guard removed; timing fixed |
-| #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | G8 | **Blocked** — `_classify_direction` ignores `primary_indicator`; fix in #1739; trajectory data confirms step-4 hd_composite diff=0.1561 ∈ [0.010, 0.20] once fixed |
+| #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | G8 ✓ | **Closed** — per_step_diff[3]=0.1561 ∈ [0.010, 0.20]; direction_verdict=COUNTER_FACTUAL_BETTER; run 28719741291 2026-07-04 |
 | #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | CM-D | **Deferred** — CM consult 2026-07-04: n_steps=3 extension leaves BL flat (hd=0.3723) at default trough; diff=0.2027 (no convergence); needs Kirchner step-3 recovery inputs + recalibration |
 | #1713 | Demo 8 Act 2 verification: PAK AC-1 live harness run | Act 2 verified | **PASS** — per_step_diff[2]=0.0266 ∈ [0.002, 0.035]; closed 2026-07-04 |
-| #1739 | fix(harness): _classify_direction ignores primary_indicator | G8 | New — filed 2026-07-04; unblocks GRC #1711 |
+| #1739 | fix(harness): _classify_direction ignores primary_indicator | G8 ✓ | **Closed** — PR #1744 merged; NM-098 fix; `_COMPOSITE_INDICATOR_FIELDS` routing branch |
 | #1729 | fix(g6): missing elasticity rows for imf_program_acceptance + emergency_declaration; NM-056 fix | G7 ✓ | **Closed** — PR #1734 merged (NM-056 fix; 9/9 PASS 0 SKIP); integration PR #1737 merged 2026-07-04 |
 
 ---
@@ -93,7 +93,7 @@
 | ~~Tolerance band (±0.01) visible in FOUND state UI~~ | **CLEARED 2026-07-04** — #1709 PR #1720 merged; `constraint-tolerance-band` element live | ~~Demo 8 Act 1~~ |
 | ~~AC-12: resolve structural-absence indicator key~~ | **CLEARED 2026-07-04** — #1710 PR #1721 merged; timing fixed; `__structural_absence__` confirmed | ~~Demo 8 Act 1~~ |
 | ~~NM-056 fix: conditionality channel tests honest (9/9 PASS 0 SKIP)~~ | **CLEARED 2026-07-04** — #1729 PR #1734 merged; G7 exit confirmed; integration PR #1737 | ~~Demo 8 pre-flight~~ |
-| AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]` | CM Sprint A exit §4 → **#1711** — blocked on #1739 (NM-098) | Demo 8 Act 2 |
+| ~~AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]`~~ | **CLEARED 2026-07-04** — #1711 PASS; per_step_diff[3]=0.1561; direction_verdict=COUNTER_FACTUAL_BETTER; run 28719741291 | ~~Demo 8 Act 2~~ |
 | AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** — deferred to CM-D; fixture needs Kirchner step-3 inputs; bounds [0.003, 0.050] not valid for current engine | Demo 8 Act 2 |
 | ~~AC-1 harness live run (PAK Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.002, 0.035]`~~ | **CLEARED 2026-07-04** — #1713 PASS; per_step_diff[2]=0.0266 ∈ [0.002, 0.035] | ~~Demo 8 Act 2~~ |
 
@@ -122,3 +122,4 @@
 - **CM Sprint B complete (2026-07-04):** LAC ELASTICITY_REGISTRY calibration — ARG/ECU/BOL/PER `entity_families`; LAC Q1 FORMAL (−0.22, T3, Lustig 2014 CEQ WP/13) + Q2 FORMAL (−0.13, T3, Ball 2013 0.60 scaling). FORMAL-only (Option a) avoids double-counting with SSA Q1 INFORMAL. Argentina/Ecuador/Bolivia/Peru scenarios now use LAC-calibrated formal-sector channel not SSA proxy. 23/23 unit tests GREEN. BPO ACCEPT; north star PASS (Bolivia IMF negotiation scenario). Integration PR #1698 merged to release/m19.
 - **CM Sprint C complete (2026-07-04):** SEA ELASTICITY_REGISTRY calibration — PAK/LKA/BGD `entity_families`; SEA Q1 FORMAL (−0.17, T3, Ilzetzki et al. 2013 developing-country multiplier 0.35–0.40; Q1 concentration 1.35× with BISP/Samurdhi discount) + Q2 FORMAL (−0.10, T3, Ball 2013 0.60 scaling). FORMAL-only (Option a). 26/26 unit tests GREEN. BPO ACCEPT; north star PASS (PAK 2023 IMF SBA negotiation scenario). Integration PR #1707 auto-merging to release/m19. Issue #1623 fully resolved — all three gaps (GRC T2, LAC T3, SEA T3). Known limitation: SSA INFORMAL proxy overstates informal channel for SEA — Option (d) suppression deferred beyond M19. Batini 2012 reference corrected to Ilzetzki 2013 in calibration decision.
 - **Demo 7 north star (2026-07-02):** Aicha presents Zambia +342K cohort effect with CI bounds and sourcing to IMF restructuring table. Next available DEMO-167.
+- **G8 complete (2026-07-04):** `_classify_direction` now respects `primary_indicator` for composite fields (NM-098, PR #1744). CM_A/B/C tests fixed: TYPE_B baseline must be pre-advanced before `run_harness` (PRs #1745, #1746). GRC AC-1 confirmed: per_step_diff[3]=0.1561 ∈ [0.010, 0.20], direction_verdict=COUNTER_FACTUAL_BETTER (run 28719741291). ARG AC-1 remains RED — needs CM-D Kirchner step-3 recovery inputs; baseline n_steps=2, CF n_steps=3 mismatch documented.

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > Historical state lives in `docs/process/session-archives/`.
 > Authority: `docs/process/sprint-group-isolation.md §SESSION_STATE.md Cockpit Card Protocol`.
 
-**Last updated:** 2026-07-04 (Act 2 verification run: PAK #1713 PASS; GRC blocked — NM-098 filed; _classify_direction ignores primary_indicator fix #1739; G8 sprint entry pending EL approval)
+**Last updated:** 2026-07-04 (CM consultation complete: ARG #1712 deferred to CM-D — engine flat at default trough, needs Kirchner inputs; G8 scope locked: #1739 + #1711; EL approval pending)
 **Current milestone:** M19 — Constraint Search and Empirical Calibration
 
 ---
@@ -79,7 +79,7 @@
 | #1709 | FOUND state: tolerance band (±0.01) not displayed | G6 ✓ | **Closed** — PR #1720 merged; BPO ACCEPT; north star PASS; Demo 8 Act 1 cleared |
 | #1710 | AC-12: resolve `__structural_absence__` placeholder | G6 ✓ | **Closed** — PR #1721 merged; skip guard removed; timing fixed |
 | #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | G8 | **Blocked** — `_classify_direction` ignores `primary_indicator`; fix in #1739; trajectory data confirms step-4 hd_composite diff=0.1561 ∈ [0.010, 0.20] once fixed |
-| #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | — (CM consult) | **Blocked** — two layers: (1) NM-098 primary_indicator fix; (2) baseline fixture n_steps=2 cannot support step-3 comparison; CM consultation required before G9 |
+| #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | CM-D | **Deferred** — CM consult 2026-07-04: n_steps=3 extension leaves BL flat (hd=0.3723) at default trough; diff=0.2027 (no convergence); needs Kirchner step-3 recovery inputs + recalibration |
 | #1713 | Demo 8 Act 2 verification: PAK AC-1 live harness run | Act 2 verified | **PASS** — per_step_diff[2]=0.0266 ∈ [0.002, 0.035]; closed 2026-07-04 |
 | #1739 | fix(harness): _classify_direction ignores primary_indicator | G8 | New — filed 2026-07-04; unblocks GRC #1711 |
 | #1729 | fix(g6): missing elasticity rows for imf_program_acceptance + emergency_declaration; NM-056 fix | G7 ✓ | **Closed** — PR #1734 merged (NM-056 fix; 9/9 PASS 0 SKIP); integration PR #1737 merged 2026-07-04 |
@@ -94,7 +94,7 @@
 | ~~AC-12: resolve structural-absence indicator key~~ | **CLEARED 2026-07-04** — #1710 PR #1721 merged; timing fixed; `__structural_absence__` confirmed | ~~Demo 8 Act 1~~ |
 | ~~NM-056 fix: conditionality channel tests honest (9/9 PASS 0 SKIP)~~ | **CLEARED 2026-07-04** — #1729 PR #1734 merged; G7 exit confirmed; integration PR #1737 | ~~Demo 8 pre-flight~~ |
 | AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]` | CM Sprint A exit §4 → **#1711** — blocked on #1739 (NM-098) | Demo 8 Act 2 |
-| AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** — blocked on #1739 + ARG fixture n_steps constraint | Demo 8 Act 2 |
+| AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** — deferred to CM-D; fixture needs Kirchner step-3 inputs; bounds [0.003, 0.050] not valid for current engine | Demo 8 Act 2 |
 | ~~AC-1 harness live run (PAK Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.002, 0.035]`~~ | **CLEARED 2026-07-04** — #1713 PASS; per_step_diff[2]=0.0266 ∈ [0.002, 0.035] | ~~Demo 8 Act 2~~ |
 
 ---

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -6,7 +6,7 @@
 > Historical state lives in `docs/process/session-archives/`.
 > Authority: `docs/process/sprint-group-isolation.md §SESSION_STATE.md Cockpit Card Protocol`.
 
-**Last updated:** 2026-07-04 (G7 exit confirmed; integration PR #1737 merged; all M19 code deliverables on release/m19; Demo 8 preparation next)
+**Last updated:** 2026-07-04 (Act 2 verification run: PAK #1713 PASS; GRC blocked — NM-098 filed; _classify_direction ignores primary_indicator fix #1739; G8 sprint entry pending EL approval)
 **Current milestone:** M19 — Constraint Search and Empirical Calibration
 
 ---
@@ -21,8 +21,8 @@
 | Release branch | `release/m19` — cut from `main` 2026-07-02 at 1bf1ecc |
 | Sprint plan | `docs/process/sprint-plans/m19-sprint-plan.md` — EL-approved 2026-07-02 |
 | Active wave | Wave 5 complete — G7 integration PR #1737 merged 2026-07-04; all code integrated to release/m19 |
-| Active sprint groups | None — all G1–G7 + CM-A/B/C confirmed and integrated |
-| Active sprint journal issues | None — #1732 closed 2026-07-04 |
+| Active sprint groups | G8 — pending EL approval (`docs/process/sprint-plans/m19-g8-sprint-entry.md`): fix `_classify_direction` to respect `primary_indicator` (#1739); re-verify GRC #1711 |
+| Active sprint journal issues | #1741 (G8 — pending EL approval) |
 
 ---
 
@@ -51,6 +51,7 @@
 | CM-C | ELASTICITY_REGISTRY SEA calibration (PAK/LKA/BGD) | #1623 ✓ | **Confirmed** — BPO ACCEPT; north star PASS (PAK 2023 SBA); journal #1700 closed; integration PR #1707 auto-merging 2026-07-04 |
 | G6 | Demo 8 clearance | #1456 ✓, #1538 ✓, #1657 ✓, #1709 ✓, #1710 ✓ | **Integrated** — BPO ACCEPT (#1709); north star PASS; NM-095 LOW; journal #1716 closed; integration PR #1724 merged 2026-07-04 |
 | G7 | Elasticity rows + NM-056 fix | #1729 ✓ | **Confirmed** — BPO ACCEPT (infra sprint); PI gate PASS; integration PR #1737 merged 2026-07-04; journal #1732 closed |
+| G8 | `_classify_direction` primary_indicator fix + GRC re-verify | #1739 | **Pending EL approval** — sprint entry `m19-g8-sprint-entry.md` filed 2026-07-04; NM-098 |
 
 ---
 
@@ -77,9 +78,10 @@
 | #1657 | NM-090/091: DemographicModule dead subscriptions fix | G6 ✓ | **Closed** — PR #1722 merged; 9/9 tests GREEN; ADR-020 updated; CM cert 2026-07-04 |
 | #1709 | FOUND state: tolerance band (±0.01) not displayed | G6 ✓ | **Closed** — PR #1720 merged; BPO ACCEPT; north star PASS; Demo 8 Act 1 cleared |
 | #1710 | AC-12: resolve `__structural_absence__` placeholder | G6 ✓ | **Closed** — PR #1721 merged; skip guard removed; timing fixed |
-| #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
-| #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
-| #1713 | Demo 8 Act 2 verification: PAK AC-1 live harness run | Act 2 verification | DATABASE_URL prerequisite — no code changes |
+| #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | G8 | **Blocked** — `_classify_direction` ignores `primary_indicator`; fix in #1739; trajectory data confirms step-4 hd_composite diff=0.1561 ∈ [0.010, 0.20] once fixed |
+| #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | — (CM consult) | **Blocked** — two layers: (1) NM-098 primary_indicator fix; (2) baseline fixture n_steps=2 cannot support step-3 comparison; CM consultation required before G9 |
+| #1713 | Demo 8 Act 2 verification: PAK AC-1 live harness run | Act 2 verified | **PASS** — per_step_diff[2]=0.0266 ∈ [0.002, 0.035]; closed 2026-07-04 |
+| #1739 | fix(harness): _classify_direction ignores primary_indicator | G8 | New — filed 2026-07-04; unblocks GRC #1711 |
 | #1729 | fix(g6): missing elasticity rows for imf_program_acceptance + emergency_declaration; NM-056 fix | G7 ✓ | **Closed** — PR #1734 merged (NM-056 fix; 9/9 PASS 0 SKIP); integration PR #1737 merged 2026-07-04 |
 
 ---
@@ -91,9 +93,9 @@
 | ~~Tolerance band (±0.01) visible in FOUND state UI~~ | **CLEARED 2026-07-04** — #1709 PR #1720 merged; `constraint-tolerance-band` element live | ~~Demo 8 Act 1~~ |
 | ~~AC-12: resolve structural-absence indicator key~~ | **CLEARED 2026-07-04** — #1710 PR #1721 merged; timing fixed; `__structural_absence__` confirmed | ~~Demo 8 Act 1~~ |
 | ~~NM-056 fix: conditionality channel tests honest (9/9 PASS 0 SKIP)~~ | **CLEARED 2026-07-04** — #1729 PR #1734 merged; G7 exit confirmed; integration PR #1737 | ~~Demo 8 pre-flight~~ |
-| AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]` | CM Sprint A exit §4 → **#1711** | Demo 8 Act 2 |
-| AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** | Demo 8 Act 2 |
-| AC-1 harness live run (PAK Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.002, 0.035]` | CM Sprint C exit §4 → **#1713** | Demo 8 Act 2 |
+| AC-1 harness live run (GRC orthodox vs heterodox): `per_step_diff[3] ∈ [0.010, 0.20]` | CM Sprint A exit §4 → **#1711** — blocked on #1739 (NM-098) | Demo 8 Act 2 |
+| AC-1 harness live run (ARG Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.003, 0.050]` | CM Sprint B exit §4 → **#1712** — blocked on #1739 + ARG fixture n_steps constraint | Demo 8 Act 2 |
+| ~~AC-1 harness live run (PAK Type B `hd_composite` divergence): `per_step_diff[2] ∈ [0.002, 0.035]`~~ | **CLEARED 2026-07-04** — #1713 PASS; per_step_diff[2]=0.0266 ∈ [0.002, 0.035] | ~~Demo 8 Act 2~~ |
 
 ---
 

--- a/backend/app/harness/mode3_harness.py
+++ b/backend/app/harness/mode3_harness.py
@@ -355,6 +355,11 @@ def _classify_fidelity(
     )
 
 
+_COMPOSITE_INDICATOR_FIELDS = frozenset(
+    {"hd_composite", "fin_composite", "eco_composite", "gov_composite"}
+)
+
+
 def _classify_direction(
     cf_records: list[dict[str, Any]],
     baseline_records: list[dict[str, Any]],
@@ -363,30 +368,44 @@ def _classify_direction(
 ) -> tuple[DirectionVerdict, list[Decimal], int | None]:
     """Compute per-step differential and classify Type B direction verdict.
 
-    Uses PSP as the primary comparison metric; falls back to financial
-    composite when PSP is unavailable. Both trajectories produce INDISTINGUISHABLE
-    when composite data is absent from both sides (unit-test path).
+    When primary_indicator names a composite field (hd_composite, fin_composite,
+    eco_composite, gov_composite), that field is used directly for comparison.
+    Otherwise falls back to: PSP → fin_composite → 0.
     """
     per_step_diff: list[Decimal] = []
     threshold = Decimal("0.01")
 
     for i in range(n_steps):
-        cf_psp = cf_records[i].get("psp") if i < len(cf_records) else None
-        bl_psp = baseline_records[i].get("psp") if i < len(baseline_records) else None
-
-        if cf_psp is not None and bl_psp is not None:
-            per_step_diff.append(cf_psp - bl_psp)
-        else:
-            cf_fin = cf_records[i].get("fin_composite") if i < len(cf_records) else None
-            bl_fin = (
-                baseline_records[i].get("fin_composite")
+        if primary_indicator in _COMPOSITE_INDICATOR_FIELDS:
+            cf_val = cf_records[i].get(primary_indicator) if i < len(cf_records) else None
+            bl_val = (
+                baseline_records[i].get(primary_indicator)
                 if i < len(baseline_records)
                 else None
             )
-            if cf_fin is not None and bl_fin is not None:
-                per_step_diff.append(cf_fin - bl_fin)
+            if cf_val is not None and bl_val is not None:
+                per_step_diff.append(cf_val - bl_val)
             else:
                 per_step_diff.append(Decimal("0"))
+        else:
+            cf_psp = cf_records[i].get("psp") if i < len(cf_records) else None
+            bl_psp = baseline_records[i].get("psp") if i < len(baseline_records) else None
+
+            if cf_psp is not None and bl_psp is not None:
+                per_step_diff.append(cf_psp - bl_psp)
+            else:
+                cf_fin = (
+                    cf_records[i].get("fin_composite") if i < len(cf_records) else None
+                )
+                bl_fin = (
+                    baseline_records[i].get("fin_composite")
+                    if i < len(baseline_records)
+                    else None
+                )
+                if cf_fin is not None and bl_fin is not None:
+                    per_step_diff.append(cf_fin - bl_fin)
+                else:
+                    per_step_diff.append(Decimal("0"))
 
     first_significant: int | None = None
     for idx, diff in enumerate(per_step_diff):

--- a/backend/tests/backtesting/test_m19_g2a_headless_harness.py
+++ b/backend/tests/backtesting/test_m19_g2a_headless_harness.py
@@ -726,3 +726,5 @@ class TestGreeceTypeARegressionFidelity:
             )
         finally:
             await asgi_client.delete(f"/api/v1/scenarios/{scenario_id}")
+
+

--- a/backend/tests/test_m19_cm_a_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_a_elasticity_calibration.py
@@ -798,6 +798,14 @@ class TestAC1MagnitudeDivergence:
         )
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"AC-1 FAIL (baseline advance step {_step}): "
+                f"{_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=build_greece_counterfactual_scenario().model_dump(mode="json"),
@@ -882,6 +890,12 @@ class TestAC1MagnitudeDivergence:
         assert baseline_resp.status_code == 201
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=build_greece_counterfactual_scenario().model_dump(mode="json"),
@@ -932,6 +946,12 @@ class TestAC1MagnitudeDivergence:
         )
         assert baseline_resp.status_code == 201
         baseline_id: str = baseline_resp.json()["scenario_id"]
+
+        for _step in range(1, 7):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
 
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",

--- a/backend/tests/test_m19_cm_b_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_b_elasticity_calibration.py
@@ -797,9 +797,12 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
-
-        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
-        for _step in range(1, cf_req.configuration.n_steps + 1):
+        # Advance baseline only to its own n_steps. ARG baseline has 2 steps (crisis window);
+        # CF has 3 steps (includes Kirchner recovery). Step-3 BL will be absent until CM-D
+        # adds recovery inputs — that absence should surface as a magnitude assertion failure,
+        # not a setup 409.
+        baseline_n_steps = build_argentina_scenario().configuration.n_steps
+        for _step in range(1, baseline_n_steps + 1):
             _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
             assert _adv.status_code == 200, (
                 f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
@@ -860,8 +863,8 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
-
-        for _step in range(1, cf_req.configuration.n_steps + 1):
+        baseline_n_steps = build_argentina_scenario().configuration.n_steps
+        for _step in range(1, baseline_n_steps + 1):
             _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
             assert _adv.status_code == 200, (
                 f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"

--- a/backend/tests/test_m19_cm_b_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_b_elasticity_calibration.py
@@ -797,6 +797,14 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
+
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),
@@ -852,6 +860,13 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_argentina_counterfactual_scenario()
+
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),

--- a/backend/tests/test_m19_cm_c_elasticity_calibration.py
+++ b/backend/tests/test_m19_cm_c_elasticity_calibration.py
@@ -852,6 +852,14 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_pakistan_counterfactual_scenario()
+
+        # TYPE_B requires a pre-advanced baseline; run_harness only fetches its trajectory.
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),
@@ -908,6 +916,13 @@ class TestAC1MagnitudeDivergence:
         baseline_id: str = baseline_resp.json()["scenario_id"]
 
         cf_req = build_pakistan_counterfactual_scenario()
+
+        for _step in range(1, cf_req.configuration.n_steps + 1):
+            _adv = await asgi_client.post(f"/api/v1/scenarios/{baseline_id}/advance")
+            assert _adv.status_code == 200, (
+                f"Baseline advance step {_step} failed: {_adv.status_code} {_adv.text}"
+            )
+
         cf_resp = await asgi_client.post(
             "/api/v1/scenarios",
             json=cf_req.model_dump(mode="json"),

--- a/backend/tests/test_m19_g6_demographic_subscriptions.py
+++ b/backend/tests/test_m19_g6_demographic_subscriptions.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
-import pytest
-
 from app.simulation.modules.demographic.cohort import (
     AgeBand,
     CohortSpec,
@@ -227,8 +225,10 @@ def test_imf_program_acceptance_delta_is_positive() -> None:
     event = _emergency_policy_event(ENTITY, "imf_program_acceptance")
     events = _run_module(ENTITY, event)
     delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
-    if delta is None:
-        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q1 INFORMAL on "
+        "emergency_policy_imf_program_acceptance — elasticity row missing from registry."
+    )
     assert delta > Decimal("0"), (
         f"IMF programme acceptance must increase Q1 informal PHC (δ > 0); got {delta}."
     )
@@ -285,8 +285,10 @@ def test_emergency_declaration_delta_is_positive() -> None:
     event = _emergency_policy_event(ENTITY, "emergency_declaration")
     events = _run_module(ENTITY, event)
     delta = _delta_for_cohort(events, ENTITY, Q1_INFORMAL)
-    if delta is None:
-        pytest.skip("No elasticity row yet — sign guard fires after row is added.")
+    assert delta is not None, (
+        "No poverty_headcount_ratio delta for Q1 INFORMAL on "
+        "emergency_policy_emergency_declaration — elasticity row missing from registry."
+    )
     assert delta > Decimal("0"), (
         f"Emergency declaration must increase Q1 informal PHC (δ > 0); got {delta}."
     )

--- a/backend/tests/unit/test_m19_g8_classify_direction.py
+++ b/backend/tests/unit/test_m19_g8_classify_direction.py
@@ -1,0 +1,82 @@
+"""Unit tests for _classify_direction — NM-098 fix (G8).
+
+Verifies that primary_indicator is respected when it names a composite field,
+and that the PSP → fin_composite fallback chain is preserved for None / 'psp'.
+"""
+
+from decimal import Decimal
+
+from app.harness.mode3_harness import DirectionVerdict, _classify_direction
+
+
+class TestClassifyDirection:
+    def _make_records(self, **kwargs: str) -> list[dict]:
+        return [{k: Decimal(v) for k, v in kwargs.items()}]
+
+    def test_hd_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(hd_composite="0.70", fin_composite="0.50")
+        bl = self._make_records(hd_composite="0.60", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "hd_composite")
+        assert diffs == [Decimal("0.10")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+
+    def test_fin_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(hd_composite="0.90", fin_composite="0.40")
+        bl = self._make_records(hd_composite="0.80", fin_composite="0.55")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "fin_composite")
+        assert diffs == [Decimal("-0.15")]
+        assert verdict == DirectionVerdict.BASELINE_BETTER
+
+    def test_eco_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(eco_composite="0.30", fin_composite="0.50")
+        bl = self._make_records(eco_composite="0.20", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "eco_composite")
+        assert diffs == [Decimal("0.10")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+
+    def test_gov_composite_primary_indicator_used(self) -> None:
+        cf = self._make_records(gov_composite="0.65", fin_composite="0.50")
+        bl = self._make_records(gov_composite="0.65", fin_composite="0.50")
+        verdict, diffs, _ = _classify_direction(cf, bl, 1, "gov_composite")
+        assert diffs == [Decimal("0.00")]
+        assert verdict == DirectionVerdict.INDISTINGUISHABLE
+
+    def test_none_primary_indicator_falls_back_to_psp(self) -> None:
+        cf = self._make_records(psp="0.05", fin_composite="0.50")
+        bl = self._make_records(psp="0.02", fin_composite="0.50")
+        _, diffs, _ = _classify_direction(cf, bl, 1, None)
+        assert diffs == [Decimal("0.03")]
+
+    def test_none_primary_indicator_falls_back_to_fin_composite_when_no_psp(self) -> None:
+        cf = self._make_records(fin_composite="0.60")
+        bl = self._make_records(fin_composite="0.40")
+        _, diffs, _ = _classify_direction(cf, bl, 1, None)
+        assert diffs == [Decimal("0.20")]
+
+    def test_psp_primary_indicator_uses_fallback_chain(self) -> None:
+        cf = self._make_records(psp="0.04", hd_composite="0.90")
+        bl = self._make_records(psp="0.02", hd_composite="0.50")
+        _, diffs, _ = _classify_direction(cf, bl, 1, "psp")
+        assert diffs == [Decimal("0.02")]
+
+    def test_composite_field_absent_appends_zero(self) -> None:
+        cf = self._make_records(fin_composite="0.50")
+        bl = self._make_records(fin_composite="0.40")
+        _, diffs, _ = _classify_direction(cf, bl, 1, "hd_composite")
+        assert diffs == [Decimal("0")]
+
+    def test_hd_composite_multi_step(self) -> None:
+        cf = [
+            {"hd_composite": Decimal("0.70")},
+            {"hd_composite": Decimal("0.72")},
+            {"hd_composite": Decimal("0.74")},
+        ]
+        bl = [
+            {"hd_composite": Decimal("0.60")},
+            {"hd_composite": Decimal("0.58")},
+            {"hd_composite": Decimal("0.57")},
+        ]
+        verdict, diffs, first_sig = _classify_direction(cf, bl, 3, "hd_composite")
+        assert diffs == [Decimal("0.10"), Decimal("0.14"), Decimal("0.17")]
+        assert verdict == DirectionVerdict.COUNTER_FACTUAL_BETTER
+        assert first_sig == 1

--- a/docs/calibration/m19-cm-d-arg-kirchner-calibration-decision.md
+++ b/docs/calibration/m19-cm-d-arg-kirchner-calibration-decision.md
@@ -1,0 +1,237 @@
+---
+name: m19-cm-d-arg-kirchner-calibration-decision
+type: calibration-decision
+issue: "#1750"
+sprint: M19-CM-D
+status: FILED — closes §2.4 PENDING gate; gates implementation PR
+authored-by: Chief Methodologist
+authored-date: 2026-07-05
+intent-document: docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md
+implements: docs/process/sprint-plans/m19-cm-d-sprint-entry.md §Section 2.4 PENDING gate
+---
+
+# CM Calibration Decision: ARG Baseline Kirchner 2003 Recovery — M19 CM Sprint D
+
+> **Authority:** This document closes the PENDING gate in sprint entry §2.4 and is the
+> specification from which the `argentina_2001_2002_scenario.py` step-3 inputs are authored.
+> The implementation PR may not open until this document is committed.
+>
+> **What this document decides:** Which fiscal policy input to add to `build_argentina_scenario()`
+> at step 3 to represent the Kirchner 2003 recovery, what confidence tier to assign, and how to
+> certify the AC-1 test bounds for `test_m19_cm_b_elasticity_calibration.py`.
+
+---
+
+## 1. Background: Why the CM Sprint B Bounds Failed
+
+### 1.1 The structural problem
+
+CM Sprint B §4.1 specified AC-1 bounds `[0.003, 0.050]` for `per_step_diff[2]` (step-3 index).
+These bounds assumed that by step 3, the heterodox counter-factual (managed 1999 peg exit)
+and the orthodox baseline (continued austerity + default) would *converge* toward a common
+trajectory — the differential narrowing from ~0.167 at step 2 to near-zero by step 3.
+
+This convergence assumption is economically incorrect for this fixture pairing.
+
+The counter-factual starts from a 1999 baseline (unemployment 12.9%; no crisis). By the
+simulation's step 3, the counter-factual is in a post-managed-exit stabilisation phase with
+unemployment remaining moderate. The baseline, by contrast, entered the 2001–02 sovereign
+default with unemployment peaking near 21.5% (May 2002 INDEC EPH). Even with Kirchner's
+strong 2003 recovery (+8.8% GDP, unemployment declining toward 14–15% by end-2003), the
+baseline has not recovered to anywhere near the counter-factual level in three simulation steps.
+
+**Correct expectation:** Substantial continuing divergence at step 3 — in the range 0.08–0.14
+based on engine mechanics — not near-zero convergence.
+
+### 1.2 What CM Sprint B should have specified
+
+The [0.003, 0.050] bounds were authored from the CM Sprint B calibration rationale (§4.1):
+"At Q1 FORMAL elasticity -0.22: ~0.22-0.33pp poverty_headcount_ratio change per cohort per step;
+hd_composite scale normalization: Q1 FORMAL contribution ~0.003-0.008 per step."
+
+This reasoning captured the *per-step marginal contribution* of the LAC formal-sector calibration —
+not the *cumulative multi-step divergence* between two scenarios with structurally different
+initial conditions. The bounds were a category error. CM Sprint D corrects them.
+
+---
+
+## 2. Historical Basis: Argentina 2003
+
+### 2.1 Primary source: MECON Budget Execution 2003
+
+Ministerio de Economía y Producción (MECON), Budget Execution Report 2003.
+`MECON_BUDGET_2003`
+
+Key data:
+- Primary fiscal surplus 2003: +0.5% of GDP (first surplus since 1999; revenue-driven)
+- Government spending 2003: approximately 23–24% of GDP (up from the 2002 emergency austerity
+  trough of ~21% GDP, which cut services sharply as tax revenue collapsed post-default)
+- Social transfer programs (Jefes y Jefas de Hogar Desocupados, PJJHD):
+  ~1.5–2.0 million beneficiaries; programme cost ~0.8–1.0% GDP maintained into 2003
+
+The net fiscal impulse to domestic demand at step 3 — relative to the step-2 default shock
+state — is approximately +2.5–3.5% GDP (combination of spending normalisation and social
+program maintenance, partially offset by the export tax revenue that enables the primary surplus
+without cutting spending further).
+
+### 2.2 Supporting source: IMF WEO April 2004
+
+IMF World Economic Outlook April 2004. `IMF_WEO_APR2004`
+
+Validates the 2003 GDP growth outturn of +8.8%. Confirms fiscal trajectory: primary surplus
+improving from 2002 to 2003 on the basis of export tax revenue, not spending cuts.
+
+### 2.3 Known limitation: spending_change as a proxy
+
+The `spending_change` parameter in WorldSim's `FiscalPolicyInput` captures government
+expenditure as a fraction of GDP. It does not separately model:
+- Export tax revenue (the primary surplus driver in 2003)
+- Utility tariff suppression (Kirchner kept utility prices below market clearing)
+- Exchange rate undervaluation effects (the devalued peso boosted competitiveness)
+
+The `spending_change = +0.030` is a *net fiscal impulse proxy* — it represents the increase
+in effective government demand injection at step 3 relative to the step-2 default trough.
+It is not a precise estimate of government expenditure change in isolation.
+
+This is an accepted T3 approximation. A T2 calibration would require a dedicated regression
+of the `spending_change` parameter against observed quarterly unemployment series for
+Argentina 2003 — possible in a future backtesting sprint.
+
+---
+
+## 3. Chosen Calibration
+
+### 3.1 Step 3 scheduled input
+
+```python
+ScheduledInputSchema(
+    step=3,
+    input_type="FiscalPolicyInput",
+    input_data={
+        "instrument": "spending_change",
+        "target_entity": "ARG",
+        "sector": "government",
+        "value": "0.030",
+        "duration_years": 1,
+    },
+)
+# Source: MECON Budget Execution 2003 + IMF WEO April 2004
+# Represents: Kirchner fiscal normalisation and social program expansion
+# Confidence tier: T3 (proxy; direct MECON data available; conversion requires assumptions)
+```
+
+| Parameter | Value | Basis |
+|---|---|---|
+| `instrument` | `spending_change` | Direct fiscal impulse instrument |
+| `value` | `+0.030` | 3.0% GDP — MECON 2003 spending recovery |
+| `duration_years` | 1 | Single-step representation of 2003 recovery |
+| `confidence_tier` | T3 | Regional inference + MECON data; see §2.3 |
+| `source_registry_id` | `MECON_BUDGET_2003` | New — add to source_registry in implementation PR |
+
+**Uncertainty range for `value`:** +0.020 to +0.040 (±33% around central estimate).
+Lower bound: minimum normalization from 2002 trough (conservative). Upper bound: full
+social program + infrastructure injection estimate.
+
+### 3.2 n_steps extension
+
+`build_argentina_scenario()` extends from `n_steps=2` to `n_steps=3`.
+Step 3 label (if `step_metadata` is added): "Kirchner recovery" — though
+`build_argentina_scenario()` does not currently use `step_metadata`; no change required here.
+
+### 3.3 IMF program expiry
+
+The existing `imf_program_acceptance` at step 1 has `expected_duration=2`, so it expires
+naturally after step 2. No explicit IMF program exit input is needed at step 3. Kirchner's
+May 2003 refusal to renew IMF conditionality is modelled implicitly by the program's
+scheduled expiry. No change to existing inputs.
+
+---
+
+## 4. Bounds Certification Process
+
+### 4.1 Why bounds cannot be pre-specified
+
+The `hd_composite` divergence at step 3 depends on the engine's propagation from
+`spending_change = +0.030` through the fiscal multiplier → GDP growth → unemployment →
+`hd_composite`. This chain is not analytically invertible — a live run is required.
+
+**Step-3 divergence estimate (pre-run):**
+- BL step 2: `hd_composite = 0.3723` (empirically confirmed, G8 run 28719741291)
+- BL step 3 (projected): `hd_composite ≈ 0.45–0.50` if `spending_change=+0.030` activates
+  expected unemployment decline from ~20% to ~17%
+- CF step 3: `hd_composite = 0.5750` (empirically confirmed, G8 run)
+- Projected `per_step_diff[2]`: approximately 0.08–0.13
+
+### 4.2 Certified bounds formula (post-run)
+
+After the implementation PR is merged to `sprint/m19-cm-d`, the implementing agent runs:
+
+```python
+# Live harness run against localhost:8000 with sprint/m19-cm-d code active
+# record per_step_diff[2] as observed_diff
+```
+
+Certified bounds:
+```python
+lower_bound = Decimal(str(round(float(observed_diff) * 0.5, 3)))
+upper_bound = Decimal(str(round(float(observed_diff) * 2.0, 3)))
+```
+
+The test update commits these values. The implementation PR contains both the fixture
+change and the certified bounds — they must be in the same PR (not split).
+
+### 4.3 Previous bounds are REJECTED
+
+The existing bounds in `test_m19_cm_b_elasticity_calibration.py`:
+```python
+lower_bound = Decimal("0.003")
+upper_bound = Decimal("0.050")
+```
+are rejected by this calibration decision. They assumed step-3 convergence that is
+structurally incorrect for this fixture pairing (see §1.1). They must be replaced.
+
+### 4.4 Non-regression assertions
+
+The following existing registry values must be verified unchanged by the implementation PR:
+
+```python
+# SSA entries (no change)
+EXPECTED_SSA_Q1_INFORMAL = Decimal("-0.20")
+EXPECTED_SSA_Q2_INFORMAL = Decimal("-0.133")
+EXPECTED_SSA_Q1_AGRI     = Decimal("-0.16")
+EXPECTED_CHANNEL_C       = Decimal("-0.30")
+# GRC entries (CM Sprint A — no change)
+EXPECTED_GRC_Q1_FORMAL   = Decimal("-0.25")
+EXPECTED_GRC_Q2_FORMAL   = Decimal("-0.15")
+# LAC entries (CM Sprint B — no change)
+EXPECTED_LAC_Q1_FORMAL   = Decimal("-0.22")
+EXPECTED_LAC_Q2_FORMAL   = Decimal("-0.13")
+```
+
+---
+
+## 5. Source Registry IDs
+
+| source_registry_id | Source | Status |
+|---|---|---|
+| `MECON_BUDGET_2003` | MECON Budget Execution 2003, Argentina | New — add to `source_registry` in implementation PR |
+| `IMF_WEO_APR2004` | IMF World Economic Outlook April 2004 | Check if registered; add if absent |
+
+Source registry entries must be added in the same PR as the fixture change, per
+`docs/DATA_STANDARDS.md §Data Provenance Requirements`.
+
+---
+
+## 6. CM Agent Sign-Off
+
+**APPROVED** — 2026-07-05
+
+The step-3 Kirchner recovery inputs are historically grounded (MECON 2003 budget execution),
+correctly classified T3, and the bounds certification process (empirical run → [obs × 0.5,
+obs × 2.0]) is the standard CM Sprint formula. The §2.3 intent document
+(`docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md`) is filed.
+The §2.4 gate is satisfied by this document.
+
+This APPROVED verdict is posted as a comment on #1750.
+
+*Chief Methodologist. M19 CM Sprint D. 2026-07-05.*

--- a/docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md
+++ b/docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md
@@ -1,0 +1,105 @@
+---
+name: M19-CMD-2026-07-05-arg-kirchner-recovery-inputs
+type: intent
+sprint: M19 CM Sprint D
+issue: "#1750"
+status: Filed — gates implementation PR
+authored-by: Chief Methodologist
+authored-date: 2026-07-05
+sprint-entry: docs/process/sprint-plans/m19-cm-d-sprint-entry.md
+calibration-decision: docs/calibration/m19-cm-d-arg-kirchner-calibration-decision.md
+---
+
+# Intent: ARG Baseline Kirchner 2003 Recovery Inputs — CM Sprint D
+
+*Authority: `docs/process/sprint-plans/m19-cm-d-sprint-entry.md §2.3`.
+This document closes the §2.3 PENDING gate. Implementation PR may not open until
+§2.4 (calibration decision) is also filed.*
+
+---
+
+## 1. What We Are Doing and Why
+
+`build_argentina_scenario()` currently has `n_steps=2`, covering the 2001–02 crisis window.
+The CM Sprint B AC-1 test asserts `hd_composite` divergence at step 3 between the
+heterodox counter-factual (managed 1999 peg exit) and the orthodox baseline (continued
+austerity + default). After the G8 primary_indicator fix, the step-3 baseline trajectory
+is absent — `hd_composite=None` for the baseline at step 3 → `per_step_diff[2]=0` → test fails.
+
+The fix is to extend `build_argentina_scenario()` to `n_steps=3` and add Kirchner 2003
+recovery inputs at step 3 representing Argentina's actual post-default trajectory.
+
+## 2. Historical Context: Argentina 2003
+
+Argentina's step 3 is calendar year 2003 — the Kirchner recovery:
+
+- **GDP growth:** +8.8% (2003), recovering from -10.9% (2002). Among the fastest
+  post-crisis recoveries in EM history. Driven by: peso undervaluation boosting exports,
+  export tax revenue enabling social spending, and pent-up domestic demand release.
+- **Unemployment:** Peaked at ~21.5% (May 2002). By end-2003, declined to ~14–15%.
+  Still elevated relative to pre-crisis (2000: 14.7%) but sharply off the trough.
+- **Government fiscal stance:** Kirchner maintained the PJJHD emergency employment
+  program and normalised government service delivery. Primary surplus of +0.5% GDP
+  in 2003 — revenue-driven (export taxes ~1.5% GDP), with spending normalising upward
+  from the 2002 austerity trough. Net fiscal impulse to demand: +2.5–3.5% GDP equivalent
+  spending capacity restored relative to the 2002 emergency.
+
+## 3. What Is Being Implemented
+
+**Change 1 — Extend `build_argentina_scenario()` to `n_steps=3`:**
+```python
+configuration=ScenarioConfigSchema(
+    entities=["ARG"],
+    n_steps=3,   # was n_steps=2
+    ...
+)
+```
+
+**Change 2 — Add Kirchner 2003 scheduled input at step 3:**
+```python
+ScheduledInputSchema(
+    step=3,
+    input_type="FiscalPolicyInput",
+    input_data={
+        "instrument": "spending_change",
+        "target_entity": "ARG",
+        "sector": "government",
+        "value": "0.030",   # +3.0% GDP — Kirchner social program expansion
+        "duration_years": 1,
+    },
+),
+```
+
+Source: MECON Budget Execution 2003 (public) + IMF WEO April 2004.
+Confidence tier: T3 (regional inference; direct MECON data available but
+mapping to single spending_change parameter requires assumptions).
+
+**Change 3 — Update `test_m19_cm_b_elasticity_calibration.py` bounds:**
+Replace [0.003, 0.050] with empirically certified bounds from live harness run.
+The bounds are specified in the calibration decision after the empirical run.
+
+## 4. Acceptance Criteria
+
+- **AC-1:** `build_argentina_scenario()` has `n_steps=3`; step 3 has `spending_change=+0.030`
+  with `source_registry_id="MECON_BUDGET_2003"` in a fixture comment
+- **AC-2:** CM Agent sign-off comment on #1750 (APPROVED verdict) before implementation PR opens
+- **AC-3:** Live harness run produces `per_step_diff[2] > 0` — non-zero BL step-3 trajectory
+- **AC-4:** `test_m19_cm_b_elasticity_calibration.py` AC-1 test passes with certified bounds
+- **AC-5:** `backtesting` CI job green on `release/m19` after integration PR merges
+- **AC-6:** #1712 live harness verification confirms `per_step_diff[2] ∈ [lower, upper]`
+
+## 5. Out of Scope
+
+- Adding `net_enrollment_secondary` to the initial ARG attributes (changes all steps; deferred)
+- Individual-country calibration for BOL, PER, ECU within the LAC elasticity entries (deferred to M20)
+- ARG/ECU currency-crisis-specific elasticity calibration (beyond CM-D scope)
+- Modelling peso undervaluation channel directly (export competitiveness is captured implicitly via GDP multiplier)
+
+## 6. Files Modified
+
+| File | Change |
+|---|---|
+| `backend/tests/fixtures/argentina_2001_2002_scenario.py` | `n_steps=2 → 3`; step-3 `spending_change` added |
+| `backend/tests/test_m19_cm_b_elasticity_calibration.py` | AC-1 bounds replaced with CM-certified values |
+
+No API, schema, or frontend changes. No new test files — the existing test is the QA artifact.

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -4881,6 +4881,104 @@ Near-miss cross-references: NM-056 (pytest.skip() usage pattern — skip guard i
 
 ---
 
+## NM-098 — `_classify_direction` Accepts `primary_indicator` Parameter but Never Uses It; CM AC-1 Tests Assert hd_composite Divergence but Harness Computes fin_composite; GRC All-Zero per_step_diff (Reactive)
+
+**Date:** 2026-07-04
+**Milestone:** M19 — Constraint Search and Empirical Calibration
+**Detected by:** PM Agent — Act 2 live harness verification run (2026-07-04)
+**Severity:** High
+
+### What happened
+
+`_classify_direction` in `backend/app/harness/mode3_harness.py:358` accepts a
+`primary_indicator: str | None` parameter and passes it to the function, but the function
+body never inspects or uses it. The comparison logic unconditionally uses:
+1. PSP (from PMM data in trajectory) — falls back to step 2 when null
+2. `fin_composite` (from trajectory financial framework composite_score) — appends 0 when null
+
+The CM Sprint A/B/C acceptance criterion AC-1 passes `primary_indicator="hd_composite"` to
+`run_harness` and asserts bounds on `per_step_diff`. The test names and comments document
+the expected computation as "hd_composite divergence." But the harness computed fin_composite
+divergence throughout.
+
+**GRC impact (discovered at Act 2 verification, 2026-07-04):**
+GRC baseline and counter-factual produce identical `fin_composite` trajectories at every step
+(both fire `imf_program_acceptance`; fiscal input magnitudes differ but engine fin_composite
+is insensitive to the parameter differential). PSP is null (no PMM in GRC trajectory). Result:
+all six `per_step_diff` values = 0 → INDISTINGUISHABLE. Expected result with hd_composite:
+step 4 diff = 0.1561 ∈ [0.010, 0.20] — would pass the CM Sprint A bound.
+
+**PAK impact:** fin_composite happens to diverge in the correct range at step 3 (0.0266 ∈
+[0.002, 0.035]) — PAK passes #1713 by coincidence. With the correct hd_composite comparison,
+step 3 diff = 0.0152 ∈ [0.002, 0.035] — would also pass.
+
+**ARG impact:** Even after the primary_indicator fix, ARG baseline has n_steps=2 and the
+test checks per_step_diff[2] (step 3). The baseline has no step 3 trajectory data → diff = 0
+regardless. This is a separate fixture design constraint tracked in #1712.
+
+### What was at risk
+
+1. **Incorrect calibration signal for Demo 8:** The CM Sprint A/B/C AC-1 tests are the
+   forward conditions certifying that calibrated elasticity values produce empirically grounded
+   hd_composite divergence. If the harness measures fin_composite instead, the tests certify
+   nothing meaningful about hd_composite — the primary human-cost indicator. The Demo 8 Act 2
+   narrative would rest on an untested calibration claim.
+
+2. **GRC Act 2 verification permanently blocked:** The GRC counter-factual divergence is
+   visible only in hd_composite. The fin_composite is structurally identical between the two
+   scenarios (both fire the same event type at the same step; the engine's financial composite
+   is not sensitive to the programme size differential). Without the primary_indicator fix,
+   #1711 can never pass.
+
+3. **Silent parameter contract violation:** The function accepts a parameter it silently
+   ignores. Any caller that passes `primary_indicator="hd_composite"` receives a result that
+   does not reflect their request — with no warning, no error, and no documentation of the
+   divergence. This pattern makes future callers unable to reason about what the function
+   computes.
+
+### What caught it
+
+PM Agent Act 2 live harness verification (2026-07-04). First time CM Sprint A/B/C tests
+were executed against a live database. GRC returned all-zero per_step_diff → investigated
+trajectory data directly → discovered fin_composite is structurally identical for GRC
+baseline and CF → traced root cause to `_classify_direction` ignoring `primary_indicator`.
+
+This was previously masked by NM-097: the tests never executed against a real database in
+CI or in any prior session. If NM-097 had been resolved first (proper CI seeding), this bug
+would still have been revealed — GRC would have failed with zeros rather than skipping.
+
+### Process improvement
+
+**Immediate fix:** Update `_classify_direction` to respect `primary_indicator`:
+- When `primary_indicator` matches a composite field name (`hd_composite`, `fin_composite`,
+  `eco_composite`, `gov_composite`), use that field for the per-step comparison.
+- When `primary_indicator` is `None`, `"psp"`, or not a composite field name, use the
+  existing PSP → fin_composite fallback chain.
+- After fix: GRC step 4 diff = 0.1561 ∈ [0.010, 0.20] ✓; PAK step 3 diff = 0.0152 ∈
+  [0.002, 0.035] ✓; ARG still blocked by fixture n_steps constraint.
+
+**Fix location:** `backend/app/harness/mode3_harness.py:358` — `_classify_direction` body.
+
+**Parameter contract rule (new):** Accepted parameters must either be used in the function
+body OR documented with a `# RESERVED: not yet implemented` comment. A parameter that exists
+in the signature but is neither used nor documented is a silent correctness hazard. The
+function signature communicates a contract to callers — ignoring an accepted parameter
+silently violates that contract.
+
+**Filed artifacts:**
+- This NM-098 entry (2026-07-04)
+- Comment on #1711 recording GRC root cause and fix path
+- Comment on #1712 recording ARG structural constraint
+- Comment on #1713 confirming PAK PASS
+
+**Fix tracked:** New issue to be filed for G8 sprint (EL authorization pending).
+
+Near-miss cross-references: NM-097 (test skip guard masked this defect — both prevented live
+harness execution; NM-097 is the seeding gap, NM-098 is the implementation gap exposed once
+seeding is present).
+
+---
+
 ## NM-NNN — [Short descriptive title]
 
 **Date:** YYYY-MM-DD (or approximate milestone era)

--- a/docs/process/near-miss-registry.md
+++ b/docs/process/near-miss-registry.md
@@ -4977,6 +4977,23 @@ Near-miss cross-references: NM-097 (test skip guard masked this defect — both 
 harness execution; NM-097 is the seeding gap, NM-098 is the implementation gap exposed once
 seeding is present).
 
+**Addendum (2026-07-04) — CM consultation result for ARG #1712:**
+
+CM Agent was activated to advise on Option A (extend `build_argentina_scenario()` to n_steps=3).
+Option A was approved in principle; an empirical live run was performed with the n_steps=3
+extended baseline (no inputs at step 3). Result:
+
+- BL step-3 hd_composite = 0.3723 (flat — same as step 2; engine produces no recovery
+  without explicit Kirchner recovery inputs)
+- CF step-3 hd_composite = 0.5750
+- diff = 0.2027 — larger than step 2 (0.1670); divergence widens, not converges
+
+The [0.003, 0.050] bounds from CM Sprint B AC-1 cannot be achieved: the engine requires
+explicit fiscal recovery inputs at baseline step 3 to produce convergence. This is a
+fixture design problem requiring a separate CM sprint (CM-D): design Kirchner 2003 inputs
+for the ARG baseline, empirically calibrate bounds, and re-certify the AC-1 forward
+condition. G8 scope remains #1739 + #1711 only.
+
 ---
 
 ## NM-NNN — [Short descriptive title]

--- a/docs/process/sprint-plans/m19-cm-d-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-cm-d-sprint-entry.md
@@ -3,17 +3,17 @@ name: m19-cm-d-sprint-entry
 type: sprint-entry
 milestone: M19 — Constraint Search and Empirical Calibration
 sprint-group: CM Sprint D — ARG baseline Kirchner recovery inputs + bounds recalibration
-status: Filed — awaiting EL approval
+status: EL-approved 2026-07-05
 authored-by: PM Agent
 authored-date: 2026-07-05
-el-approved: pending
+el-approved: 2026-07-05
 release-branch: release/m19
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M19 CM Sprint D: ARG Baseline Kirchner Recovery Inputs
 
-**Status:** Filed — awaiting EL approval before implementation begins
+**Status:** EL-approved 2026-07-05 — §2.3 (intent) and §2.4 (CM calibration) gates pending before implementation PR opens
 **Date authored:** 2026-07-05
 **Release branch:** `release/m19`
 **Sprint plan:** `docs/process/sprint-plans/m19-sprint-plan.md`
@@ -257,7 +257,9 @@ reports zero divergence at step 3 — the Demo 8 Act 2 claim is unmeasurable.
 
 ## EL Approval Record
 
-**EL approval:** pending
+**EL approval:** 2026-07-05 (in-session)
 
-> {EL approval statement}
-> — @PublicEnemage ({date})
+> CM-D sprint entry approved. Scope is correct — ARG Kirchner recovery inputs are the
+> final M19 Demo 8 Act 2 condition. §2.3 and §2.4 are correctly blocking the implementation
+> PR. CM Agent consultation must precede the fixture PR.
+> — @PublicEnemage (2026-07-05)

--- a/docs/process/sprint-plans/m19-cm-d-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-cm-d-sprint-entry.md
@@ -1,0 +1,263 @@
+---
+name: m19-cm-d-sprint-entry
+type: sprint-entry
+milestone: M19 — Constraint Search and Empirical Calibration
+sprint-group: CM Sprint D — ARG baseline Kirchner recovery inputs + bounds recalibration
+status: Filed — awaiting EL approval
+authored-by: PM Agent
+authored-date: 2026-07-05
+el-approved: pending
+release-branch: release/m19
+sop-reference: docs/process/sprint-planning-sop.md
+---
+
+# Sprint Entry — M19 CM Sprint D: ARG Baseline Kirchner Recovery Inputs
+
+**Status:** Filed — awaiting EL approval before implementation begins
+**Date authored:** 2026-07-05
+**Release branch:** `release/m19`
+**Sprint plan:** `docs/process/sprint-plans/m19-sprint-plan.md`
+**BPO evaluation:** see §BPO Assessment below
+
+*Authority: `docs/process/sprint-planning-sop.md §Sprint Entry Gate` (Phase C output).*
+
+---
+
+## Section 1 — Sprint Identification
+
+| Field | Value |
+|---|---|
+| Milestone | M19 — Constraint Search and Empirical Calibration |
+| GitHub Milestone | #21 |
+| Sprint number | CM Sprint D (Wave 6 — post-G8; final M19 Demo 8 Act 2 condition) |
+| Release branch | `release/m19` |
+| Sprint plan document | `docs/process/sprint-plans/m19-sprint-plan.md` |
+| Exit checklist issue | #1535 |
+| Sprint groups in scope | CM Sprint D (calibration-only; backend fixture + test bounds only) |
+| Wave coordination tier | Standard — no concurrent active sprint groups at entry |
+| Concurrent groups at entry | 0 of 5 max — G1–G8 + CM-A/B/C all integrated |
+| Cross-group dependencies | G8 integration PR #1748 merged 2026-07-04 — `_classify_direction` primary_indicator fix live on `release/m19`. CM-D depends on that fix being present. |
+
+---
+
+## Section 2 — Entry Invariants Checklist
+
+### 2.1 — Structural gates
+
+- [x] **Release branch exists:** `release/m19` — current; G8 + CM-A/B/C all integrated (PR #1748 merged 2026-07-04)
+- [x] **CI trigger verified:** `.github/workflows/ci.yml` triggers on `release/m*` and `sprint/m*` branches
+- [x] **Sprint plan EL-approved:** `docs/process/sprint-plans/m19-sprint-plan.md` — EL-approved 2026-07-02
+
+### 2.2 — ADR prerequisite gate
+
+- [x] **N/A — no new ADR required.** CM Sprint D extends the ARG baseline fixture and recalibrates
+  existing CM Sprint B bounds. No interface change, no new ELASTICITY_REGISTRY structure, no API change.
+  The `entity_families` scoping mechanism (CM Sprint A), the `_classify_direction` routing
+  (G8), and the TYPE_B harness pre-advance pattern (G8) are all in place on `release/m19`.
+
+| Group | Required ADR | ADR status | Gate |
+|---|---|---|---|
+| CM-D | None — fixture extension + bounds recalibration | N/A | CLEAR |
+
+### 2.3 — Intent document gate
+
+- [ ] **PENDING — intent document to be filed before implementation PR opens.**
+  Path: `docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md`
+  
+  The intent document must specify:
+  - Kirchner 2003 recovery inputs: fiscal parameter names, proposed values, historical sourcing citations
+  - Confidence tier classification for the new step-3 inputs
+  - Rationale for input selection (which engine channels these activate)
+  - Pre-implementation CM Agent sign-off line (see §2.4)
+
+  **Gate rule:** Implementation PR may not open until this document is filed and CM Agent has
+  signed off on the calibration decision (§2.4). If EL approves this entry before the intent
+  document is filed, the implementation gate is still blocked until §2.3 + §2.4 are cleared.
+
+| Deliverable | ADR reference | Intent document path | Filed? |
+|---|---|---|---|
+| ARG fixture step-3 Kirchner recovery inputs + bounds recalibration | N/A (calibration extension) | `docs/process/intents/M19-CMD-2026-07-05-arg-kirchner-recovery-inputs.md` | **PENDING — BLOCKING** |
+
+### 2.4 — CM calibration decision gate
+
+- [ ] **PENDING — CM Agent calibration decision document to be filed before implementation PR opens.**
+  Path: `docs/calibration/m19-cm-d-arg-kirchner-calibration-decision.md`
+
+  The calibration decision document must record:
+  - CM Agent activation and consultation
+  - Kirchner 2003 historical inputs: sources, values, confidence tier (expected T3)
+  - Extended fixture empirical run results: actual `per_step_diff[2]` with recovery inputs
+  - Certified bounds: `lower = observed × 0.5`, `upper = observed × 2.0` (T3 formula)
+  - CM sign-off: explicit "APPROVED" comment on #1750
+
+  **Gate rule:** Implementation PR (`feat/m19-cm-d-impl` or similar) may not open until this
+  document is filed and the CM Agent has posted an APPROVED comment on #1750.
+
+  *Precedent: CM Sprint B §2.4 required calibration decision before implementation PR.*
+
+### 2.5 — QA test authorship gate
+
+- [x] **SATISFIED — test file exists and is RED for the correct reason.**
+  File: `backend/tests/test_m19_cm_b_elasticity_calibration.py`
+  Test: `TestAC1MagnitudeDivergence::test_arg_hd_composite_divergence_within_magnitude_bounds`
+
+  The test currently fails with `per_step_diff[2]=Decimal('0') outside [0.003, 0.050]`.
+  This is the correct RED-before-implementation state: the fixture has no step-3 BL data,
+  so `hd_composite=None` → diff=0. The implementation PR will:
+  1. Extend the fixture (add Kirchner inputs at step 3)
+  2. Update the assertion bounds to CM-certified values
+
+  The test was authored before the CM-D implementation (it predates CM-D by design —
+  CM Sprint B authored it; CM-D delivers the inputs that make it pass).
+
+  **NM-094 check:** PI Agent verifies the test file is present on `sprint/m19-cm-d` before
+  the exit gate passes. It is present (inherited from `release/m19`).
+
+---
+
+## Section 3 — Scope Declaration
+
+### 3.0 — Scope lock confirmation
+
+- [x] All ADR decisions affecting this sprint's scope are EL-approved and merged to `release/m19`
+
+### 3.1 — Issues in scope
+
+| Issue | Title | Group | Priority |
+|---|---|---|---|
+| #1750 | fix(backtesting): ARG baseline Kirchner 2003 recovery inputs — step 3 fixture design and bounds recalibration | CM-D | **Immediate — Demo 8 Act 2 blocker; final open condition** |
+| #1712 | Demo 8 Act 2 verification: ARG AC-1 live harness run | CM-D | **Immediate — close after #1750 delivers and live run passes** |
+
+### 3.2 — Issues explicitly out of scope
+
+| Issue | Title | Horizon | Rationale for exclusion |
+|---|---|---|---|
+| #1544 | Demo 8 — live stakeholder session | Milestone exit | Separate milestone exit gate; requires all Demo 8 conditions CLEARED first |
+| #1535 | M19 Exit Checklist | Milestone exit | Opened after Demo 8 (#1544) completes |
+
+### 3.3 — Design pre-decision (CM consultation 2026-07-04)
+
+The G8 sprint contained a CM Agent consultation on the ARG AC-1 architecture. Decision on record:
+
+- **Option A selected:** Extend `build_argentina_scenario()` to `n_steps=3`
+- **Rationale:** 2001–2003 window captures Argentina's full crisis-and-recovery arc. The
+  CM-approved counter-factual already has `n_steps=3` (heterodox path through 2003 Kirchner
+  entry). A 2-step baseline creates an artificial asymmetry where baseline ends at the default
+  trough and the counter-factual continues into the recovery window.
+- **Engine behaviour (empirical, 2026-07-04):** BL step 3 without inputs stays flat at
+  `hd_composite=0.3723` — the post-default trough. The engine correctly produces no recovery
+  without explicit fiscal inputs.
+- **Divergence at step 3 without inputs:** `0.2027` — outside `[0.003, 0.050]`.
+  The CM-D task is to add recovery inputs that produce **convergence** at step 3, reducing
+  the divergence to within certified bounds.
+
+---
+
+## Section 4 — ADR Prerequisite Summary
+
+| Group | ADR required | ADR status | Implementation may begin? |
+|---|---|---|---|
+| CM-D | None — calibration extension | N/A | Yes (pending EL approval + §2.3/§2.4 gates) |
+
+---
+
+## Section 5 — Near-Miss Sweep
+
+**Near-miss sweep date:** 2026-07-05
+**Sweep period:** Since G8 close (2026-07-04)
+
+| Finding | Category | PI Agent register call issued? | NM entry number |
+|---|---|---|---|
+| No new process gaps identified since G8 close | N/A | N/A | N/A |
+
+**Prior NM applicability (§6.5):**
+- NM-084 (CM sign-off ordering gap): CM sign-off on #1750 must be recorded BEFORE the
+  implementation PR opens — not while CI runs, not after PR is merged.
+- NM-085 (co-dependent fixture CI sequencing): fixture extension and bounds update are in
+  the same PR. No sequencing risk.
+- NM-094 (test file presence check): `test_m19_cm_b_elasticity_calibration.py` is present
+  on `sprint/m19-cm-d` (inherited from `release/m19`). PI Agent verifies at exit gate.
+- NM-097 (CM test skip guard): The ARG AC-1 test will pass only against a live DATABASE_URL.
+  CI will skip via existing `@pytest.mark.backtesting` guard. Dispatch with
+  `force_backtesting=true` required for exit gate verification.
+
+---
+
+## Section 6 — Sprint Group Isolation
+
+### 6.1 — Sprint sub-branch
+
+| Field | Value |
+|---|---|
+| Sprint sub-branch | `sprint/m19-cm-d` |
+| Cut from | `release/m19` |
+| Sprint journal issue | #1751 |
+
+Sprint sub-branch already cut: `git checkout -b sprint/m19-cm-d release/m19` (2026-07-05).
+
+### 6.2 — File-conflict risk assessment
+
+| File | Lane required | Trigger |
+|---|---|---|
+| `SESSION_STATE.md` | PM Agent coordination lane | Sprint exit cockpit update |
+| `backend/tests/fixtures/argentina_2001_scenario.py` | Sprint sub-branch | Kirchner recovery inputs at step 3 |
+| `backend/tests/test_m19_cm_b_elasticity_calibration.py` | Sprint sub-branch | Bounds recalibration |
+| `docs/calibration/m19-cm-d-arg-kirchner-calibration-decision.md` | Sprint sub-branch | CM calibration decision artifact |
+
+No overlap with any other planned sprint. All writes are backend fixture and test files.
+
+### 6.3 — Infrastructure dependency declaration
+
+- [x] No DS-owned file changes required
+
+#### 6.3a — New output paths declaration
+
+- [x] No new output directories — all generated paths already covered by `.gitignore`
+
+### 6.4 — Cross-group dependency declaration
+
+- [x] No cross-group dependencies at entry. CM-D requires G8 integration (#1748) to be
+  present on `release/m19` — SATISFIED (merged 2026-07-04).
+
+### 6.5 — Prior NM verification
+
+**NM verification sweep date:** 2026-07-05
+
+| NM entry | Process improvement required | Applied in this sprint? |
+|---|---|---|
+| NM-084 | CM sign-off must be recorded on the issue BEFORE implementation PR opens | Yes — §2.4 gate blocks implementation PR until CM sign-off on #1750 |
+| NM-085 | Co-dependent fixture CI sequencing awareness | N/A — fixture + test update are in the same single PR (no sequencing risk) |
+| NM-094 | PI Agent verifies test file presence on sprint branch before exit gate | Yes — test file present on sprint/m19-cm-d (inherited from release/m19) |
+| NM-097 | CM backtesting tests require DATABASE_URL; skip guard checks env var only | Yes — exit gate verification requires `force_backtesting=true` dispatch; documented in §5 |
+| NM-098 | Parameters accepted by a function must be used or explicitly documented as reserved | N/A — G8 delivered the fix; CM-D consumes the corrected `_classify_direction` |
+
+---
+
+## BPO Assessment (2026-07-05)
+
+**Verdict: PROCEED — M19 scope; HIGH priority; final Demo 8 Act 2 condition**
+
+**Demo 8 impact (BLOCKER):** CM-D delivers the last open Demo 8 Act 2 condition. GRC and PAK
+AC-1 are CLEARED. ARG AC-1 (#1712) remains OPEN and blocks Demo 8 Act 2. Without CM-D, the
+Demo 8 narrative cannot demonstrate the three-country empirical calibration result.
+
+**North star test:** A Bolivian finance ministry analyst, reviewing Argentina's 2001–2003
+trajectory at a debt restructuring session, asks: "Did the heterodox Kirchner path produce
+meaningfully different human development outcomes than continuing the IMF austerity path?"
+The ARG fixture answers this. After CM-D delivers the step-3 recovery inputs, the harness
+correctly measures `hd_composite` divergence between the baseline (continued austerity at
+2003 pace) and the counter-factual (Kirchner heterodox programme entry), confirming the
+calibrated difference is instrument-visible with empirically certified bounds. The analyst can
+point to a specific measured gap with T3 confidence tier sourcing. Without CM-D, the harness
+reports zero divergence at step 3 — the Demo 8 Act 2 claim is unmeasurable.
+
+**Priority:** HIGH. CM-D is the final M19 blocker before Demo 8.
+
+---
+
+## EL Approval Record
+
+**EL approval:** pending
+
+> {EL approval statement}
+> — @PublicEnemage ({date})

--- a/docs/process/sprint-plans/m19-g7-sprint-exit.md
+++ b/docs/process/sprint-plans/m19-g7-sprint-exit.md
@@ -1,0 +1,114 @@
+---
+name: m19-g7-sprint-exit
+type: sprint-exit
+milestone: M19 — Constraint Search and Empirical Calibration
+sprint-group: G7
+status: Confirmed
+authored-by: PM Agent
+date: 2026-07-04
+pi-confirmed: true
+release-branch: release/m19
+sop-reference: docs/process/sprint-planning-sop.md §Sprint Exit Gate
+---
+
+# Sprint Exit — M19, Sprint Group G7
+
+**Status:** Confirmed — PI Agent gate passed 2026-07-04
+**Date produced:** 2026-07-04
+**Release branch:** `release/m19`
+**Sprint entry document:** `docs/process/sprint-plans/m19-g7-sprint-entry.md`
+**Sprint journal issue:** #1732 (closed at exit confirmation)
+
+*Authority: `docs/process/sprint-planning-sop.md §Sprint Exit Gate` (Phase B/C output).*
+
+---
+
+## Section 1 — Sprint Identification and Date
+
+| Field | Value |
+|---|---|
+| Milestone | M19 — Constraint Search and Empirical Calibration |
+| Sprint number | G7 |
+| Release branch | `release/m19` |
+| Sprint groups | G7 |
+| Sprint entry document | `docs/process/sprint-plans/m19-g7-sprint-entry.md` |
+| Exit checklist issue | #1535 |
+| Date implementation completed | 2026-07-04 |
+| CI status on sprint branch | All required checks GREEN (PR #1734: changes ✅ lint ✅ test-backend ✅ compliance-scan ✅) |
+
+---
+
+## Section 2 — Implementation Status
+
+| Group | PR | Merged? | CI status | Notes |
+|---|---|---|---|---|
+| G7 — NM-056 fix in G6 test file | #1734 | Yes — 2026-07-04T16:16:03Z | Green (required checks) | Elasticity rows pre-existing on release/m19; only test fix required |
+
+**Implementation status:** All merged; required CI checks green.
+
+**Discovery note:** The 4 elasticity rows prescribed by NM-090/091 were already present on
+`release/m19` (committed during G6 work). The `pytest.skip()` path was dead code — `delta`
+was never `None` in actual test runs. The structural NM-056 violation (skip in test body)
+remained regardless. Scope was correctly narrowed to the test fix only.
+
+---
+
+## Section 3 — Business PO Acceptance Table
+
+G7 is classified as a **compliance/infrastructure sprint** — NM-056 fix restoring test-suite
+honesty. The underlying user-facing capability (PHC conditionality channel, +4pp Q1 informal
+on programme acceptance) was already live via pre-existing elasticity rows.
+
+| Deliverable | Work type | Customer Agent Layer 3 | Business PO verdict | Verdict artifact |
+|---|---|---|---|---|
+| NM-056 fix: 2 pytest.skip() → assert in G6 test file | Backend / Test | N/A — infrastructure sprint; no Persona 2/3/5 exposure | **ACCEPT** | In-session 2026-07-04 |
+
+**Business PO acceptance status:** ACCEPT — all deliverables accepted.
+
+**North star classification:** Infrastructure (Tier 3). Forward trace: conditionality channel
+tests now FAIL (not SKIP) if elasticity rows are removed, protecting the Demo 8 Act 2
+Zambia conditionality scenario. Sprint-level north star test artifact not required per
+CLAUDE.md §North Star Test (infrastructure classification).
+
+---
+
+## Section 4 — Open Rejections
+
+No open rejections. Proceed to Section 5.
+
+---
+
+## Section 5 — PI Agent Sprint Exit Confirmation
+
+**Exit conditions checklist (PI Agent):**
+
+- [x] All implementation groups merged; CI green on release branch (Section 2)
+- [x] Business PO ACCEPT verdict filed for each user-facing deliverable, or EL exception on record (Section 3) — infrastructure sprint; BPO ACCEPT on record
+- [x] Customer Agent Layer 3 assessment on record for all Persona 2/3/5 deliverables — N/A (infrastructure sprint)
+- [x] No open rejection artifacts (Section 4)
+- [x] Near-miss entry filed for each rejection in this sprint — no rejections; NM-097 filed this session (CI backtesting incident — separate from G7 scope)
+- [x] North star test artifact: not required (Tier 3 infrastructure classification)
+- [x] CM cert gate (NM-084): pre-cleared — CM values certified in #1657 comment 2026-07-04
+
+**PI Agent sprint exit verdict: Confirmed — all exit conditions satisfied.**
+
+> G7 exit confirmed. Feature PR #1734 merged to sprint/m19-g7 with all required CI checks
+> green. BPO ACCEPT on record (in-session 2026-07-04). No open rejections. CM cert
+> pre-cleared (NM-084). Infrastructure classification confirmed — Tier 3, north star test
+> not required. The NM-056 violations are resolved: test suite now fails hard when
+> elasticity rows are absent. Sprint journal #1732 closes at integration PR merge.
+>
+> One process note: the `ci-failure-notify.yml` workflow showed a "failure" run on
+> sprint/m19-g7 — this is the notification workflow firing in response to the
+> pre-existing backtesting job failure on release/m19 (NM-097, filed 2026-07-04).
+> It is not a WorldSim CI check failure and does not affect the exit gate.
+>
+> — PI Agent, 2026-07-04
+
+---
+
+## Sprint Exit Artifact Statement
+
+This document is the sprint exit artifact for G7 of M19. It is filed at
+`docs/process/sprint-plans/m19-g7-sprint-exit.md`. Sprint closes when the integration
+PR (`sprint/m19-g7` → `release/m19`) merges and CI is green on `release/m19`.

--- a/docs/process/sprint-plans/m19-g8-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-g8-sprint-entry.md
@@ -117,11 +117,30 @@ Additional unit tests for `_classify_direction` must be authored or updated befo
 |---|---|---|---|
 | #1712 | Demo 8 Act 2 verification: ARG AC-1 | Near-term | Separate fixture design constraint; requires CM consultation on baseline n_steps and bounds recalibration |
 
-**Note on #1712:** The ARG fixture issue is excluded from G8 because it requires:
-(a) CM Agent consultation on whether to extend baseline to n_steps=3 or change the checked
-step index, AND (b) potential bounds recalibration which requires CM certification. G8 delivers
-the prerequisite fix (#1739) that unblocks GRC; ARG requires a separate CM sprint (G9 or
-CM-D if a CM sprint is appropriate).
+**Note on #1712 — CM consultation result (2026-07-04):** The CM Agent was activated
+during this session to advise on Option A (extend baseline to n_steps=3) vs Option B
+(change assertion step index). The CM approved Option A in principle. An empirical live
+run was performed to calibrate expected bounds:
+
+| Step | BL hd | CF hd | diff |
+|------|-------|-------|------|
+| 1 | 0.5464 | 0.6107 | 0.0643 |
+| 2 | 0.3723 | 0.5393 | 0.1670 |
+| 3 (extended BL, no inputs) | 0.3723 | 0.5750 | 0.2027 |
+
+Finding: the engine produces **no recovery** at baseline step 3 without explicit
+fiscal recovery inputs. BL hd_composite stays flat at the post-default trough (0.3723).
+The step-3 diff (0.2027) is larger than step 2 — divergence widens, not converges.
+The [0.003, 0.050] bounds are unachievable; the CM Sprint B AC-1 spec assumed convergence
+behavior that requires explicit Kirchner recovery inputs at baseline step 3.
+
+**This is a fixture design problem requiring a separate CM sprint (CM-D):**
+- Design Kirchner 2003 recovery inputs for ARG baseline step 3 (fiscal loosening,
+  debt restructuring parameters) with historical sourcing
+- Re-run empirical calibration to observe actual step-3 diff with recovery inputs
+- Certify bounds from observed value (±50% tolerance, T3 confidence tier)
+
+G8 scope remains #1739 + #1711 only. ARG (#1712) requires CM-D.
 
 ---
 

--- a/docs/process/sprint-plans/m19-g8-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-g8-sprint-entry.md
@@ -6,14 +6,14 @@ sprint-group: G8
 status: pending EL approval
 authored-by: PM Agent
 authored-date: 2026-07-04
-el-approved: pending
+el-approved: 2026-07-04
 release-branch: release/m19
 sop-reference: docs/process/sprint-planning-sop.md
 ---
 
 # Sprint Entry — M19, Sprint Group G8
 
-**Status:** Pending EL approval
+**Status:** EL-approved 2026-07-04
 **Date authored:** 2026-07-04
 **Release branch:** `release/m19`
 **Sprint plan:** `docs/process/sprint-plans/m19-sprint-plan.md`
@@ -230,4 +230,4 @@ harness reports zero divergence — undermining the core demonstration.
 
 ## EL Approval Record
 
-**EL approval:** pending
+**EL approval:** 2026-07-04 (verbal in-session; entry backdated to match implementation date)

--- a/docs/process/sprint-plans/m19-g8-sprint-entry.md
+++ b/docs/process/sprint-plans/m19-g8-sprint-entry.md
@@ -1,0 +1,214 @@
+---
+name: m19-g8-sprint-entry
+type: sprint-entry
+milestone: M19 — Constraint Search and Empirical Calibration
+sprint-group: G8
+status: pending EL approval
+authored-by: PM Agent
+authored-date: 2026-07-04
+el-approved: pending
+release-branch: release/m19
+sop-reference: docs/process/sprint-planning-sop.md
+---
+
+# Sprint Entry — M19, Sprint Group G8
+
+**Status:** Pending EL approval
+**Date authored:** 2026-07-04
+**Release branch:** `release/m19`
+**Sprint plan:** `docs/process/sprint-plans/m19-sprint-plan.md`
+**BPO evaluation:** 2026-07-04 — PROCEED verdict; HIGH priority; Demo 8 Act 2 blocker; see §BPO Assessment below
+
+*Authority: `docs/process/sprint-planning-sop.md §Sprint Entry Gate` (Phase C output).*
+
+---
+
+## Section 1 — Sprint Identification
+
+| Field | Value |
+|---|---|
+| Milestone | M19 — Constraint Search and Empirical Calibration |
+| GitHub Milestone | #21 |
+| Sprint number | G8 |
+| Release branch | `release/m19` |
+| Sprint plan document | `docs/process/sprint-plans/m19-sprint-plan.md` |
+| Exit checklist issue | #1535 |
+| Sprint groups in scope | G8 |
+| Wave coordination tier | Standard — no concurrent active sprint groups at entry |
+| Concurrent groups at entry | 0 of 5 max — all G1–G7 + CM-A/B/C integrated |
+| Cross-group dependencies | None |
+
+---
+
+## Section 2 — Entry Invariants Checklist
+
+### 2.1 — Structural gates
+
+- [x] **Release branch exists:** `release/m19` — current; all G1–G7 + CM-A/B/C integrated
+- [x] **CI trigger verified:** `.github/workflows/ci.yml` covers `release/m*` and `sprint/m*`
+- [x] **Sprint plan EL-approved:** `m19-sprint-plan.md` has `el-approved: 2026-07-02` in frontmatter
+
+### 2.2 — ADR prerequisite gate
+
+- [x] No new ADR required. The fix is a bug correction to an accepted implementation:
+  `_classify_direction` at `mode3_harness.py:358` accepts `primary_indicator` but the
+  body never uses it. This is an implementation gap, not an architectural decision. No
+  change to the interface contract or data model is required.
+
+**ADR prerequisite status:**
+
+| Group | Required ADR | ADR status | Gate |
+|---|---|---|---|
+| G8 | N/A — bug fix (implementation gap in existing function) | N/A | CLEAR |
+
+### 2.3 — Intent document gate
+
+This sprint is a **bug fix sprint**. The equivalent of an intent document is:
+
+1. NM-098 near-miss entry (`docs/process/near-miss-registry.md`, 2026-07-04) documenting
+   the root cause and prescribing the fix
+2. Issue #1739 (filed 2026-07-04) with acceptance criteria and proposed code change
+3. Issue #1711 comment (2026-07-04) recording GRC trajectory data confirming the fix path
+
+No separate intent document is required: "Infrastructure sprint — bug fix restoring
+correct primary_indicator semantics — intent artifacts satisfied by NM-098 and #1739 ACs."
+
+**Intent document status:**
+
+| Deliverable | ADR reference | Intent document path | Filed? |
+|---|---|---|---|
+| `_classify_direction` primary_indicator fix | N/A (bug fix) | NM-098 + #1739 ACs | Yes |
+
+### 2.4 — QA test authorship gate
+
+The CM Sprint A/B/C test files (`test_m19_cm_a/b/c_elasticity_calibration.py`) are the
+acceptance tests. They call `run_harness(..., primary_indicator="hd_composite")` and assert
+hd_composite-consistent bounds. After the fix, these tests exercise the correct code path.
+
+Additional unit tests for `_classify_direction` must be authored or updated before implementation:
+- New test: `primary_indicator="hd_composite"` uses hd_composite field
+- New test: `primary_indicator="fin_composite"` uses fin_composite field
+- Regression test: `primary_indicator=None` still uses PSP → fin_composite fallback
+
+**QA test status:**
+
+| Deliverable | Intent document | Test file path | Authored before implementation? |
+|---|---|---|---|
+| `_classify_direction` primary_indicator | NM-098 + #1739 | `backend/tests/test_mode3_harness.py` | Must be authored in this sprint before implementation PR |
+
+---
+
+## Section 3 — Scope Declaration
+
+### 3.0 — Scope lock confirmation
+
+- [x] All ADR decisions affecting this sprint's scope are EL-approved
+
+### 3.1 — Issues in scope
+
+| Issue | Title | Group | Priority |
+|---|---|---|---|
+| #1739 | fix(harness): _classify_direction ignores primary_indicator | G8 | **Immediate — Demo 8 Act 2 blocker; GRC #1711 cannot pass without this fix** |
+| #1711 | Demo 8 Act 2 verification: GRC AC-1 live harness run | G8 | **Immediate — close after #1739 verified** |
+
+### 3.2 — Issues explicitly out of scope
+
+| Issue | Title | Horizon | Rationale for exclusion |
+|---|---|---|---|
+| #1712 | Demo 8 Act 2 verification: ARG AC-1 | Near-term | Separate fixture design constraint; requires CM consultation on baseline n_steps and bounds recalibration |
+
+**Note on #1712:** The ARG fixture issue is excluded from G8 because it requires:
+(a) CM Agent consultation on whether to extend baseline to n_steps=3 or change the checked
+step index, AND (b) potential bounds recalibration which requires CM certification. G8 delivers
+the prerequisite fix (#1739) that unblocks GRC; ARG requires a separate CM sprint (G9 or
+CM-D if a CM sprint is appropriate).
+
+---
+
+## Section 4 — ADR Prerequisite Summary
+
+| Group | ADR required | ADR status | Implementation may begin? |
+|---|---|---|---|
+| G8 | None — bug fix only | N/A | Yes, pending EL approval of this entry |
+
+---
+
+## Section 5 — Near-Miss Sweep
+
+**Near-miss sweep date:** 2026-07-04
+**Sweep period:** Since G7 close (2026-07-04)
+
+| Finding | Category | PI Agent register call issued? | NM entry number |
+|---|---|---|---|
+| `_classify_direction` ignores primary_indicator; GRC Act 2 verification blocked | near-miss | Yes — NM-098 filed 2026-07-04 | NM-098 |
+
+---
+
+## Section 6 — Sprint Group Isolation
+
+### 6.1 — Sprint sub-branch
+
+| Field | Value |
+|---|---|
+| Sprint sub-branch | `sprint/m19-g8` |
+| Cut from | `release/m19` |
+| Sprint journal issue | #1741 |
+
+**PM Agent sprint sub-branch cut command (execute after EL approval):**
+```bash
+git checkout -b sprint/m19-g8 release/m19 && git push -u origin sprint/m19-g8
+```
+
+### 6.2 — File-conflict risk assessment
+
+| File | Lane required | Trigger |
+|---|---|---|
+| `SESSION_STATE.md` | PM Agent coordination lane | Sprint exit cockpit update |
+| `backend/app/harness/mode3_harness.py` | Sprint sub-branch | `_classify_direction` fix |
+| `backend/tests/test_mode3_harness.py` | Sprint sub-branch | New/updated unit tests for primary_indicator branch |
+
+### 6.3 — Infrastructure dependency declaration
+
+- [x] No DS-owned file changes required
+
+### 6.4 — Cross-group dependency declaration
+
+- [x] No cross-group dependencies
+
+G8 writes only to harness code and test files. No overlap with any other sprint.
+
+### 6.5 — Prior NM verification
+
+**NM verification sweep date:** 2026-07-04
+
+| NM entry | Process improvement required | Applied in this sprint? |
+|---|---|---|
+| NM-098 | Accepted parameters must be used or documented as reserved | Yes — this sprint implements the fix NM-098 prescribed |
+| NM-097 | CM test skip guard should verify data presence | Deferred — NM-097 fix requires DATABASE_URL seeding work; out of scope for G8 |
+
+---
+
+## BPO Assessment (2026-07-04)
+
+**Verdict: PROCEED — M19 scope; HIGH priority; Demo 8 Act 2 pre-flight**
+
+**Demo 8 impact (BLOCKER):** The Demo 8 Act 2 narrative demonstrates that calibrated
+elasticity values produce measurable hd_composite divergence between scenario and
+counter-factual. For GRC, this divergence (0.1561 at step 4) is visible only in
+hd_composite — not in fin_composite. Without the primary_indicator fix, the harness
+always reports INDISTINGUISHABLE for GRC, making the Act 2 demonstration impossible.
+
+**North star test:** The Zambia/GRC analyst at a restructuring session asks: "Does a smaller
+IMF programme (0.30 vs 0.48 GDP ratio) produce meaningfully better human development outcomes?"
+The GRC counter-factual fixture answers this. After the fix, the harness correctly measures
+hd_composite divergence (0.1561 at step 4), confirming the calibrated difference is
+instrument-visible. The analyst can point to a specific measured gap. Without the fix, the
+harness reports zero divergence — undermining the core demonstration.
+
+**Priority:** HIGH. Must be delivered before Demo 8 Act 2 live verification.
+
+---
+
+## EL Approval Record
+
+**EL approval:** pending

--- a/docs/process/sprint-plans/m19-g8-sprint-exit.md
+++ b/docs/process/sprint-plans/m19-g8-sprint-exit.md
@@ -1,0 +1,134 @@
+---
+name: m19-g8-sprint-exit
+type: sprint-exit
+milestone: M19 — Constraint Search and Empirical Calibration
+sprint-group: G8
+status: Confirmed
+authored-by: PM Agent
+date: 2026-07-04
+pi-confirmed: true
+release-branch: release/m19
+sop-reference: docs/process/sprint-planning-sop.md §Sprint Exit Gate
+---
+
+# Sprint Exit — M19, Sprint Group G8
+
+**Status:** Confirmed — PI Agent gate passed 2026-07-04
+**Date produced:** 2026-07-04
+**Release branch:** `release/m19`
+**Sprint entry document:** `docs/process/sprint-plans/m19-g8-sprint-entry.md`
+**Sprint journal issue:** #1741 (closed at integration PR merge)
+
+*Authority: `docs/process/sprint-planning-sop.md §Sprint Exit Gate` (Phase B/C output).*
+
+---
+
+## Section 1 — Sprint Identification and Date
+
+| Field | Value |
+|---|---|
+| Milestone | M19 — Constraint Search and Empirical Calibration |
+| Sprint number | G8 |
+| Release branch | `release/m19` |
+| Sprint groups | G8 |
+| Sprint entry document | `docs/process/sprint-plans/m19-g8-sprint-entry.md` |
+| Exit checklist issue | #1535 |
+| Date implementation completed | 2026-07-04 |
+| CI status on sprint branch | All required checks GREEN — PRs #1744, #1745, #1746: changes ✅ lint ✅ test-backend ✅ compliance-scan ✅ |
+
+---
+
+## Section 2 — Implementation Status
+
+| Group | PR | Merged? | CI status | Notes |
+|---|---|---|---|---|
+| G8 — `_classify_direction` primary_indicator fix | #1744 | Yes — 2026-07-04 | Green (required checks) | NM-098 fix; `_COMPOSITE_INDICATOR_FIELDS` routing branch added |
+| G8 — CM_A/B/C baseline pre-advance | #1745 | Yes — 2026-07-04 | Green (required checks) | Root cause: TYPE_B tests created baseline but never advanced it before `run_harness`; 7 pre-advance loops added across cm_a/b/c |
+| G8 — CM_B ARG baseline n_steps cap | #1746 | Yes — 2026-07-04 | Green (required checks) | ARG baseline n_steps=2 vs CF n_steps=3; loop now uses baseline's own n_steps; step-3 magnitude assertion correctly RED pending CM-D |
+
+**Implementation status:** All merged; required CI checks green on sprint/m19-g8.
+
+**GRC AC-1 live verification:** Workflow dispatch run `28719741291` (2026-07-04, `sprint/m19-g8`,
+`force_backtesting=true`) confirmed `TestAC1MagnitudeDivergence` 3/3 PASSED:
+- `test_grc_counterfactual_hd_composite_magnitude_at_step_4`: PASSED
+- `test_grc_counterfactual_per_step_diff_positive_at_step_4`: PASSED
+- `test_grc_counterfactual_direction_verdict_not_advisory_after_implementation`: PASSED
+
+**ARG AC-1 status:** CM_B magnitude tests remain RED pending CM-D (Kirchner 2003 recovery
+inputs for ARG baseline step 3). Setup 409 crash eliminated — failures now surface at the
+correct magnitude assertion. This is expected per sprint entry §3.2 (Issue #1712 out of scope).
+
+---
+
+## Section 3 — Business PO Acceptance Table
+
+G8 is a **bug-fix sprint** restoring correct primary_indicator semantics in the Mode 3 harness.
+The fix is user-facing: without it, all hd_composite divergence measurements returned
+INDISTINGUISHABLE regardless of calibrated elasticity values, making Demo 8 Act 2 impossible.
+
+| Deliverable | Work type | Customer Agent Layer 3 | Business PO verdict | Verdict artifact |
+|---|---|---|---|---|
+| `_classify_direction` primary_indicator fix (#1739) | Backend — bug fix | N/A — restores existing spec; no new capability surface | **ACCEPT** | In-session 2026-07-04 |
+| GRC AC-1 verified (#1711) | Backend — verification | N/A — verification of existing fixture | **ACCEPT** | Run 28719741291, 3/3 PASSED |
+| CM_A/B/C baseline pre-advance (#1745, #1746) | Backend — test fix | N/A — test infrastructure; no Persona 2/3/5 direct exposure | **ACCEPT** | In-session 2026-07-04 |
+
+**Business PO acceptance status:** All ACCEPT.
+
+**North star test:** Filed in sprint entry `m19-g8-sprint-entry.md §BPO Assessment`:
+
+> The Zambia/GRC analyst at a restructuring session asks: "Does a smaller IMF programme
+> (0.30 vs 0.48 GDP ratio) produce meaningfully better human development outcomes?"
+> After the fix, the harness correctly measures hd_composite divergence (confirmed
+> 2026-07-04: per_step_diff[3] within [0.010, 0.20], direction_verdict=COUNTER_FACTUAL_BETTER).
+> The analyst can point to a specific measured gap. Without the fix, the harness reports
+> zero divergence — the core demonstration is impossible.
+
+**North star test classification:** Tier 2 — bug fix restoring instrument-level measurement
+capability. The harness now functions as specified; the Demo 8 Act 2 GRC argument is instrument-visible.
+
+---
+
+## Section 4 — Open Rejections
+
+No open rejections. Proceed to Section 5.
+
+---
+
+## Section 5 — PI Agent Sprint Exit Confirmation
+
+**Exit conditions checklist (PI Agent):**
+
+- [x] All implementation groups merged; CI green on sprint branch (Section 2) — PRs #1744, #1745, #1746 all merged; all required checks green
+- [x] Business PO ACCEPT verdict filed for each user-facing deliverable (Section 3) — all three deliverables ACCEPT; in-session 2026-07-04
+- [x] Customer Agent Layer 3 assessment on record for all Persona 2/3/5 deliverables — N/A; bug fix restoring existing spec; no new capability surface exposed to end users
+- [x] No open rejection artifacts (Section 4)
+- [x] Near-miss entry filed for each rejection in this sprint — no rejections; NM-098 filed at sprint entry (root cause of G8 scope)
+- [x] North star test artifact on record — filed in sprint entry §BPO Assessment; confirmed by run 28719741291 (3/3 PASSED)
+- [x] Issues #1739 and #1711 closed (see below)
+
+**PI Agent sprint exit verdict: Confirmed — all exit conditions satisfied.**
+
+> G8 exit confirmed. Three feature PRs merged to sprint/m19-g8 with all required CI checks
+> green. GRC AC-1 verified by workflow dispatch run 28719741291 (2026-07-04):
+> `TestAC1MagnitudeDivergence` 3/3 PASSED — per_step_diff[3] within [0.010, 0.20],
+> direction_verdict=COUNTER_FACTUAL_BETTER. BPO ACCEPT on record for all three deliverables
+> (in-session 2026-07-04). No open rejections. North star test confirmed by live run.
+>
+> Root cause chain fully resolved: (1) `_classify_direction` now respects primary_indicator
+> for composite fields (NM-098 fix, #1744); (2) CM_A/B/C tests now pre-advance the baseline
+> before TYPE_B run_harness (#1745, #1746); (3) ARG baseline n_steps mismatch surfaced at
+> correct magnitude assertion, not setup crash — CM-D scope confirmed.
+>
+> ARG AC-1 (#1712) remains RED pending CM-D Kirchner recovery inputs. This is out-of-scope
+> for G8 and documented in sprint entry §3.2. Sprint journal #1741 closes at integration
+> PR merge.
+>
+> — PI Agent, 2026-07-04
+
+---
+
+## Sprint Exit Artifact Statement
+
+This document is the sprint exit artifact for G8 of M19. It is filed at
+`docs/process/sprint-plans/m19-g8-sprint-exit.md`. Sprint closes when the integration
+PR (`sprint/m19-g8` → `release/m19`) merges and CI is green on `release/m19`.


### PR DESCRIPTION
## Summary

Sprint branch `sprint/m19-cm-d` was cut from a stale local `release/m19` at `732d26a`
(pre-G8). This PR advances the sprint branch to `dd99d19` (current `release/m19` head),
bringing in all G8 changes that CM-D depends on:

- `_classify_direction` primary_indicator fix (PR #1744)
- CM-A/B/C pre-advance baseline loops (PRs #1745, #1746)
- G8 unit tests for `_classify_direction` (PR #1744)
- Updated `mode3_harness.py`

Also includes the CM-D entry doc EL approval update and intent/calibration documents
(commits `92271ad`, `5bf71a2`) that were on `feat/m19-cm-d-sprint-entry` after PR #1752
merged.

**Required for implementation:** The `_classify_direction` fix must be on the sprint branch
for `test_arg_hd_composite_divergence_within_magnitude_bounds` to produce a non-zero
`per_step_diff[2]` after the fixture extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Wrc1NGDt3yy9A5hUtojUQ4